### PR TITLE
Bug patient profile saving

### DIFF
--- a/backend/core/urls.py
+++ b/backend/core/urls.py
@@ -273,6 +273,11 @@ urlpatterns = [
         patient_thresholds_view,
         name="patient-thresholds",
     ),
+    path(
+        "api/patients/<str:patient_id>/reset-password/",
+        user_views.reset_patient_password,
+        name="reset-patient-password",
+    ),
 ]
 
 # Only add this if DEBUG=True, which is typical in development

--- a/backend/core/views/user_views.py
+++ b/backend/core/views/user_views.py
@@ -366,15 +366,15 @@ def user_profile_view(request, user_id):
             # Validate email + phone — skip validation when value is None/empty
             # (REDCap-imported patients have no email/phone set on their User record)
             email_val = raw.get("email")
-            if email_val is not None and email_val != "" and not re.match(
-                r"^[^\s@]+@[^\s@]+\.[^\s@]+$", str(email_val)
+            if (
+                email_val is not None
+                and email_val != ""
+                and not re.match(r"^[^\s@]+@[^\s@]+\.[^\s@]+$", str(email_val))
             ):
                 return JsonResponse({"error": "Invalid email"}, status=400)
 
             phone_val = raw.get("phone")
-            if phone_val is not None and phone_val != "" and not re.match(
-                r"^\+?[0-9]{7,15}$", str(phone_val)
-            ):
+            if phone_val is not None and phone_val != "" and not re.match(r"^\+?[0-9]{7,15}$", str(phone_val)):
                 return JsonResponse({"error": "Invalid phone"}, status=400)
 
             updated = {}

--- a/backend/core/views/user_views.py
+++ b/backend/core/views/user_views.py
@@ -363,11 +363,18 @@ def user_profile_view(request, user_id):
                 if k in forbidden:
                     del raw[k]
 
-            # Validate email + phone
-            if "email" in raw and not re.match(r"^[^\s@]+@[^\s@]+\.[^\s@]+$", raw["email"]):
+            # Validate email + phone — skip validation when value is None/empty
+            # (REDCap-imported patients have no email/phone set on their User record)
+            email_val = raw.get("email")
+            if email_val is not None and email_val != "" and not re.match(
+                r"^[^\s@]+@[^\s@]+\.[^\s@]+$", str(email_val)
+            ):
                 return JsonResponse({"error": "Invalid email"}, status=400)
 
-            if "phone" in raw and not re.match(r"^\+?[0-9]{7,15}$", raw["phone"]):
+            phone_val = raw.get("phone")
+            if phone_val is not None and phone_val != "" and not re.match(
+                r"^\+?[0-9]{7,15}$", str(phone_val)
+            ):
                 return JsonResponse({"error": "Invalid phone"}, status=400)
 
             updated = {}
@@ -476,6 +483,70 @@ def user_profile_view(request, user_id):
             return JsonResponse({"error": "Internal server error"}, status=500)
 
     return JsonResponse({"error": "Method not allowed"}, status=405)
+
+
+@csrf_exempt
+@permission_classes([IsAuthenticated])
+def reset_patient_password(request, patient_id):
+    """
+    PUT /api/patients/<patient_id>/reset-password/
+
+    Allows a therapist to set a new password for a patient without knowing the
+    old one.  The caller must be authenticated; no old-password check is
+    performed because therapists legitimately lack the patient's current password.
+
+    Body: {"new_password": "..."}
+
+    Password rules (same as the self-service endpoint):
+      - at least 8 characters
+      - contains uppercase, lowercase, digit and special character
+    """
+    if request.method != "PUT":
+        return JsonResponse({"error": "Method not allowed"}, status=405)
+
+    try:
+        data = json.loads(request.body or "{}")
+    except Exception:
+        return JsonResponse({"error": "Invalid JSON"}, status=400)
+
+    new_password = data.get("new_password") or data.get("newPassword")
+    if not new_password:
+        return JsonResponse({"error": "new_password is required"}, status=400)
+
+    # Strength check – same rules as the self-service change-password endpoint
+    if (
+        len(new_password) < 8
+        or not re.search(r"[A-Z]", new_password)
+        or not re.search(r"[a-z]", new_password)
+        or not re.search(r"[0-9]", new_password)
+        or not re.search(r"[!@#$%^&*(),.?\":{}|<>]", new_password)
+    ):
+        return JsonResponse(
+            {"error": "Weak password: must contain upper, lower, number, special char, and 8+ chars"},
+            status=400,
+        )
+
+    # Resolve patient
+    try:
+        patient = Patient.objects.get(pk=ObjectId(patient_id))
+    except Patient.DoesNotExist:
+        return JsonResponse({"error": "Patient not found"}, status=404)
+    except Exception:
+        return JsonResponse({"error": "Invalid patient ID"}, status=400)
+
+    user = patient.userId
+
+    user.pwdhash = make_password(new_password)
+    user.save()
+
+    Logs.objects.create(
+        userId=user,
+        action="UPDATE_PROFILE",
+        userAgent="Therapist",
+        details=f"Password reset by therapist for patient {patient_id}",
+    )
+
+    return JsonResponse({"message": "Password reset successfully"}, status=200)
 
 
 @csrf_exempt

--- a/backend/tests/user_views/test_user_views.py
+++ b/backend/tests/user_views/test_user_views.py
@@ -4,11 +4,12 @@ User views tests
 
 Endpoints covered
 -----------------
-``GET/PUT/DELETE /api/users/<user_id>/profile/``  → ``user_profile_view``
-``GET            /api/admin/pending-users/``       → ``get_pending_users``
-``POST           /api/admin/accept-user/``         → ``accept_user``
-``POST           /api/admin/decline-user/``        → ``decline_user``
-``PUT            /api/users/<user_id>/change-password/`` → ``change_password``
+``GET/PUT/DELETE /api/users/<user_id>/profile/``           → ``user_profile_view``
+``GET            /api/admin/pending-users/``               → ``get_pending_users``
+``POST           /api/admin/accept-user/``                 → ``accept_user``
+``POST           /api/admin/decline-user/``                → ``decline_user``
+``PUT            /api/users/<user_id>/change-password/``   → ``change_password``
+``PUT            /api/patients/<patient_id>/reset-password/`` → ``reset_patient_password``
 
 Coverage goals
 --------------
@@ -19,6 +20,8 @@ Happy-path
     remains in the database.
   * Admin workflow: list pending users, accept (activates + e-mail), decline
     (hard-deletes + e-mail).
+  * Therapist can reset a patient's password without knowing the old one via
+    ``PUT /api/patients/<id>/reset-password/``.
 
 Input validation (400)
   * Missing required fields (userId, old password, etc.).
@@ -26,6 +29,8 @@ Input validation (400)
   * Invalid e-mail / phone format on profile update.
   * Invalid date format on patient profile update.
   * Password-change without old password.
+  * Weak new password on reset-password endpoint.
+  * Missing new_password on reset-password endpoint.
 
 Authorisation / access control (403)
   * Wrong old password on PUT password change.
@@ -41,12 +46,25 @@ Resource not found
   * Non-existent user/ObjectId returns 404 or 500 depending on the view's
     own documented behaviour (see individual tests).
 
+REDCap patient regression (email/phone = None)
+-----------------------------------------------
+REDCap-imported patients have no e-mail or phone.  Sending ``null`` for those
+fields in the PUT body used to trigger ``re.match(pattern, None)`` → TypeError
+→ HTTP 500.  Fixed by checking for None/empty before calling ``re.match``.
+
 change_password endpoint behaviour note
 ----------------------------------------
 ``change_password`` (``PUT /api/users/<id>/change-password/``) always
 returns HTTP 400 when ``old_password`` / ``new_password`` are supplied in the
 body; it redirects callers to the profile endpoint instead.  The tests below
 document this current runtime behaviour.
+
+reset_patient_password endpoint
+---------------------------------
+``PUT /api/patients/<patient_id>/reset-password/`` lets a therapist set a
+brand-new password for a patient without requiring the old password.  The same
+strength rules apply (8+ chars, upper, lower, digit, special char).  The
+patient is located by their Patient document ObjectId.
 
 Test setup
 ----------
@@ -157,6 +175,43 @@ def create_patient():
         lifestyle=["Sedentary"],
         personal_goals=["Improved Mobility"],
         reha_end_date=datetime.now() + timedelta(days=30),
+    ).save()
+
+    return user, patient
+
+
+def create_redcap_patient():
+    """
+    Creates a patient without e-mail or phone, mimicking a patient imported
+    from REDCap where only the bare minimum User fields are populated.
+    """
+    user = User(
+        username="redcap_1",
+        # intentionally no email / phone
+        createdAt=datetime.now(),
+        role="Patient",
+        isActive=True,
+    ).save()
+
+    therapist_user = User(
+        username="t_redcap",
+        email="t_redcap@example.com",
+        createdAt=datetime.now(),
+        role="Therapist",
+    ).save()
+
+    therapist = Therapist(
+        userId=therapist_user,
+        name="REDCapTherapist",
+        first_name="John",
+        specializations=["Cardiology"],
+        clinics=["Inselspital"],
+    ).save()
+
+    patient = Patient(
+        userId=user,
+        patient_code="REDCAP001",
+        therapist=therapist,
     ).save()
 
     return user, patient
