### PR TITLE
Feature control initial questionaire for patient

### DIFF
--- a/backend/core/models.py
+++ b/backend/core/models.py
@@ -479,6 +479,7 @@ class Patient(Document):
     social_support = ListField(StringField(max_length=120), required=False, default=list)
     duration = IntField(required=False, null=True)
     care_giver = StringField(max_length=80, required=False, default="")
+    initial_questionnaire_enabled = BooleanField(default=False)
 
     reha_end_date = DateTimeField(required=False, null=True)
 

--- a/backend/core/views/auth_views.py
+++ b/backend/core/views/auth_views.py
@@ -710,6 +710,7 @@ def register_view(request):
                 reha_end_date=reha_end_date,
                 # ✅ FIX: correct key (your payload uses "careGiver")
                 care_giver=sanitize_text(data.get("careGiver", ""), True),
+                initial_questionnaire_enabled=bool(data.get("initialQuestionnaireEnabled", False)),
             )
 
             try:

--- a/backend/core/views/patient_views.py
+++ b/backend/core/views/patient_views.py
@@ -2699,6 +2699,10 @@ def initial_patient_questionaire(request, patient_id):
     # GET → check if questionnaire is needed
     # ----------------------------
     if request.method == "GET":
+        # If the questionnaire is disabled for this patient, never prompt it
+        if not patient.initial_questionnaire_enabled:
+            return JsonResponse({"success": True, "requires_questionnaire": False}, status=200)
+
         missing = not all(
             [
                 patient.level_of_education,

--- a/backend/core/views/user_views.py
+++ b/backend/core/views/user_views.py
@@ -238,6 +238,7 @@ def user_profile_view(request, user_id):
         "lifestyle": list,
         "personal_goals": list,
         "social_support": list,
+        "initial_questionnaire_enabled": bool,
     }
 
     TH_ALLOWED_USER = {"username": str, "email": str, "phone": str}
@@ -446,6 +447,11 @@ def user_profile_view(request, user_id):
                     old[field] = getattr(patient, field)
                     setattr(patient, field, val)
                     updated[field] = val
+
+                # Handle boolean fields explicitly (valid_update_value(False) would skip them)
+                if "initial_questionnaire_enabled" in raw:
+                    patient.initial_questionnaire_enabled = bool(raw["initial_questionnaire_enabled"])
+                    updated["initial_questionnaire_enabled"] = patient.initial_questionnaire_enabled
 
                 user.save()
                 patient.save()

--- a/backend/tests/auth_views/test_register_view.py
+++ b/backend/tests/auth_views/test_register_view.py
@@ -29,6 +29,8 @@ Role-based registration behaviour
   * Therapist is created with ``isActive=False`` by default (admin approval
     required); Patient is created with ``isActive=True``.
   * The response ``id`` is the generated system username, not the database id.
+  * ``initialQuestionnaireEnabled: true`` in the payload persists
+    ``initial_questionnaire_enabled=True`` on the Patient document.
 
 Admin notification on therapist registration
   * ``send_mail`` is called once per successful therapist registration.
@@ -432,3 +434,54 @@ def test_register_therapist_mail_failure_does_not_block_registration(mock_send_m
 
     assert resp.status_code == 200
     assert resp.json().get("success") is True
+
+
+# ===========================================================================
+# initial_questionnaire_enabled on patient registration
+# ===========================================================================
+
+
+def test_register_patient_initial_questionnaire_enabled_persisted(mongo_mock):
+    """
+    When ``initialQuestionnaireEnabled: true`` is included in the Patient
+    registration payload, the resulting Patient document must have
+    ``initial_questionnaire_enabled=True``.  The default is ``False``, so
+    this test confirms the flag is correctly read from the payload and saved.
+    """
+    therapist_user = User(
+        username="th_reg",
+        role="Therapist",
+        email="th_reg@example.com",
+        pwdhash="",
+        createdAt=datetime.now(),
+        isActive=True,
+    ).save()
+    from core.models import Patient, Therapist as TherapistModel
+
+    TherapistModel(
+        userId=therapist_user,
+        name="Reg",
+        first_name="T",
+        specializations=["Cardiology"],
+        clinics=["Inselspital"],
+    ).save()
+
+    _post(
+        {
+            "userType": "Patient",
+            "email": "pat_iq@example.com",
+            "password": "pw",
+            "firstName": "P",
+            "lastName": "A",
+            "therapist": str(therapist_user.id),
+            "rehaEndDate": (datetime.now() + timedelta(days=30)).strftime("%Y-%m-%d"),
+            "initialQuestionnaireEnabled": True,
+        }
+    )
+
+    from core.models import User as UserModel
+    created_user = UserModel.objects.filter(email="pat_iq@example.com").first()
+    assert created_user is not None, "Patient User must be created"
+    patient = Patient.objects.filter(userId=created_user).first()
+    assert patient is not None, "Patient document must be created"
+    assert patient.initial_questionnaire_enabled is True

--- a/backend/tests/auth_views/test_register_view.py
+++ b/backend/tests/auth_views/test_register_view.py
@@ -456,7 +456,8 @@ def test_register_patient_initial_questionnaire_enabled_persisted(mongo_mock):
         createdAt=datetime.now(),
         isActive=True,
     ).save()
-    from core.models import Patient, Therapist as TherapistModel
+    from core.models import Patient
+    from core.models import Therapist as TherapistModel
 
     TherapistModel(
         userId=therapist_user,
@@ -480,6 +481,7 @@ def test_register_patient_initial_questionnaire_enabled_persisted(mongo_mock):
     )
 
     from core.models import User as UserModel
+
     created_user = UserModel.objects.filter(email="pat_iq@example.com").first()
     assert created_user is not None, "Patient User must be created"
     patient = Patient.objects.filter(userId=created_user).first()

--- a/backend/tests/patient_views/test_initial_questionnaire.py
+++ b/backend/tests/patient_views/test_initial_questionnaire.py
@@ -26,6 +26,16 @@ Resource not found (404)
 HTTP method enforcement (405)
   * PUT (or any unsupported verb) returns 405.
 
+initial_questionnaire_enabled flag
+------------------------------------
+The ``Patient.initial_questionnaire_enabled`` boolean (default ``False``) acts
+as the master switch for the questionnaire prompt.
+
+  * When ``False`` (default), the GET endpoint always returns
+    ``requires_questionnaire: false`` regardless of whether demographics are
+    empty, so the patient is never prompted.
+  * When ``True``, the normal field-completeness check applies.
+
 Test setup
 ----------
 The ``mongo_mock`` autouse fixture provides an isolated in-memory mongomock
@@ -135,12 +145,14 @@ FULL_DEMOGRAPHICS = {
 
 def test_get_requires_questionnaire(mongo_mock):
     """
-    GET for a patient who has no demographic fields returns 200 with
-    ``requires_questionnaire: true``.  The mobile app uses this flag to route
-    new patients to the on-boarding questionnaire screen before showing the
-    main dashboard.
+    GET for a patient who has no demographic fields AND has the questionnaire
+    enabled returns 200 with ``requires_questionnaire: true``.  The mobile app
+    uses this flag to route new patients to the on-boarding questionnaire screen
+    before showing the main dashboard.
     """
     patient = create_patient(complete=False)
+    patient.initial_questionnaire_enabled = True
+    patient.save()
     resp = client.get(
         QUEST_URL.format(patient_id=str(patient.userId.id)),
         HTTP_AUTHORIZATION="Bearer test",
@@ -276,3 +288,46 @@ def test_method_not_allowed(mongo_mock):
         HTTP_AUTHORIZATION="Bearer test",
     )
     assert resp.status_code == 405
+
+
+# ===========================================================================
+# initial_questionnaire_enabled flag
+# ===========================================================================
+
+
+def test_get_questionnaire_disabled_returns_not_required(mongo_mock):
+    """
+    When ``initial_questionnaire_enabled=False`` (the default), the GET
+    endpoint must return ``requires_questionnaire: false`` even when all five
+    demographic fields are empty.  The patient is never shown the on-boarding
+    modal when the flag is off.
+    """
+    patient = create_patient(complete=False)  # demographics empty, flag=False (default)
+    resp = client.get(
+        QUEST_URL.format(patient_id=str(patient.userId.id)),
+        HTTP_AUTHORIZATION="Bearer test",
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["success"] is True
+    assert data["requires_questionnaire"] is False
+
+
+def test_get_questionnaire_enabled_still_checks_fields(mongo_mock):
+    """
+    When ``initial_questionnaire_enabled=True`` and demographics are missing,
+    the GET endpoint must return ``requires_questionnaire: true``.  The flag
+    restores the normal completeness-check behaviour.
+    """
+    patient = create_patient(complete=False)
+    patient.initial_questionnaire_enabled = True
+    patient.save()
+
+    resp = client.get(
+        QUEST_URL.format(patient_id=str(patient.userId.id)),
+        HTTP_AUTHORIZATION="Bearer test",
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["success"] is True
+    assert data["requires_questionnaire"] is True

--- a/backend/tests/user_views/test_user_views.py
+++ b/backend/tests/user_views/test_user_views.py
@@ -22,6 +22,8 @@ Happy-path
     (hard-deletes + e-mail).
   * Therapist can reset a patient's password without knowing the old one via
     ``PUT /api/patients/<id>/reset-password/``.
+  * Therapist can toggle ``initial_questionnaire_enabled`` on a patient via
+    the profile PUT endpoint (``True`` → ``False`` and vice-versa).
 
 Input validation (400)
   * Missing required fields (userId, old password, etc.).
@@ -1236,3 +1238,51 @@ def test_reset_patient_password_works_for_regular_patient():
         )
 
     assert resp.status_code == 200
+
+
+# ===========================================================================
+# initial_questionnaire_enabled toggle via patient profile PUT
+# ===========================================================================
+
+
+def test_patient_profile_put_enables_initial_questionnaire():
+    """
+    A therapist can enable the initial questionnaire for a patient by sending
+    ``initial_questionnaire_enabled: true`` via the patient profile PUT.
+    The value must be persisted to the Patient document.
+    """
+    user, patient = create_patient()
+    assert patient.initial_questionnaire_enabled is False  # default
+
+    resp = client.put(
+        f"/api/users/{str(user.id)}/profile/",
+        data=json.dumps({"initial_questionnaire_enabled": True}),
+        content_type="application/json",
+        HTTP_AUTHORIZATION="Bearer test",
+    )
+    assert resp.status_code == 200
+
+    refreshed = Patient.objects.get(pk=patient.id)
+    assert refreshed.initial_questionnaire_enabled is True
+
+
+def test_patient_profile_put_disables_initial_questionnaire():
+    """
+    A therapist can disable the initial questionnaire for a patient by sending
+    ``initial_questionnaire_enabled: false``.  Setting a boolean to ``False``
+    must not be dropped by the update logic.
+    """
+    user, patient = create_patient()
+    patient.initial_questionnaire_enabled = True
+    patient.save()
+
+    resp = client.put(
+        f"/api/users/{str(user.id)}/profile/",
+        data=json.dumps({"initial_questionnaire_enabled": False}),
+        content_type="application/json",
+        HTTP_AUTHORIZATION="Bearer test",
+    )
+    assert resp.status_code == 200
+
+    refreshed = Patient.objects.get(pk=patient.id)
+    assert refreshed.initial_questionnaire_enabled is False

--- a/docs/09-API_DOCUMENTATION.md
+++ b/docs/09-API_DOCUMENTATION.md
@@ -78,7 +78,11 @@ JWT refresh endpoint:
 - `POST /api/patients/feedback/questionaire/` -> `patient_views.submit_patient_feedback`
 - `GET /api/patients/get-questions/<questionaire_type>/<patient_id>/` -> `patient_views.get_feedback_questions`
 - `GET /api/patients/get-questions/<questionaire_type>/<patient_id>/<intervention_id>/` -> `patient_views.get_feedback_questions`
+- `GET /api/users/<patient_id>/initial-questionaire/` -> `patient_views.initial_patient_questionaire`
+  - Returns `{ requires_questionnaire: true|false }`. Returns `false` immediately when `Patient.initial_questionnaire_enabled` is `False` (default). When `True`, returns `true` only if any of the five demographic fields are still empty.
 - `POST /api/users/<patient_id>/initial-questionaire/` -> `patient_views.initial_patient_questionaire`
+  - Saves the five demographic fields (`level_of_education`, `professional_status`, `marital_status`, `lifestyle`, `personal_goals`).
+- **`initial_questionnaire_enabled` flag**: Defaults to `False` (opt-in). Set via `POST /api/auth/register/` (`initialQuestionnaireEnabled` field) or toggled at any time via `PUT /api/users/<patient_id>/profile/` (`initial_questionnaire_enabled` field).
 - `GET /api/patients/healthstatus-history/<patient_id>/` -> `patient_views.get_patient_healthstatus_history`
 - `GET /api/patients/health-combined-history/<patient_id>/` -> `patient_views.get_combined_health_data` (effective mapping)
 - `POST /api/patients/vitals/manual/<patient_id>/` -> `patient_views.add_manual_vitals`

--- a/frontend/src/components/AddPatient/RegisterPatientForm.tsx
+++ b/frontend/src/components/AddPatient/RegisterPatientForm.tsx
@@ -30,6 +30,7 @@ const initialFormData = (therapist: string): FormData => ({
   email: '',
   password: '',
   repeatPassword: '',
+  initialQuestionnaireEnabled: false,
   userType: 'Patient',
   patient_code: '',
   therapist,
@@ -372,6 +373,16 @@ const FormRegisterPatient: React.FC<RegisterFormProps> = ({ therapist }) => {
                   </option>
                 ))}
               </Form.Control>
+            ) : field.type === 'checkbox' ? (
+              <Form.Check
+                type="checkbox"
+                id={field.name}
+                label=""
+                checked={!!formData[field.name]}
+                onChange={(e) =>
+                  setFormData((prev) => ({ ...prev, [field.name]: e.target.checked }))
+                }
+              />
             ) : (
               <Form.Control
                 type={inputType}

--- a/frontend/src/components/TherapistPatientPage/PatientPopup.tsx
+++ b/frontend/src/components/TherapistPatientPage/PatientPopup.tsx
@@ -158,6 +158,21 @@ const PatientPopup: React.FC<PatientPopupProps> = observer(({ patient_id, show, 
       );
     }
 
+    if (field.type === 'checkbox') {
+      const checked = store.isEditing ? !!store.formData[key] : !!store.getDisplayValue(key);
+      return (
+        <Form.Check
+          type="checkbox"
+          id={key}
+          label=""
+          checked={checked}
+          onChange={(e) => store.setField(key, e.target.checked)}
+          disabled={isDisabled}
+          aria-label={t(field.label)}
+        />
+      );
+    }
+
     const commonMaxLength = field.type === 'text' || !field.type ? 500 : undefined;
     const v = store.isEditing ? manualValue || '' : displayValue || '';
 

--- a/frontend/src/config/config.json
+++ b/frontend/src/config/config.json
@@ -230,7 +230,14 @@
           "required": true,
           "be_name": "password"
         },
-        { "name": "repeatPassword", "label": "Confirm Password", "type": "text", "required": true }
+        { "name": "repeatPassword", "label": "Confirm Password", "type": "text", "required": true },
+        {
+          "name": "initialQuestionnaireEnabled",
+          "label": "Enable Initial Questionnaire",
+          "type": "checkbox",
+          "required": false,
+          "be_name": "initial_questionnaire_enabled"
+        }
       ]
     },
     {


### PR DESCRIPTION
### PR: Initial Questionnaire Enable/Disable Toggle
### Summary

- Add an initial_questionnaire_enabled flag to the Patient model (default: False)
- When the flag is False, the questionnaire endpoint immediately returns requires_questionnaire: false — patients are never prompted
- Therapists can enable the questionnaire at patient creation (checkbox in the registration form) or toggle it later via the patient profile modal
- Includes backend tests and API documentation updates

### Changes
Backend — Model

- core/models.py: Added initial_questionnaire_enabled = BooleanField(default=False) to Patient

Backend — Views

- core/views/patient_views.py: Short-circuit in initial_patient_questionaire GET handler — if patient.initial_questionnaire_enabled is False, return {"requires_questionnaire": false} immediately, skipping all field-completeness checks
- core/views/user_views.py: Added initial_questionnaire_enabled to PATIENT_ALLOWED_PATIENT whitelist; handled explicitly outside the generic valid_update_value loop (which would silently drop a False value)
- core/views/auth_views.py: Reads initialQuestionnaireEnabled from the registration payload and saves it on the Patient document

Frontend

- config/config.json: Added a checkbox field (initialQuestionnaireEnabled) to step 0 of PatientForm
- AddPatient/RegisterPatientForm.tsx: Added checkbox rendering branch and initialQuestionnaireEnabled: false to initialFormData
- TherapistPatientPage/PatientPopup.tsx: Added checkbox rendering in renderField for the profile edit modal

Tests

- tests/patient_views/test_initial_questionnaire.py: 2 new tests
- test_get_questionnaire_disabled_returns_not_required — flag False + empty demographics → requires_questionnaire: false
- test_get_questionnaire_enabled_still_checks_fields — flag True + empty demographics → requires_questionnaire: true
- Updated existing test_get_requires_questionnaire to set initial_questionnaire_enabled = True (was relying on the old default)
- tests/user_views/test_user_views.py: 2 new tests
- test_patient_profile_put_enables_initial_questionnaire — PUT true persists to DB
- test_patient_profile_put_disables_initial_questionnaire — PUT false persists to DB (explicit coverage for the valid_update_value edge case)
- tests/auth_views/test_register_view.py: 1 new test
- test_register_patient_initial_questionnaire_enabled_persisted — registration with initialQuestionnaireEnabled: true creates a Patient document with initial_questionnaire_enabled = True

Documentation

- docs/09-API_DOCUMENTATION.md: Documented initial_questionnaire_enabled flag behaviour, both mutation paths (registration payload and profile PUT), and added the missing GET route for the questionnaire endpoint
- Test plan
-  docker exec django pytest tests/patient_views/test_initial_questionnaire.py -v
-  docker exec django pytest tests/user_views/test_user_views.py -v
-  docker exec django pytest tests/auth_views/test_register_view.py -v
-  Create a patient with the toggle off → log in as that patient → confirm no questionnaire modal appears
-  Create a patient with the toggle on → log in → confirm questionnaire modal appears as normal
-  Open an existing patient profile → toggle the flag → save → verify the change persists after re-opening the modal