### PR TITLE
Feature inform admin of registrations

### DIFF
--- a/backend/core/views/auth_views.py
+++ b/backend/core/views/auth_views.py
@@ -499,6 +499,42 @@ def _err(message: str, status: int = 400, field_errors=None, non_field_errors=No
     return JsonResponse(payload, status=status)
 
 
+def _notify_admins_new_therapist(user, therapist):
+    """
+    Send a notification e-mail to every active Admin user when a new therapist
+    registers.  Failures are logged but never surface to the caller so that a
+    misconfigured mail server cannot block registration.
+    """
+    try:
+        admins = User.objects.filter(role="Admin", isActive=True)
+        admin_emails = [u.email for u in admins if u.email]
+        if not admin_emails:
+            return
+
+        first = getattr(therapist, "first_name", "") or ""
+        last = getattr(therapist, "name", "") or ""
+        full_name = f"{first} {last}".strip() or user.username
+
+        subject = "New therapist registration pending approval"
+        message = (
+            f"A new therapist has registered and is awaiting approval.\n\n"
+            f"Name:     {full_name}\n"
+            f"Email:    {user.email}\n"
+            f"Username: {user.username}\n\n"
+            f"Please log in to the admin panel to accept or decline the account."
+        )
+
+        send_mail(
+            subject=subject,
+            message=message,
+            from_email=settings.DEFAULT_FROM_EMAIL,
+            recipient_list=admin_emails,
+            fail_silently=True,
+        )
+    except Exception:
+        logger.exception("Failed to notify admins of new therapist registration")
+
+
 @csrf_exempt
 def register_view(request):
     """
@@ -745,6 +781,9 @@ def register_view(request):
                 logger.exception("Therapist save failed.")
                 rollback()
                 return _err("Therapist creation failed.", status=400, non_field_errors=[str(e)])
+
+            # Notify all admin users that a new therapist is awaiting approval
+            _notify_admins_new_therapist(user, therapist)
 
             return JsonResponse(
                 {

--- a/backend/tests/auth_views/test_register_view.py
+++ b/backend/tests/auth_views/test_register_view.py
@@ -30,10 +30,21 @@ Role-based registration behaviour
     required); Patient is created with ``isActive=True``.
   * The response ``id`` is the generated system username, not the database id.
 
+Admin notification on therapist registration
+  * ``send_mail`` is called once per successful therapist registration.
+  * Recipient list contains every active Admin user's e-mail address.
+  * Multiple admins each receive the notification.
+  * No e-mail is sent when a patient registers (not a therapist).
+  * No e-mail is sent when there are no Admin users in the database.
+  * A mail-server failure (exception from ``send_mail``) does NOT prevent a
+    successful 200 response — registration is never blocked by mail errors.
+
 Test setup
 ----------
 Each test uses the ``mongo_mock`` autouse fixture that spins up an
 in-memory mongomock connection and tears it down afterwards.
+``send_mail`` is patched via ``@mock.patch`` to avoid real SMTP calls and to
+allow assertion on call arguments.
 """
 
 import json
@@ -290,3 +301,133 @@ def test_register_get_method_not_allowed(mongo_mock):
     """
     resp = client.get(REGISTER_URL)
     assert resp.status_code == 405
+
+
+# ===========================================================================
+# Admin notification on therapist registration
+# ===========================================================================
+
+_THERAPIST_PAYLOAD = {
+    "userType": "Therapist",
+    "email": "newtherapist@example.com",
+    "password": "strongpassword",
+    "firstName": "John",
+    "lastName": "Doe",
+}
+
+
+def _create_admin(email):
+    return User(
+        username=f"admin_{email.split('@')[0]}",
+        role="Admin",
+        email=email,
+        pwdhash="",
+        createdAt=datetime.now(),
+        isActive=True,
+    ).save()
+
+
+@mock.patch("core.views.auth_views.send_mail")
+def test_register_therapist_notifies_single_admin(mock_send_mail, mongo_mock):
+    """
+    When exactly one Admin user exists, ``send_mail`` is called once after a
+    successful therapist registration and that admin's e-mail is in the
+    recipient list.
+    """
+    _create_admin("admin@example.com")
+
+    resp = _post(_THERAPIST_PAYLOAD)
+
+    assert resp.status_code == 200
+    mock_send_mail.assert_called_once()
+    _, kwargs = mock_send_mail.call_args
+    assert "admin@example.com" in kwargs.get("recipient_list", [])
+
+
+@mock.patch("core.views.auth_views.send_mail")
+def test_register_therapist_notifies_multiple_admins(mock_send_mail, mongo_mock):
+    """
+    When multiple Admin users exist, all of their e-mail addresses appear in
+    the ``recipient_list`` of the single ``send_mail`` call.
+    """
+    _create_admin("admin1@example.com")
+    _create_admin("admin2@example.com")
+
+    resp = _post({**_THERAPIST_PAYLOAD, "email": "therapist2@example.com"})
+
+    assert resp.status_code == 200
+    mock_send_mail.assert_called_once()
+    _, kwargs = mock_send_mail.call_args
+    recipients = kwargs.get("recipient_list", [])
+    assert "admin1@example.com" in recipients
+    assert "admin2@example.com" in recipients
+
+
+@mock.patch("core.views.auth_views.send_mail")
+def test_register_therapist_no_admins_no_email_sent(mock_send_mail, mongo_mock):
+    """
+    When there are no Admin users in the database, ``send_mail`` is never
+    called.  The registration itself still returns 200.
+    """
+    resp = _post({**_THERAPIST_PAYLOAD, "email": "therapist3@example.com"})
+
+    assert resp.status_code == 200
+    mock_send_mail.assert_not_called()
+
+
+@mock.patch("core.views.auth_views.send_mail")
+def test_register_patient_does_not_notify_admins(mock_send_mail, mongo_mock):
+    """
+    Registering a Patient must NOT trigger any admin notification e-mail.
+    Only therapist registrations require admin approval and therefore
+    notification.
+    """
+    _create_admin("admin@example.com")
+
+    admin_user = User(
+        username="therapistowner",
+        role="Therapist",
+        email="owner@example.com",
+        pwdhash="",
+        createdAt=datetime.now(),
+        isActive=True,
+    ).save()
+    from core.models import Therapist as TherapistModel
+    TherapistModel(
+        userId=admin_user,
+        name="Owner",
+        first_name="T",
+        specializations=["Cardiology"],
+        clinics=["Inselspital"],
+    ).save()
+
+    resp = _post(
+        {
+            "userType": "Patient",
+            "email": "patient@example.com",
+            "password": "pw",
+            "firstName": "P",
+            "lastName": "A",
+            "therapist": str(admin_user.id),
+            "rehaEndDate": (datetime.now() + timedelta(days=30)).strftime("%Y-%m-%d"),
+        }
+    )
+
+    # Patient registration may succeed or fail depending on rehab plan; either
+    # way, the admin notification must never be triggered.
+    mock_send_mail.assert_not_called()
+
+
+@mock.patch("core.views.auth_views.send_mail", side_effect=Exception("SMTP error"))
+def test_register_therapist_mail_failure_does_not_block_registration(mock_send_mail, mongo_mock):
+    """
+    If ``send_mail`` raises an exception (e.g. SMTP server unreachable), the
+    therapist registration must still return HTTP 200.  Mail failures are
+    logged but must never prevent account creation.
+    """
+    _create_admin("admin@example.com")
+
+    resp = _post({**_THERAPIST_PAYLOAD, "email": "therapist4@example.com"})
+
+    assert resp.status_code == 200
+    assert resp.json().get("success") is True

--- a/backend/tests/auth_views/test_register_view.py
+++ b/backend/tests/auth_views/test_register_view.py
@@ -393,6 +393,7 @@ def test_register_patient_does_not_notify_admins(mock_send_mail, mongo_mock):
         isActive=True,
     ).save()
     from core.models import Therapist as TherapistModel
+
     TherapistModel(
         userId=admin_user,
         name="Owner",

--- a/docs/09-API_DOCUMENTATION.md
+++ b/docs/09-API_DOCUMENTATION.md
@@ -44,6 +44,7 @@ JWT refresh endpoint:
 - `POST /api/auth/logout/` -> `auth_views.logout_view`
 - `POST /api/auth/forgot-password/` -> `auth_views.reset_password_view`
 - `POST /api/auth/register/` -> `auth_views.register_view`
+  - **Side-effect (therapist only):** on successful therapist registration an e-mail notification is sent to every active Admin user so they can approve or decline the pending account via `POST /api/admin/accept-user/` or `POST /api/admin/decline-user/`. Newly registered therapists have `isActive=False` until approved. Mail failures are logged silently and do not affect the 200 response.
 - `POST /api/auth/send-verification-code/` -> `auth_views.send_verification_code`
 - `POST /api/auth/verify-code/` -> `auth_views.verify_code_view`
 - `POST /api/auth/token/refresh/` -> `TokenRefreshView`
@@ -56,6 +57,8 @@ JWT refresh endpoint:
 - `POST /api/admin/decline-user/` -> `user_views.decline_user`
 - `GET|PUT|DELETE /api/users/<user_id>/profile/` -> `user_views.user_profile_view`
 - `PUT /api/users/<therapist_id>/change-password/` -> `user_views.change_password`
+- `PUT /api/patients/<patient_id>/reset-password/` -> `user_views.reset_patient_password`
+  - Allows a therapist to set a new password for a patient without knowing the current password. Requires the new password to meet strength rules (8+ chars, upper, lower, digit, special character).
 
 ### Therapist
 


### PR DESCRIPTION
### PR Description
Notify admins by email when a new therapist registers
Branch: bug-patient-profile-saving
## Summary
When a therapist self-registers, admins previously had no automated signal that a new account was awaiting their approval. They had to poll the pending-users list manually. This change sends an email to every active Admin user immediately after a successful therapist registration.
## What changed
backend/core/views/auth_views.py

- Added _notify_admins_new_therapist(user, therapist) helper that queries all User documents with role="Admin" and isActive=True, then calls send_mail with a plain-text notification including the therapist's name, email, and username

- Called from register_view after therapist.save() succeeds

- Uses fail_silently=True and a surrounding try/except so a misconfigured SMTP server can never block registration — failures are logged only

backend/tests/auth_views/test_register_view.py — 5 new tests, updated docstring

- Single admin receives the notification
- Multiple admins all appear in the recipient list of one send_mail call
- No email sent when no Admin users exist in the database
- Patient registration does not trigger admin notification
- SMTP exception during send_mail still returns HTTP 200 (registration is not blocked)

docs/09-API_DOCUMENTATION.md

- Documented the admin notification side-effect under POST /api/auth/register/
- Added the previously undocumented PUT /api/patients/<patient_id>/reset-password/ endpoint to the User/Admin catalog
- Behaviour notes
- Admins are identified by User.role == "Admin" and isActive=True — no separate config required
- Only therapist registrations trigger the notification; patient registrations do not
- The email body contains the therapist's full name, email address, and system username, and directs the admin to the accept/decline panel
- 129 tests passing