@@ -847,3 +902,337 @@ def test_change_password_get_method_not_allowed():
         HTTP_AUTHORIZATION="Bearer test",
     )
     assert resp.status_code == 405
+
+
+# ===========================================================================
+# REDCap patient profile — PUT (regression tests for email/phone=None bug)
+#
+# REDCap-imported patients are created with only a username; email and phone
+# are left unset (None).  When the frontend sends the full profile back as a
+# PUT body it includes ``"email": null`` and ``"phone": null``.  The original
+# validator called ``re.match(pattern, None)`` which raised TypeError → 500.
+# ===========================================================================
+
+
+def test_redcap_patient_put_with_null_email_and_phone_returns_200():
+    """
+    PUT for a REDCap-imported patient whose User has no email/phone must NOT
+    raise a TypeError when the body contains ``email: null`` / ``phone: null``.
+    The request must complete with HTTP 200.
+    """
+    user, patient = create_redcap_patient()
+
+    # Simulate what the frontend sends: the full profile with null email/phone
+    payload = {"email": None, "phone": None, "last_clinic_visit": "2026-03-02"}
+
+    resp = client.put(
+        f"/api/users/{str(patient.id)}/profile/",
+        data=json.dumps(payload),
+        content_type="application/json",
+        HTTP_AUTHORIZATION="Bearer test",
+    )
+    assert resp.status_code == 200, resp.json()
+
+
+def test_redcap_patient_put_updates_last_clinic_visit():
+    """
+    A REDCap patient (no email/phone) can have ``last_clinic_visit`` updated
+    via PUT on their Patient ID.  The ``updated`` dict in the response must
+    contain the ``last_clinic_visit`` key.
+    """
+    user, patient = create_redcap_patient()
+
+    payload = {"last_clinic_visit": "2026-03-02"}
+
+    resp = client.put(
+        f"/api/users/{str(patient.id)}/profile/",
+        data=json.dumps(payload),
+        content_type="application/json",
+        HTTP_AUTHORIZATION="Bearer test",
+    )
+    assert resp.status_code == 200
+    assert "last_clinic_visit" in resp.json().get("updated", {})
+
+
+def test_redcap_patient_put_persists_to_database():
+    """
+    After a successful PUT the ``last_clinic_visit`` stored in MongoDB must
+    match the value that was sent.  This verifies that the save actually
+    reached the database and is not just echoed from the payload.
+    """
+    user, patient = create_redcap_patient()
+
+    payload = {"last_clinic_visit": "2026-03-02"}
+
+    resp = client.put(
+        f"/api/users/{str(patient.id)}/profile/",
+        data=json.dumps(payload),
+        content_type="application/json",
+        HTTP_AUTHORIZATION="Bearer test",
+    )
+    assert resp.status_code == 200
+
+    refreshed = Patient.objects.get(pk=patient.id)
+    assert refreshed.last_clinic_visit is not None
+    assert refreshed.last_clinic_visit.date().isoformat() == "2026-03-02"
+
+
+def test_redcap_patient_put_via_patient_id_resolves_correctly():
+    """
+    The profile PUT accepts either the User ID or the Patient ID.
+    For REDCap patients the frontend always sends the Patient (``_id``) as the
+    URL parameter.  The view must resolve it to the linked User and succeed.
+    """
+    user, patient = create_redcap_patient()
+
+    payload = {"name": "TestSurname"}
+
+    resp = client.put(
+        f"/api/users/{str(patient.id)}/profile/",
+        data=json.dumps(payload),
+        content_type="application/json",
+        HTTP_AUTHORIZATION="Bearer test",
+    )
+    assert resp.status_code == 200
+    assert "name" in resp.json().get("updated", {})
+
+
+def test_redcap_patient_get_after_put_reflects_updated_value():
+    """
+    A GET immediately after a successful PUT must return the newly saved
+    value.  This covers the frontend "modal not updated" symptom end-to-end
+    at the API level: the server does persist and serve the fresh data.
+    """
+    user, patient = create_redcap_patient()
+
+    client.put(
+        f"/api/users/{str(patient.id)}/profile/",
+        data=json.dumps({"last_clinic_visit": "2026-03-02"}),
+        content_type="application/json",
+        HTTP_AUTHORIZATION="Bearer test",
+    )
+
+    resp = client.get(
+        f"/api/users/{str(patient.id)}/profile/",
+        HTTP_AUTHORIZATION="Bearer test",
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data.get("last_clinic_visit", "").startswith("2026-03-02")
+
+
+def test_profile_put_password_change_succeeds_for_redcap_patient():
+    """
+    Password change via ``PUT /api/users/<id>/profile/`` with
+    ``oldPassword`` / ``newPassword`` must work for REDCap patients too.
+    The password-change path runs before the email/phone validation so it
+    must not be affected by the None-email bug.
+    """
+    user, patient = create_redcap_patient()
+    user.pwdhash = "oldhash"
+    user.save()
+
+    payload = {"oldPassword": "oldhash", "newPassword": "New!Secure1"}
+
+    with (
+        mock.patch("core.views.user_views.check_password", return_value=True),
+        mock.patch("core.views.user_views.make_password", return_value="new_hashed"),
+    ):
+        resp = client.put(
+            f"/api/users/{str(patient.id)}/profile/",
+            data=json.dumps(payload),
+            content_type="application/json",
+            HTTP_AUTHORIZATION="Bearer test",
+        )
+    assert resp.status_code == 200
+    assert "Profile updated" in resp.json().get("message", "")
+
+
+def test_profile_put_null_email_is_skipped_not_saved():
+    """
+    When the body contains ``email: null`` the view must skip the field
+    (``valid_update_value(None)`` returns False) and must NOT overwrite a
+    previously stored email with None.
+    """
+    user, patient = create_patient()
+    original_email = user.email  # "p1@example.com"
+
+    # Send null email alongside a valid update
+    payload = {"email": None, "name": "UpdatedName"}
+
+    resp = client.put(
+        f"/api/users/{str(user.id)}/profile/",
+        data=json.dumps(payload),
+        content_type="application/json",
+        HTTP_AUTHORIZATION="Bearer test",
+    )
+    assert resp.status_code == 200
+
+    refreshed = User.objects.get(pk=user.id)
+    assert refreshed.email == original_email, "null email in PUT must not overwrite existing email"
+
+
+# ===========================================================================
+# reset_patient_password  (PUT /api/patients/<patient_id>/reset-password/)
+#
+# Lets a therapist set a brand-new password for a patient without needing to
+# know the old password.  Identical strength rules as the self-service flow.
+# ===========================================================================
+
+
+def test_reset_patient_password_success():
+    """
+    PUT with a strong new password returns HTTP 200 with 'Password reset
+    successfully' in the response body.
+    """
+    _, patient = create_redcap_patient()
+
+    with mock.patch("core.views.user_views.make_password", return_value="hashed_new"):
+        resp = client.put(
+            f"/api/patients/{str(patient.id)}/reset-password/",
+            data=json.dumps({"new_password": "NewPass1!"}),
+            content_type="application/json",
+            HTTP_AUTHORIZATION="Bearer test",
+        )
+
+    assert resp.status_code == 200
+    assert "Password reset successfully" in resp.json().get("message", "")
+
+
+def test_reset_patient_password_persists_new_hash():
+    """
+    After a successful reset the User document's ``pwdhash`` must be updated.
+    The test mocks ``make_password`` so we can assert the exact stored value.
+    """
+    _, patient = create_redcap_patient()
+
+    with mock.patch("core.views.user_views.make_password", return_value="hashed_new"):
+        client.put(
+            f"/api/patients/{str(patient.id)}/reset-password/",
+            data=json.dumps({"new_password": "NewPass1!"}),
+            content_type="application/json",
+            HTTP_AUTHORIZATION="Bearer test",
+        )
+
+    refreshed_patient = Patient.objects.get(pk=patient.id)
+    refreshed_user = refreshed_patient.userId
+    assert refreshed_user.pwdhash == "hashed_new", "pwdhash must be updated after reset"
+
+
+def test_reset_patient_password_accepts_camel_case_key():
+    """
+    The endpoint accepts both ``new_password`` (snake_case) and
+    ``newPassword`` (camelCase) to be consistent with the profile endpoint.
+    """
+    _, patient = create_redcap_patient()
+
+    with mock.patch("core.views.user_views.make_password", return_value="hashed_new"):
+        resp = client.put(
+            f"/api/patients/{str(patient.id)}/reset-password/",
+            data=json.dumps({"newPassword": "NewPass1!"}),
+            content_type="application/json",
+            HTTP_AUTHORIZATION="Bearer test",
+        )
+
+    assert resp.status_code == 200
+
+
+def test_reset_patient_password_missing_new_password_returns_400():
+    """
+    PUT with an empty body (no ``new_password``) returns 400 with
+    'new_password is required'.
+    """
+    _, patient = create_redcap_patient()
+
+    resp = client.put(
+        f"/api/patients/{str(patient.id)}/reset-password/",
+        data=json.dumps({}),
+        content_type="application/json",
+        HTTP_AUTHORIZATION="Bearer test",
+    )
+
+    assert resp.status_code == 400
+    assert "new_password is required" in resp.json().get("error", "")
+
+
+def test_reset_patient_password_weak_password_returns_400():
+    """
+    PUT with a password that fails the strength rules (no uppercase, no
+    special character, fewer than 8 chars, etc.) returns 400 with 'Weak
+    password' in the error.
+    """
+    _, patient = create_redcap_patient()
+
+    resp = client.put(
+        f"/api/patients/{str(patient.id)}/reset-password/",
+        data=json.dumps({"new_password": "weakpw"}),
+        content_type="application/json",
+        HTTP_AUTHORIZATION="Bearer test",
+    )
+
+    assert resp.status_code == 400
+    assert "Weak password" in resp.json().get("error", "")
+
+
+def test_reset_patient_password_patient_not_found_returns_404():
+    """
+    Using a valid ObjectId that matches no Patient document returns 404 with
+    'Patient not found'.
+    """
+    resp = client.put(
+        f"/api/patients/{ObjectId()}/reset-password/",
+        data=json.dumps({"new_password": "NewPass1!"}),
+        content_type="application/json",
+        HTTP_AUTHORIZATION="Bearer test",
+    )
+
+    assert resp.status_code == 404
+    assert "Patient not found" in resp.json().get("error", "")
+
+
+def test_reset_patient_password_invalid_objectid_returns_400():
+    """
+    Sending a malformed ObjectId as the patient_id returns 400.
+    """
+    resp = client.put(
+        "/api/patients/not-an-objectid/reset-password/",
+        data=json.dumps({"new_password": "NewPass1!"}),
+        content_type="application/json",
+        HTTP_AUTHORIZATION="Bearer test",
+    )
+
+    assert resp.status_code == 400
+    assert "Invalid patient ID" in resp.json().get("error", "")
+
+
+def test_reset_patient_password_method_not_allowed():
+    """
+    GET to the reset-password endpoint returns 405.  Only PUT is accepted.
+    """
+    _, patient = create_redcap_patient()
+
+    resp = client.get(
+        f"/api/patients/{str(patient.id)}/reset-password/",
+        HTTP_AUTHORIZATION="Bearer test",
+    )
+
+    assert resp.status_code == 405
+    assert "Method not allowed" in resp.json().get("error", "")
+
+
+def test_reset_patient_password_works_for_regular_patient():
+    """
+    The endpoint must also work for manually-created (non-REDCap) patients
+    that have a full User record with e-mail and phone.
+    """
+    _, patient = create_patient()
+
+    with mock.patch("core.views.user_views.make_password", return_value="hashed_new"):
+        resp = client.put(
+            f"/api/patients/{str(patient.id)}/reset-password/",
+            data=json.dumps({"new_password": "NewPass1!"}),
+            content_type="application/json",
+            HTTP_AUTHORIZATION="Bearer test",
+        )
+
+    assert resp.status_code == 200

--- a/frontend/src/components/TherapistPatientPage/PatientPopup.tsx
+++ b/frontend/src/components/TherapistPatientPage/PatientPopup.tsx
@@ -4,7 +4,15 @@ import { Button, Col, Form, Row, Spinner, Tabs, Tab, Badge, Table } from 'react-
 import { useTranslation } from 'react-i18next';
 import Select from 'react-select';
 import { observer } from 'mobx-react-lite';
-import { FaEdit, FaTrash, FaUndo, FaDownload, FaCloudDownloadAlt, FaSyncAlt, FaKey } from 'react-icons/fa';
+import {
+  FaEdit,
+  FaTrash,
+  FaUndo,
+  FaDownload,
+  FaCloudDownloadAlt,
+  FaSyncAlt,
+  FaKey,
+} from 'react-icons/fa';
 
 import config from '../../config/config.json';
 import { PatientType } from '../../types';

--- a/frontend/src/components/TherapistPatientPage/PatientPopup.tsx
+++ b/frontend/src/components/TherapistPatientPage/PatientPopup.tsx
@@ -4,7 +4,7 @@ import { Button, Col, Form, Row, Spinner, Tabs, Tab, Badge, Table } from 'react-
 import { useTranslation } from 'react-i18next';
 import Select from 'react-select';
 import { observer } from 'mobx-react-lite';
-import { FaEdit, FaTrash, FaUndo, FaDownload, FaCloudDownloadAlt, FaSyncAlt } from 'react-icons/fa';
+import { FaEdit, FaTrash, FaUndo, FaDownload, FaCloudDownloadAlt, FaSyncAlt, FaKey } from 'react-icons/fa';
 
 import config from '../../config/config.json';
 import { PatientType } from '../../types';
@@ -404,7 +404,7 @@ const PatientPopup: React.FC<PatientPopupProps> = observer(({ patient_id, show, 
                     <h5 className="mb-3">{t(section.title)}</h5>
                     <Row className="g-3">
                       {section.fields
-                        .filter((f: any) => !['password', 'repeatPassword'].includes(f.type))
+                        .filter((f: any) => !['password', 'repeatPassword'].includes(f.name))
                         .map((field: any, index: number) => (
                           <Col xs={12} md={6} key={`${section.title}-${field.be_name}-${index}`}>
                             <Form.Group controlId={field.be_name}>
@@ -419,6 +419,75 @@ const PatientPopup: React.FC<PatientPopupProps> = observer(({ patient_id, show, 
                     </Row>
                   </div>
                 ))}
+
+                {/* ── Password reset section ───────────────────────────── */}
+                <div className="mb-2">
+                  <hr />
+                  <Button
+                    variant={store.showPasswordReset ? 'outline-secondary' : 'outline-warning'}
+                    size="sm"
+                    onClick={() => store.setShowPasswordReset(!store.showPasswordReset)}
+                    aria-expanded={store.showPasswordReset}
+                  >
+                    <FaKey className="me-2" />
+                    {store.showPasswordReset ? t('CancelPasswordReset') : t('ResetPassword')}
+                  </Button>
+
+                  {store.showPasswordReset && (
+                    <div className="mt-3">
+                      {store.passwordError && (
+                        <div className="alert alert-danger py-2 px-3 mb-2" role="alert">
+                          {store.passwordError}
+                        </div>
+                      )}
+                      {store.passwordSuccess && (
+                        <div className="alert alert-success py-2 px-3 mb-2" role="alert">
+                          {t('PasswordResetSuccess')}
+                        </div>
+                      )}
+                      <Row className="g-2 align-items-end">
+                        <Col xs={12} md={4}>
+                          <Form.Group controlId="pw-reset-new">
+                            <Form.Label className="small mb-1">{t('NewPassword')}</Form.Label>
+                            <Form.Control
+                              type="password"
+                              value={store.passwordNew}
+                              onChange={(e) => store.setPasswordNew(e.target.value)}
+                              placeholder="••••••••"
+                              autoComplete="new-password"
+                            />
+                          </Form.Group>
+                        </Col>
+                        <Col xs={12} md={4}>
+                          <Form.Group controlId="pw-reset-confirm">
+                            <Form.Label className="small mb-1">{t('ConfirmPassword')}</Form.Label>
+                            <Form.Control
+                              type="password"
+                              value={store.passwordConfirm}
+                              onChange={(e) => store.setPasswordConfirm(e.target.value)}
+                              placeholder="••••••••"
+                              autoComplete="new-password"
+                            />
+                          </Form.Group>
+                        </Col>
+                        <Col xs={12} md={4}>
+                          <Button
+                            variant="warning"
+                            disabled={store.passwordSaving}
+                            onClick={() => store.resetPassword(t)}
+                            className="w-100"
+                          >
+                            <FaKey className="me-2" />
+                            {store.passwordSaving ? t('Saving...') : t('SetNewPassword')}
+                          </Button>
+                        </Col>
+                      </Row>
+                      <div className="text-muted mt-1" style={{ fontSize: '0.8rem' }}>
+                        {t('PasswordStrengthHint')}
+                      </div>
+                    </div>
+                  )}
+                </div>
               </Tab>
 
               <Tab eventKey="characteristics" title={t('Characteristics')}>

--- a/frontend/src/stores/patientPopupStore.ts
+++ b/frontend/src/stores/patientPopupStore.ts
@@ -195,6 +195,16 @@ export class PatientPopupStore {
   specialityDiagnosisMap: Record<string, string[]> = {};
 
   // -------------------------
+  // Password reset (therapist → patient)
+  // -------------------------
+  showPasswordReset = false;
+  passwordNew = '';
+  passwordConfirm = '';
+  passwordSaving = false;
+  passwordError: string | null = null;
+  passwordSuccess = false;
+
+  // -------------------------
   // Thresholds (NEW)
   // -------------------------
   thresholdsLoading = false;
@@ -237,6 +247,69 @@ export class PatientPopupStore {
 
   setActiveTab(v: 'profile' | 'characteristics' | 'redcap' | 'thresholds') {
     this.activeTab = v;
+  }
+
+  // -------------------------
+  // Password reset setters
+  // -------------------------
+  setShowPasswordReset(v: boolean) {
+    this.showPasswordReset = v;
+    if (!v) {
+      this.passwordNew = '';
+      this.passwordConfirm = '';
+      this.passwordError = null;
+      this.passwordSuccess = false;
+    }
+  }
+
+  setPasswordNew(v: string) {
+    this.passwordNew = v;
+    this.passwordError = null;
+    this.passwordSuccess = false;
+  }
+
+  setPasswordConfirm(v: string) {
+    this.passwordConfirm = v;
+    this.passwordError = null;
+    this.passwordSuccess = false;
+  }
+
+  async resetPassword(t: (k: string) => string) {
+    if (!this.passwordNew) {
+      this.passwordError = t('NewPasswordRequired');
+      return false;
+    }
+    if (this.passwordNew !== this.passwordConfirm) {
+      this.passwordError = t('PasswordsDoNotMatch');
+      return false;
+    }
+
+    this.passwordSaving = true;
+    this.passwordError = null;
+    this.passwordSuccess = false;
+
+    try {
+      await apiClient.put(`/patients/${this.patientId}/reset-password/`, {
+        new_password: this.passwordNew,
+      });
+      runInAction(() => {
+        this.passwordSuccess = true;
+        this.passwordNew = '';
+        this.passwordConfirm = '';
+      });
+      return true;
+    } catch (err: any) {
+      const api = err?.response?.data;
+      runInAction(() => {
+        this.passwordError =
+          api?.error || api?.message || err?.message || t('Failed to reset password.');
+      });
+      return false;
+    } finally {
+      runInAction(() => {
+        this.passwordSaving = false;
+      });
+    }
   }
 
   // -------------------------
@@ -606,12 +679,15 @@ export class PatientPopupStore {
 
     try {
       // ✅ match your existing GET (and trailing slash)
-      const res = await apiClient.put(`/users/${this.patientId}/profile/`, this.formData);
-      const updated = res.data || {};
+      await apiClient.put(`/users/${this.patientId}/profile/`, this.formData);
+
+      // Re-fetch the full profile so the modal shows accurate server state
+      const profileRes = await apiClient.get(`/users/${this.patientId}/profile`);
+      const freshData = profileRes.data || {};
 
       runInAction(() => {
-        this.manualData = updated;
-        this.formData = { ...(updated || {}) };
+        this.manualData = freshData;
+        this.formData = { ...(freshData || {}) };
         this.isEditing = false;
       });
 


### PR DESCRIPTION
### PR Description
Fix patient profile saving and add therapist password reset
**Branch:** bug-patient-profile-saving

Bug Fixes
1. REDCap patients: 500 error on profile save (PUT /api/users/{id}/profile/)

REDCap-imported patients have no email or phone on their User record (None). When a therapist saved their profile, the PUT handler called re.match(pattern, None) which raised a TypeError, caught by the generic except and returned as a 500. Fixed by null/empty-checking both values before calling re.match.

2. Manual patient modal not updating after a successful save

After a successful PUT, the store was assigning the raw response body ({message: "...", updated: {...}}) to manualData instead of the actual profile. Fixed by re-fetching the full profile via a GET request after the PUT, ensuring the modal always reflects the true server state.

3. Password/Confirm Password fields appearing in the patient info modal

The profile edit form in PatientPopup.tsx was filtering out password fields using f.type, but those config fields have "type": "text", so they slipped through. Fixed by changing the filter to use f.name instead of f.type.

### New Feature
Therapist-initiated password reset for patients

Therapists can now reset a patient's password directly from the patient info modal (Profile tab), without requiring the old password.

- Backend: New PUT /api/patients/<patient_id>/reset-password/ endpoint with the same password strength rules (8+ chars, upper, lower, digit, special character). Creates an audit log entry.

- Frontend store (patientPopupStore.ts): New observable state (showPasswordReset, passwordNew, passwordConfirm, passwordSaving, passwordError, passwordSuccess) and resetPassword() action.

- Frontend UI (PatientPopup.tsx): Toggle button at the bottom of the Profile tab that expands a new password / confirm password form with inline success/error feedback.

### Tests

- Added create_redcap_patient() factory helper for REDCap-specific test cases
- 7 new regression tests for REDCap patient profile save (email/phone None edge cases)
- 9 new tests for reset_patient_password (success, wrong method, missing/weak password, patient not found, etc.)
- Updated module docstring to document all covered endpoints
- Total: 56 tests, all passing