### PR TITLE
Content importing & manual upload improvements

### DIFF
--- a/backend/core/models.py
+++ b/backend/core/models.py
@@ -280,7 +280,7 @@ class Intervention(Document):
     input_from = StringField(required=False, null=True)
     lc9 = ListField(StringField(), default=list)
     original_language = StringField(required=False, null=True)
-    primary_diagnosis = StringField(required=False, null=True)
+    primary_diagnosis = ListField(StringField(), default=list)
     aim = StringField(required=False, null=True)
     topic = ListField(StringField(), default=list)
     cognitive_level = StringField(required=False, null=True)

--- a/backend/core/views/intervention_import.py
+++ b/backend/core/views/intervention_import.py
@@ -170,35 +170,125 @@ def _parse_duration_minutes(s: str) -> Optional[int]:
     return None
 
 
+# Valid language and format-code sets for the ICF intervention ID scheme.
+# ID format:
+#   4-digit prefix = original content  e.g. 3500_web_de
+#   5-digit prefix = self-made content e.g. 30500_vid_pt
+VALID_LANGS = {"de", "fr", "it", "pt", "nl", "en"}
+VALID_FORMAT_CODES = {"vid", "img", "pdf", "web", "aud", "app", "br", "gfx"}
+
+_FORMAT_CODE_TO_CONTENT_TYPE: Dict[str, str] = {
+    "vid": "Video",
+    "aud": "Audio",
+    "img": "Image",
+    "gfx": "Image",
+    "pdf": "Text",
+    "br":  "Text",
+    "web": "Website",
+    "app": "App",
+}
+
+
 def _map_content_type(x: str) -> str:
     s = _norm(x).lower()
     if not s:
         return "Text"
-    if "video" in s:
+    # Accept format-code abbreviations directly
+    if s in _FORMAT_CODE_TO_CONTENT_TYPE:
+        return _FORMAT_CODE_TO_CONTENT_TYPE[s]
+    if "video" in s or "vid" in s:
         return "Video"
     if "audio" in s or "podcast" in s or "sound" in s:
         return "Audio"
-    if "image" in s or "picture" in s:
+    if "image" in s or "picture" in s or "graphic" in s or "gfx" in s:
         return "Image"
     if "app" in s:
         return "App"
-    if "web" in s or "site" in s or "link" in s or "website" in s:
+    if "web" in s or "site" in s or "website" in s:
         return "Website"
     if "pdf" in s or "text" in s or "brochure" in s:
         return "Text"
     return "Text"
 
 
-def _parse_external_id_and_language(intervention_id: str) -> Tuple[str, Optional[str]]:
+def _parse_external_id_and_language(
+    intervention_id: str,
+) -> Tuple[str, Optional[str], Optional[str]]:
     """
-    Excel uses e.g. '4001_de', '4001_it'. We want:
-      external_id='4001', language='de'
+    Parse an intervention ID into (external_id, language, format_code).
+
+    New 3-part format (preferred):
+      '3500_web_de'  → external_id='3500_web', language='de', format_code='web'
+      '30500_vid_pt' → external_id='30500_vid', language='pt', format_code='vid'
+
+      - 4-digit numeric prefix = original content
+      - 5-digit numeric prefix = self-made content
+
+    Legacy 2-part format (still accepted for backward compatibility):
+      '4001_de'      → external_id='4001', language='de', format_code=None
+
+    Returns (external_id, language_or_None, format_code_or_None).
     """
-    s = _norm(intervention_id)
-    m = re.match(r"^(.+?)_([a-z]{2})$", s.lower())
+    s = _norm(intervention_id).lower()
+    parts = s.split("_")
+
+    # Try new 3-part format: {num}_{fmt}_{lang}
+    if len(parts) >= 3:
+        lang_candidate = parts[-1]
+        fmt_candidate = parts[-2]
+        if lang_candidate in VALID_LANGS:
+            external_id = "_".join(parts[:-1])
+            fmt = fmt_candidate if fmt_candidate in VALID_FORMAT_CODES else None
+            return external_id, lang_candidate, fmt
+
+    # Fall back to legacy 2-part format: {anything}_{lang}
+    m = re.match(r"^(.+?)_([a-z]{2})$", s)
     if m:
-        return m.group(1), m.group(2)
-    return s, None
+        return m.group(1), m.group(2), None
+
+    return s, None, None
+
+
+def _validate_id_format(intervention_id: str) -> List[str]:
+    """
+    Return a list of human-readable warning strings for a non-conforming ID.
+    Returns an empty list when the ID is fully valid.
+    """
+    warnings: List[str] = []
+    s = _norm(intervention_id).lower()
+    parts = s.split("_")
+
+    if len(parts) >= 3:
+        num_part = "_".join(parts[:-2])
+        fmt_part = parts[-2]
+        lang_part = parts[-1]
+        if not re.match(r"^\d{4,5}$", num_part):
+            warnings.append(
+                f"Prefix '{num_part}' should be 4 digits (original content) "
+                f"or 5 digits (self-made content)."
+            )
+        if fmt_part not in VALID_FORMAT_CODES:
+            valid_list = ", ".join(sorted(VALID_FORMAT_CODES))
+            warnings.append(
+                f"Unknown format code '{fmt_part}'. "
+                f"Valid codes: {valid_list} "
+                f"(vid=video, img/gfx=image, pdf/br=document, web=website, aud=audio, app=app)."
+            )
+        if lang_part not in VALID_LANGS:
+            valid_list = ", ".join(sorted(VALID_LANGS))
+            warnings.append(
+                f"Unknown language suffix '{lang_part}'. Valid: {valid_list}."
+            )
+    elif len(parts) == 2:
+        # Legacy 2-part format — accepted, no warnings
+        pass
+    else:
+        warnings.append(
+            f"Unexpected ID format '{intervention_id}'. "
+            "Expected: {{4-5 digits}}_{{format}}_{{lang}} (e.g. 3500_web_de) "
+            "or {{4-5 digits}}_{{lang}} (e.g. 4001_de)."
+        )
+    return warnings
 
 
 def _normalize_lang(raw: Any) -> Optional[str]:
@@ -213,6 +303,10 @@ def _normalize_lang(raw: Any) -> Optional[str]:
         return "fr"
     if s in ("it", "ita", "italian", "italiano"):
         return "it"
+    if s in ("pt", "por", "portuguese", "português", "portugues"):
+        return "pt"
+    if s in ("nl", "nld", "dutch", "nederlands"):
+        return "nl"
     return None
 
 
@@ -465,7 +559,10 @@ def import_interventions_from_excel(
             continue
 
         try:
-            external_id, lang_from_id = _parse_external_id_and_language(intervention_id_raw)
+            external_id, lang_from_id, format_code = _parse_external_id_and_language(intervention_id_raw)
+
+            # Collect non-fatal format warnings (still import the row)
+            id_warnings = _validate_id_format(intervention_id_raw)
 
             lang_from_col = _normalize_lang(row[col["language"]]) if col.get("language") is not None else None
             language = (lang_from_id or lang_from_col or default_lang).lower()
@@ -485,7 +582,14 @@ def import_interventions_from_excel(
             content_type_raw = _norm(row[col["content_type"]])
             duration_raw = _norm(row[col["duration"]]) if col.get("duration") is not None else ""
 
-            mapped_ct = _map_content_type(content_type_raw)
+            # Prefer explicit content_type column; fall back to format_code from ID
+            if content_type_raw:
+                mapped_ct = _map_content_type(content_type_raw)
+            elif format_code and format_code in _FORMAT_CODE_TO_CONTENT_TYPE:
+                mapped_ct = _FORMAT_CODE_TO_CONTENT_TYPE[format_code]
+            else:
+                mapped_ct = "Text"
+
             duration_min = _parse_duration_minutes(duration_raw)
 
             # Lists (store as fields)
@@ -597,19 +701,36 @@ def import_interventions_from_excel(
             else:
                 created += 1
 
+            # Append non-fatal ID format warnings (row was still imported)
+            if id_warnings:
+                errors.append(
+                    {
+                        "row": row_idx,
+                        "intervention_id": intervention_id_raw,
+                        "severity": "warning",
+                        "error": " ".join(id_warnings),
+                    }
+                )
+
         except Exception as e:
             errors.append(
                 {
                     "row": row_idx,
                     "intervention_id": intervention_id_raw,
+                    "severity": "error",
                     "error": str(e),
                 }
             )
             skipped += 1
+
+    warnings_count = sum(1 for e in errors if e.get("severity") == "warning")
+    errors_count = sum(1 for e in errors if e.get("severity") != "warning")
 
     return {
         "created": created,
         "updated": updated,
         "skipped": skipped,
         "errors": errors,
+        "warnings": warnings_count,
+        "errors_count": errors_count,
     }

--- a/backend/core/views/intervention_import.py
+++ b/backend/core/views/intervention_import.py
@@ -183,7 +183,7 @@ _FORMAT_CODE_TO_CONTENT_TYPE: Dict[str, str] = {
     "img": "Image",
     "gfx": "Image",
     "pdf": "Text",
-    "br":  "Text",
+    "br": "Text",
     "web": "Website",
     "app": "App",
 }
@@ -264,8 +264,7 @@ def _validate_id_format(intervention_id: str) -> List[str]:
         lang_part = parts[-1]
         if not re.match(r"^\d{4,5}$", num_part):
             warnings.append(
-                f"Prefix '{num_part}' should be 4 digits (original content) "
-                f"or 5 digits (self-made content)."
+                f"Prefix '{num_part}' should be 4 digits (original content) " f"or 5 digits (self-made content)."
             )
         if fmt_part not in VALID_FORMAT_CODES:
             valid_list = ", ".join(sorted(VALID_FORMAT_CODES))
@@ -276,9 +275,7 @@ def _validate_id_format(intervention_id: str) -> List[str]:
             )
         if lang_part not in VALID_LANGS:
             valid_list = ", ".join(sorted(VALID_LANGS))
-            warnings.append(
-                f"Unknown language suffix '{lang_part}'. Valid: {valid_list}."
-            )
+            warnings.append(f"Unknown language suffix '{lang_part}'. Valid: {valid_list}.")
     elif len(parts) == 2:
         # Legacy 2-part format — accepted, no warnings
         pass

--- a/backend/core/views/recomendation_views.py
+++ b/backend/core/views/recomendation_views.py
@@ -494,7 +494,7 @@ def add_new_intervention(request):
         input_from = _first_str_from_any(taxonomy.get("input_from") or taxonomy.get("inputFrom"))
         lc9_list = _list_of_str(taxonomy.get("lc9"))
         original_language = _first_str_from_any(taxonomy.get("original_language") or taxonomy.get("originalLanguage"))
-        primary_diagnosis = _first_str_from_any(taxonomy.get("primary_diagnosis") or taxonomy.get("primaryDiagnosis"))
+        primary_diagnosis = _list_of_str(taxonomy.get("primary_diagnosis") or taxonomy.get("primaryDiagnosis"))
 
         # Aim is StringField in DB: choose first
         aim_from_tax = _first_str_from_any(taxonomy.get("aim") or taxonomy.get("aims"))

--- a/backend/tests/intervention_import_views/test_intervention_import_view.py
+++ b/backend/tests/intervention_import_views/test_intervention_import_view.py
@@ -23,6 +23,7 @@ from core.views.intervention_import import (
     _parse_int,
     _split_list,
     _spotify_embed,
+    _validate_id_format,
     _youtube_embed,
     import_interventions_from_excel,
 )
@@ -50,8 +51,18 @@ def mongo_mock():
 
 
 def test_helper_parsers():
-    assert _parse_external_id_and_language("4001_de") == ("4001", "de")
+    # Legacy 2-part format
+    assert _parse_external_id_and_language("4001_de") == ("4001", "de", None)
+    # New 3-part format: {number}_{format}_{lang}
+    assert _parse_external_id_and_language("3500_web_de") == ("3500_web", "de", "web")
+    assert _parse_external_id_and_language("30500_vid_pt") == ("30500_vid", "pt", "vid")
+    assert _parse_external_id_and_language("3500_br_it") == ("3500_br", "it", "br")
+    # Unknown format code → format_code is None, but external_id still correct
+    assert _parse_external_id_and_language("3500_xyz_de") == ("3500_xyz", "de", None)
     assert _map_content_type("video") == "Video"
+    assert _map_content_type("vid") == "Video"
+    assert _map_content_type("br") == "Text"
+    assert _map_content_type("gfx") == "Image"
     assert _parse_duration_minutes("10-20") == 15
     assert _split_list("a, b; a") == ["a", "b"]
 
@@ -65,6 +76,9 @@ def test_helper_bool_int_lang_provider_and_media():
 
     assert _normalize_lang("german") == "de"
     assert _normalize_lang("italiano") == "it"
+    assert _normalize_lang("português") == "pt"
+    assert _normalize_lang("nl") == "nl"
+    assert _normalize_lang("dutch") == "nl"
     assert _normalize_lang("unknown") is None
 
     assert _guess_provider("https://open.spotify.com/track/abc") == "spotify"
@@ -84,6 +98,24 @@ def test_helper_bool_int_lang_provider_and_media():
     assert _guess_file_media_type("image.png", "text") == "image"
     assert _is_raw_file_name("file.pdf") is True
     assert _is_raw_file_name("https://example.com/file.pdf") is False
+
+
+def test_validate_id_format():
+    # Valid new 3-part IDs produce no warnings
+    assert _validate_id_format("3500_web_de") == []
+    assert _validate_id_format("30500_vid_pt") == []
+    assert _validate_id_format("3500_br_it") == []
+    # Legacy 2-part ID — no warnings (backward compat)
+    assert _validate_id_format("4001_de") == []
+    # Unknown format code
+    msgs = _validate_id_format("3500_xyz_de")
+    assert any("xyz" in m for m in msgs)
+    # Invalid prefix length
+    msgs = _validate_id_format("350_web_de")
+    assert any("350" in m for m in msgs)
+    # Unknown language
+    msgs = _validate_id_format("3500_web_xx")
+    assert any("xx" in m for m in msgs)
 
 
 def test_more_helper_branches_for_import_module():

--- a/backend/tests/interventions_views/test_interventions_views.py
+++ b/backend/tests/interventions_views/test_interventions_views.py
@@ -355,6 +355,139 @@ def test_add_new_intervention_get_method_not_allowed(mongo_mock):
     assert resp.status_code == 405
 
 
+_MEDIA_URL = json.dumps([{"kind": "external", "media_type": "video", "url": "https://example.com/v"}])
+_MEDIA_WEB = json.dumps([{"kind": "external", "media_type": "website", "url": "https://example.com"}])
+
+
+def test_add_new_intervention_language_pt(mongo_mock):
+    """
+    Language 'pt' (Portuguese) is accepted and stored.
+    Regression test: PT was missing from the frontend dropdown and must
+    round-trip correctly through the API.
+    """
+    payload = {
+        "title": "Yoga em Português",
+        "description": "Sessão de yoga",
+        "contentType": "video",
+        "duration": "30",
+        "language": "pt",
+        "media": _MEDIA_URL,
+    }
+    resp = client.post("/api/interventions/add/", data=payload, HTTP_AUTHORIZATION="Bearer test")
+    assert resp.status_code == 200, resp.content.decode()
+    assert resp.json()["success"] is True
+    iv = Intervention.objects(language="pt").first()
+    assert iv is not None
+    assert iv.language == "pt"
+
+
+def test_add_new_intervention_language_nl(mongo_mock):
+    """
+    Language 'nl' (Dutch) is accepted and stored.
+    Regression test: NL was missing from the frontend dropdown and must
+    round-trip correctly through the API.
+    """
+    payload = {
+        "title": "Yoga in het Nederlands",
+        "description": "Yoga sessie",
+        "contentType": "video",
+        "duration": "30",
+        "language": "nl",
+        "media": _MEDIA_URL,
+    }
+    resp = client.post("/api/interventions/add/", data=payload, HTTP_AUTHORIZATION="Bearer test")
+    assert resp.status_code == 200, resp.content.decode()
+    assert resp.json()["success"] is True
+    iv = Intervention.objects(language="nl").first()
+    assert iv is not None
+    assert iv.language == "nl"
+
+
+def test_add_new_intervention_new_format_external_id(mongo_mock):
+    """
+    External ID in the new {4-digit}_{format} format (e.g. '3500_web') is
+    stored as-is; language is provided separately.
+    """
+    payload = {
+        "title": "Web Intervention",
+        "description": "A web-based intervention",
+        "contentType": "website",
+        "duration": "15",
+        "external_id": "3500_web",
+        "language": "de",
+        "media": _MEDIA_WEB,
+    }
+    resp = client.post("/api/interventions/add/", data=payload, HTTP_AUTHORIZATION="Bearer test")
+    assert resp.status_code == 200, resp.content.decode()
+    iv = Intervention.objects(external_id="3500_web", language="de").first()
+    assert iv is not None
+    assert iv.external_id == "3500_web"
+    assert iv.language == "de"
+
+
+def test_add_new_intervention_self_made_external_id(mongo_mock):
+    """
+    External ID with 5-digit prefix (self-made content, e.g. '30500_vid')
+    is accepted with any supported language including 'pt'.
+    """
+    payload = {
+        "title": "Custom Video",
+        "description": "A self-made video",
+        "contentType": "video",
+        "duration": "20",
+        "external_id": "30500_vid",
+        "language": "pt",
+        "media": _MEDIA_URL,
+    }
+    resp = client.post("/api/interventions/add/", data=payload, HTTP_AUTHORIZATION="Bearer test")
+    assert resp.status_code == 200, resp.content.decode()
+    iv = Intervention.objects(external_id="30500_vid", language="pt").first()
+    assert iv is not None
+    assert iv.external_id == "30500_vid"
+
+
+def test_add_new_intervention_primary_diagnosis_stored_as_list(mongo_mock):
+    """
+    primary_diagnosis sent as a JSON array in the taxonomy field is stored
+    as a list in MongoDB (ListField), not collapsed to a string.
+    """
+    payload = {
+        "title": "Multi-diagnosis intervention",
+        "description": "Applies to several diagnoses",
+        "contentType": "video",
+        "duration": "30",
+        "media": _MEDIA_URL,
+        "taxonomy": json.dumps({"primary_diagnosis": ["Stroke", "Arrhythmia"]}),
+    }
+    resp = client.post("/api/interventions/add/", data=payload, HTTP_AUTHORIZATION="Bearer test")
+    assert resp.status_code == 200, resp.content.decode()
+    iv = Intervention.objects(title="Multi-diagnosis intervention").first()
+    assert iv is not None
+    assert isinstance(iv.primary_diagnosis, list)
+    assert "Stroke" in iv.primary_diagnosis
+    assert "Arrhythmia" in iv.primary_diagnosis
+
+
+def test_add_new_intervention_primary_diagnosis_single_string_still_works(mongo_mock):
+    """
+    primary_diagnosis sent as a single string (legacy) is coerced to a list.
+    """
+    payload = {
+        "title": "Single diagnosis",
+        "description": "One diagnosis",
+        "contentType": "video",
+        "duration": "30",
+        "media": _MEDIA_URL,
+        "taxonomy": json.dumps({"primary_diagnosis": "Stroke"}),
+    }
+    resp = client.post("/api/interventions/add/", data=payload, HTTP_AUTHORIZATION="Bearer test")
+    assert resp.status_code == 200, resp.content.decode()
+    iv = Intervention.objects(title="Single diagnosis").first()
+    assert iv is not None
+    assert isinstance(iv.primary_diagnosis, list)
+    assert "Stroke" in iv.primary_diagnosis
+
+
 # ===========================================================================
 # get_intervention_detail  —  GET /api/interventions/<id>/
 # ===========================================================================

--- a/frontend/src/__tests__/components/AddIntervention/AddRecomendationPopUp.test.tsx
+++ b/frontend/src/__tests__/components/AddIntervention/AddRecomendationPopUp.test.tsx
@@ -1,0 +1,117 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (k: string) => k }),
+}));
+
+jest.mock('@/api/client', () => require('@/__mocks__/api/client'));
+
+jest.mock('@/stores/authStore', () => ({
+  __esModule: true,
+  default: {
+    checkAuthentication: jest.fn(),
+    isAuthenticated: true,
+    userType: 'Therapist',
+    specialisations: 'Cardiology',
+  },
+}));
+
+jest.mock('@/stores/interventionsTaxonomyStore', () => ({
+  __esModule: true,
+  default: {
+    fetchAll: jest.fn(),
+    toOptions: (vals: string[]) => (vals || []).map((v: string) => ({ value: v, label: v })),
+    originalLanguages: [],
+    lc9: [],
+    topics: [],
+    aims: [],
+    where: [],
+    setting: [],
+    cognitiveLevels: [],
+    physicalLevels: [],
+    frequencyTime: [],
+    timing: [],
+    durationBuckets: [],
+    sexSpecific: [],
+    inputFrom: [],
+    contentTypes: ['Video', 'Audio', 'Website', 'Text', 'Image', 'App', 'Streaming'],
+    primaryDiagnoses: [],
+  },
+}));
+
+jest.mock('@/config/config.json', () => ({
+  RecomendationInfo: { types: ['video', 'audio'] },
+  patientInfo: {
+    function: {
+      Cardiology: { diagnosis: ['Coronary Artery Disease', 'Arrhythmia'] },
+    },
+  },
+}));
+
+// Render StandardModal body inline to expose form fields
+jest.mock('@/components/common/StandardModal', () => ({
+  __esModule: true,
+  default: ({ children, show }: any) => (show ? <div>{children}</div> : null),
+}));
+
+// react-select is complex — stub to a plain native select
+jest.mock('react-select', () => ({
+  __esModule: true,
+  default: ({ options, value, onChange, inputId }: any) => (
+    <select
+      id={inputId}
+      value={value?.value ?? ''}
+      onChange={(e) => onChange(options.find((o: any) => o.value === e.target.value))}
+    >
+      {(options || []).map((o: any) => (
+        <option key={o.value} value={o.value}>{o.label}</option>
+      ))}
+    </select>
+  ),
+}));
+
+import AddRecomendationPopUp from '@/components/AddIntervention/AddRecomendationPopUp';
+
+describe('AddRecomendationPopUp', () => {
+  const renderPopup = () =>
+    render(
+      <AddRecomendationPopUp show handleClose={jest.fn()} onSuccess={jest.fn()} />
+    );
+
+  describe('Language dropdown', () => {
+    it('contains all 6 supported languages including PT and NL', () => {
+      renderPopup();
+      // The form has both "Language" and "Original language" selects; use the one with id="language"
+      const select = document.getElementById('language') as HTMLSelectElement;
+      expect(select).not.toBeNull();
+      const values = Array.from(select.options).map((o) => o.value);
+      expect(values).toContain('de');
+      expect(values).toContain('en');
+      expect(values).toContain('fr');
+      expect(values).toContain('it');
+      expect(values).toContain('pt');
+      expect(values).toContain('nl');
+    });
+
+    it('defaults to English', () => {
+      renderPopup();
+      const select = document.getElementById('language') as HTMLSelectElement;
+      expect(select.value).toBe('en');
+    });
+  });
+
+  describe('External ID field', () => {
+    it('renders with the new format placeholder', () => {
+      renderPopup();
+      const input = screen.getByPlaceholderText(/3500_web/i);
+      expect(input).toBeInTheDocument();
+    });
+
+    it('shows hint text with valid format codes', () => {
+      renderPopup();
+      expect(screen.getByText(/vid.*img.*gfx.*pdf.*br.*web.*aud.*app/i)).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/__tests__/components/AddIntervention/AddRecomendationPopUp.test.tsx
+++ b/frontend/src/__tests__/components/AddIntervention/AddRecomendationPopUp.test.tsx
@@ -66,7 +66,9 @@ jest.mock('react-select', () => ({
       onChange={(e) => onChange(options.find((o: any) => o.value === e.target.value))}
     >
       {(options || []).map((o: any) => (
-        <option key={o.value} value={o.value}>{o.label}</option>
+        <option key={o.value} value={o.value}>
+          {o.label}
+        </option>
       ))}
     </select>
   ),
@@ -76,9 +78,7 @@ import AddRecomendationPopUp from '@/components/AddIntervention/AddRecomendation
 
 describe('AddRecomendationPopUp', () => {
   const renderPopup = () =>
-    render(
-      <AddRecomendationPopUp show handleClose={jest.fn()} onSuccess={jest.fn()} />
-    );
+    render(<AddRecomendationPopUp show handleClose={jest.fn()} onSuccess={jest.fn()} />);
 
   describe('Language dropdown', () => {
     it('contains all 6 supported languages including PT and NL', () => {

--- a/frontend/src/__tests__/pages/AddInterventionView.test.tsx
+++ b/frontend/src/__tests__/pages/AddInterventionView.test.tsx
@@ -1,0 +1,140 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import '@testing-library/jest-dom';
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (k: string) => k }),
+}));
+
+jest.mock('@/api/client', () => require('@/__mocks__/api/client'));
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => jest.fn(),
+}));
+
+jest.mock('@/stores/authStore', () => ({
+  __esModule: true,
+  default: {
+    checkAuthentication: jest.fn(),
+    isAuthenticated: true,
+    userType: 'Therapist',
+    specialisations: 'Cardiology',
+  },
+}));
+
+jest.mock('../../config/config.json', () => ({
+  RecomendationInfo: { types: ['video', 'audio', 'website'] },
+  patientInfo: {
+    function: {
+      Cardiology: { diagnosis: ['Coronary Artery Disease', 'Arrhythmia', 'Stroke'] },
+    },
+  },
+}));
+
+jest.mock('@/components/common/Header', () => () => <div>Header</div>);
+jest.mock('@/components/common/Footer', () => () => <div>Footer</div>);
+
+import AddInterventionView from '@/pages/AddInterventionView';
+
+const renderPage = () =>
+  render(
+    <MemoryRouter>
+      <AddInterventionView />
+    </MemoryRouter>
+  );
+
+describe('AddInterventionView', () => {
+  describe('Language field', () => {
+    it('renders all 6 languages including PT and NL', () => {
+      renderPage();
+      const select = screen.getByRole('combobox', { name: /language/i }) as HTMLSelectElement;
+      const values = Array.from(select.options).map((o) => o.value);
+      expect(values).toContain('de');
+      expect(values).toContain('en');
+      expect(values).toContain('fr');
+      expect(values).toContain('it');
+      expect(values).toContain('pt');
+      expect(values).toContain('nl');
+    });
+
+    it('defaults to empty (no language pre-selected)', () => {
+      renderPage();
+      const select = screen.getByRole('combobox', { name: /language/i }) as HTMLSelectElement;
+      expect(select.value).toBe('');
+    });
+  });
+
+  describe('External ID field', () => {
+    it('renders the ID input with the new format placeholder', () => {
+      renderPage();
+      const input = screen.getByPlaceholderText('3500_web');
+      expect(input).toBeInTheDocument();
+    });
+
+    it('shows format hint text with valid codes', () => {
+      renderPage();
+      expect(screen.getByText(/vid.*img.*gfx.*pdf.*br.*web.*aud.*app/i)).toBeInTheDocument();
+    });
+
+    it('shows inline error for an ID with wrong prefix length', () => {
+      renderPage();
+      const input = screen.getByPlaceholderText('3500_web');
+      fireEvent.change(input, { target: { value: '35_web' } });
+      expect(screen.getByText(/4 digits.*5 digits/i)).toBeInTheDocument();
+    });
+
+    it('shows inline error for an unknown format code', () => {
+      renderPage();
+      const input = screen.getByPlaceholderText('3500_web');
+      fireEvent.change(input, { target: { value: '3500_xyz' } });
+      expect(screen.getByText(/Unknown format code/i)).toBeInTheDocument();
+    });
+
+    it('shows no error for a valid 4-digit + format ID', () => {
+      renderPage();
+      const input = screen.getByPlaceholderText('3500_web');
+      fireEvent.change(input, { target: { value: '3500_web' } });
+      expect(screen.queryByText(/Unknown format code/i)).not.toBeInTheDocument();
+      expect(screen.queryByText(/4 digits.*5 digits/i)).not.toBeInTheDocument();
+    });
+
+    it('shows no error for a valid 5-digit + format ID', () => {
+      renderPage();
+      const input = screen.getByPlaceholderText('3500_web');
+      fireEvent.change(input, { target: { value: '30500_vid' } });
+      expect(screen.queryByText(/Unknown format code/i)).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Primary Diagnosis checkboxes', () => {
+    it('renders a checkbox for each diagnosis from config', () => {
+      renderPage();
+      expect(screen.getByLabelText('Coronary Artery Disease')).toBeInTheDocument();
+      expect(screen.getByLabelText('Arrhythmia')).toBeInTheDocument();
+      expect(screen.getByLabelText('Stroke')).toBeInTheDocument();
+    });
+
+    it('allows selecting multiple diagnoses independently', () => {
+      renderPage();
+      const stroke = screen.getByLabelText('Stroke') as HTMLInputElement;
+      const arrhythmia = screen.getByLabelText('Arrhythmia') as HTMLInputElement;
+
+      fireEvent.click(stroke);
+      fireEvent.click(arrhythmia);
+
+      expect(stroke.checked).toBe(true);
+      expect(arrhythmia.checked).toBe(true);
+    });
+
+    it('unchecks a diagnosis when clicked again', () => {
+      renderPage();
+      const stroke = screen.getByLabelText('Stroke') as HTMLInputElement;
+      fireEvent.click(stroke);
+      expect(stroke.checked).toBe(true);
+      fireEvent.click(stroke);
+      expect(stroke.checked).toBe(false);
+    });
+  });
+});

--- a/frontend/src/components/AddIntervention/AddRecomendationPopUp.tsx
+++ b/frontend/src/components/AddIntervention/AddRecomendationPopUp.tsx
@@ -156,10 +156,12 @@ const kindOptions = [
 ];
 
 const langOptions = [
-  { value: 'de', label: 'DE' },
-  { value: 'en', label: 'EN' },
-  { value: 'fr', label: 'FR' },
-  { value: 'it', label: 'IT' },
+  { value: 'de', label: 'DE — Deutsch' },
+  { value: 'en', label: 'EN — English' },
+  { value: 'fr', label: 'FR — Français' },
+  { value: 'it', label: 'IT — Italiano' },
+  { value: 'pt', label: 'PT — Português' },
+  { value: 'nl', label: 'NL — Nederlands' },
 ];
 
 const mediaTypeOptions: { value: MediaType; label: string }[] = [
@@ -775,8 +777,11 @@ const AddInterventionPopup: React.FC<AddInterventionPopupProps> = observer(
                       type="text"
                       value={formData.externalId}
                       onChange={handleChange}
-                      placeholder="e.g. 4001"
+                      placeholder="e.g. 3500_web or 30500_vid"
                     />
+                    <Form.Text className="text-muted">
+                      4 digits = original · 5 digits = self-made · format: vid, img, gfx, pdf, br, web, aud, app
+                    </Form.Text>
                   </Form.Group>
                 </Col>
 

--- a/frontend/src/components/AddIntervention/AddRecomendationPopUp.tsx
+++ b/frontend/src/components/AddIntervention/AddRecomendationPopUp.tsx
@@ -780,7 +780,8 @@ const AddInterventionPopup: React.FC<AddInterventionPopupProps> = observer(
                       placeholder="e.g. 3500_web or 30500_vid"
                     />
                     <Form.Text className="text-muted">
-                      4 digits = original · 5 digits = self-made · format: vid, img, gfx, pdf, br, web, aud, app
+                      4 digits = original · 5 digits = self-made · format: vid, img, gfx, pdf, br,
+                      web, aud, app
                     </Form.Text>
                   </Form.Group>
                 </Col>

--- a/frontend/src/components/TherapistInterventionPage/ImportInterventionsModal.tsx
+++ b/frontend/src/components/TherapistInterventionPage/ImportInterventionsModal.tsx
@@ -99,17 +99,19 @@ const ImportInterventionsModal: React.FC<Props> = observer(({ show, onHide, onSu
               disabled={interventionsImportStore.loading}
             />
             <div className="text-muted small mt-1">
-              {t('The file should contain the intervention sheet (default: Content).')}
-              {' '}
+              {t('The file should contain the intervention sheet (default: Content).')}{' '}
               <span className="text-muted">
-                {t('ID format')}{': '}
+                {t('ID format')}
+                {': '}
                 <code>3500_web_de</code> {t('(original)')} /&nbsp;
                 <code>30500_vid_pt</code> {t('(self-made)')}
                 {' — '}
-                {t('formats')}{': '}
+                {t('formats')}
+                {': '}
                 <code>vid, img, pdf, web, aud, app, br, gfx</code>
                 {' — '}
-                {t('languages')}{': '}
+                {t('languages')}
+                {': '}
                 <code>de, fr, it, pt, nl, en</code>
               </span>
             </div>
@@ -177,15 +179,23 @@ const ImportInterventionsModal: React.FC<Props> = observer(({ show, onHide, onSu
                   {t('Skipped')}: {r.skipped ?? 0}
                 </Badge>
                 {(() => {
-                  const errorsCount = r.errors_count ?? (r.errors || []).filter((e: any) => e.severity !== 'warning').length;
-                  const warningsCount = r.warnings ?? (r.errors || []).filter((e: any) => e.severity === 'warning').length;
+                  const errorsCount =
+                    r.errors_count ??
+                    (r.errors || []).filter((e: any) => e.severity !== 'warning').length;
+                  const warningsCount =
+                    r.warnings ??
+                    (r.errors || []).filter((e: any) => e.severity === 'warning').length;
                   return (
                     <>
                       {errorsCount > 0 && (
-                        <Badge bg="danger">{t('Errors')}: {errorsCount}</Badge>
+                        <Badge bg="danger">
+                          {t('Errors')}: {errorsCount}
+                        </Badge>
                       )}
                       {warningsCount > 0 && (
-                        <Badge bg="warning" text="dark">{t('Warnings')}: {warningsCount}</Badge>
+                        <Badge bg="warning" text="dark">
+                          {t('Warnings')}: {warningsCount}
+                        </Badge>
                       )}
                       {errorsCount === 0 && warningsCount === 0 && (
                         <Badge bg="success">{t('Errors')}: 0</Badge>
@@ -204,7 +214,10 @@ const ImportInterventionsModal: React.FC<Props> = observer(({ show, onHide, onSu
                       return (
                         <div key={idx} className="small mb-2">
                           <div className="d-flex align-items-center gap-2 flex-wrap">
-                            <Badge bg={isWarning ? 'warning' : 'danger'} text={isWarning ? 'dark' : undefined}>
+                            <Badge
+                              bg={isWarning ? 'warning' : 'danger'}
+                              text={isWarning ? 'dark' : undefined}
+                            >
                               {isWarning ? t('Warning') : t('Error')}
                             </Badge>
                             <span>
@@ -213,7 +226,9 @@ const ImportInterventionsModal: React.FC<Props> = observer(({ show, onHide, onSu
                               <code>{e.intervention_id ?? e.external_id ?? '-'}</code>
                             </span>
                           </div>
-                          <div className={`mt-1 ${isWarning ? 'text-warning-emphasis' : 'text-danger'}`}>
+                          <div
+                            className={`mt-1 ${isWarning ? 'text-warning-emphasis' : 'text-danger'}`}
+                          >
                             {e.error ?? '-'}
                           </div>
                           <hr className="my-2" />

--- a/frontend/src/components/TherapistInterventionPage/ImportInterventionsModal.tsx
+++ b/frontend/src/components/TherapistInterventionPage/ImportInterventionsModal.tsx
@@ -100,6 +100,18 @@ const ImportInterventionsModal: React.FC<Props> = observer(({ show, onHide, onSu
             />
             <div className="text-muted small mt-1">
               {t('The file should contain the intervention sheet (default: Content).')}
+              {' '}
+              <span className="text-muted">
+                {t('ID format')}{': '}
+                <code>3500_web_de</code> {t('(original)')} /&nbsp;
+                <code>30500_vid_pt</code> {t('(self-made)')}
+                {' — '}
+                {t('formats')}{': '}
+                <code>vid, img, pdf, web, aud, app, br, gfx</code>
+                {' — '}
+                {t('languages')}{': '}
+                <code>de, fr, it, pt, nl, en</code>
+              </span>
             </div>
           </Form.Group>
 
@@ -124,11 +136,12 @@ const ImportInterventionsModal: React.FC<Props> = observer(({ show, onHide, onSu
                   onChange={(e) => setDefaultLang(e.target.value)}
                   disabled={interventionsImportStore.loading}
                 >
-                  {/* ✅ Align with your supported language set */}
                   <option value="en">EN</option>
                   <option value="de">DE</option>
                   <option value="fr">FR</option>
                   <option value="it">IT</option>
+                  <option value="pt">PT</option>
+                  <option value="nl">NL</option>
                 </Form.Select>
               </Form.Group>
 
@@ -163,29 +176,53 @@ const ImportInterventionsModal: React.FC<Props> = observer(({ show, onHide, onSu
                 <Badge bg="secondary">
                   {t('Skipped')}: {r.skipped ?? 0}
                 </Badge>
-                <Badge bg={(r.errors?.length ?? 0) ? 'danger' : 'success'}>
-                  {t('Errors')}: {r.errors?.length ?? 0}
-                </Badge>
+                {(() => {
+                  const errorsCount = r.errors_count ?? (r.errors || []).filter((e: any) => e.severity !== 'warning').length;
+                  const warningsCount = r.warnings ?? (r.errors || []).filter((e: any) => e.severity === 'warning').length;
+                  return (
+                    <>
+                      {errorsCount > 0 && (
+                        <Badge bg="danger">{t('Errors')}: {errorsCount}</Badge>
+                      )}
+                      {warningsCount > 0 && (
+                        <Badge bg="warning" text="dark">{t('Warnings')}: {warningsCount}</Badge>
+                      )}
+                      {errorsCount === 0 && warningsCount === 0 && (
+                        <Badge bg="success">{t('Errors')}: 0</Badge>
+                      )}
+                    </>
+                  );
+                })()}
               </div>
 
               {(r.errors?.length ?? 0) > 0 && (
                 <div className="mt-3">
-                  <div className="fw-semibold mb-2">{t('Error details')}</div>
-                  <div style={{ maxHeight: 220, overflowY: 'auto' }} className="border rounded p-2">
-                    {(r.errors || []).slice(0, 200).map((e: any, idx: number) => (
-                      <div key={idx} className="small mb-2">
-                        <div>
-                          <strong>{t('Row')}:</strong> {e.row ?? '-'}{' '}
-                          <strong className="ms-2">{t('ID')}:</strong>{' '}
-                          {e.intervention_id ?? e.external_id ?? '-'}
+                  <div className="fw-semibold mb-2">{t('Details')}</div>
+                  <div style={{ maxHeight: 260, overflowY: 'auto' }} className="border rounded p-2">
+                    {(r.errors || []).slice(0, 200).map((e: any, idx: number) => {
+                      const isWarning = e.severity === 'warning';
+                      return (
+                        <div key={idx} className="small mb-2">
+                          <div className="d-flex align-items-center gap-2 flex-wrap">
+                            <Badge bg={isWarning ? 'warning' : 'danger'} text={isWarning ? 'dark' : undefined}>
+                              {isWarning ? t('Warning') : t('Error')}
+                            </Badge>
+                            <span>
+                              <strong>{t('Row')}:</strong> {e.row ?? '-'}{' '}
+                              <strong className="ms-2">{t('ID')}:</strong>{' '}
+                              <code>{e.intervention_id ?? e.external_id ?? '-'}</code>
+                            </span>
+                          </div>
+                          <div className={`mt-1 ${isWarning ? 'text-warning-emphasis' : 'text-danger'}`}>
+                            {e.error ?? '-'}
+                          </div>
+                          <hr className="my-2" />
                         </div>
-                        <div className="text-danger">{e.error ?? '-'}</div>
-                        <hr className="my-2" />
-                      </div>
-                    ))}
+                      );
+                    })}
                     {(r.errors || []).length > 200 && (
                       <div className="text-muted small">
-                        {t('Too many errors to display (showing first 200).')}
+                        {t('Too many issues to display (showing first 200).')}
                       </div>
                     )}
                   </div>

--- a/frontend/src/pages/AddInterventionView.tsx
+++ b/frontend/src/pages/AddInterventionView.tsx
@@ -22,8 +22,7 @@ function validateExternalId(id: string): string {
   if (parts.length < 2) return 'Expected format: {number}_{format} e.g. 3500_web';
   const num = parts.slice(0, -1).join('_');
   const fmt = parts[parts.length - 1];
-  if (!/^\d{4,5}$/.test(num))
-    return 'Prefix must be 4 digits (original) or 5 digits (self-made).';
+  if (!/^\d{4,5}$/.test(num)) return 'Prefix must be 4 digits (original) or 5 digits (self-made).';
   if (!VALID_FORMAT_CODES.has(fmt))
     return `Unknown format code "${fmt}". Valid: ${[...VALID_FORMAT_CODES].sort().join(', ')} (vid=video, img/gfx=image, pdf/br=document, web=website, aud=audio, app=app).`;
   return '';
@@ -123,7 +122,11 @@ const AddInterventionView: React.FC = observer(() => {
       // client-side external_id validation
       if (formData.externalId) {
         const idErr = validateExternalId(formData.externalId);
-        if (idErr) { setError(idErr); setIsSubmitting(false); return; }
+        if (idErr) {
+          setError(idErr);
+          setIsSubmitting(false);
+          return;
+        }
       }
 
       const payload = new FormData();
@@ -138,7 +141,9 @@ const AddInterventionView: React.FC = observer(() => {
       payload.append(
         'taxonomy',
         JSON.stringify({
-          ...(formData.primaryDiagnosis.length ? { primary_diagnosis: formData.primaryDiagnosis } : {}),
+          ...(formData.primaryDiagnosis.length
+            ? { primary_diagnosis: formData.primaryDiagnosis }
+            : {}),
         })
       );
 
@@ -225,9 +230,9 @@ const AddInterventionView: React.FC = observer(() => {
                 isInvalid={!!formData.externalId && !!validateExternalId(formData.externalId)}
               />
               <Form.Text className="text-muted">
-                {t('ID format')}{': '}
-                <code>3500_web</code> {t('(original)')} /{' '}
-                <code>30500_vid</code> {t('(self-made)')}
+                {t('ID format')}
+                {': '}
+                <code>3500_web</code> {t('(original)')} / <code>30500_vid</code> {t('(self-made)')}
                 {' — '}
                 <code>vid, img, gfx, pdf, br, web, aud, app</code>
               </Form.Text>
@@ -240,14 +245,12 @@ const AddInterventionView: React.FC = observer(() => {
 
             <Form.Group controlId="language" className="mt-3">
               <Form.Label>{t('Language')}</Form.Label>
-              <Form.Select
-                id="language"
-                value={formData.language}
-                onChange={handleChange}
-              >
+              <Form.Select id="language" value={formData.language} onChange={handleChange}>
                 <option value="">{t('SelectType')}</option>
                 {LANGUAGES.map((l) => (
-                  <option key={l.value} value={l.value}>{l.label}</option>
+                  <option key={l.value} value={l.value}>
+                    {l.label}
+                  </option>
                 ))}
               </Form.Select>
             </Form.Group>
@@ -255,10 +258,7 @@ const AddInterventionView: React.FC = observer(() => {
             {diagnoses.length > 0 && (
               <Form.Group className="mt-3">
                 <Form.Label>{t('Diagnosis')}</Form.Label>
-                <div
-                  className="border rounded p-2"
-                  style={{ maxHeight: 160, overflowY: 'auto' }}
-                >
+                <div className="border rounded p-2" style={{ maxHeight: 160, overflowY: 'auto' }}>
                   {diagnoses.map((d: string) => (
                     <Form.Check
                       key={d}
@@ -269,9 +269,7 @@ const AddInterventionView: React.FC = observer(() => {
                     />
                   ))}
                 </div>
-                <Form.Text className="text-muted">
-                  {t('SelectDiagnosis')}
-                </Form.Text>
+                <Form.Text className="text-muted">{t('SelectDiagnosis')}</Form.Text>
               </Form.Group>
             )}
 

--- a/frontend/src/pages/AddInterventionView.tsx
+++ b/frontend/src/pages/AddInterventionView.tsx
@@ -13,14 +13,42 @@ import axios from 'axios';
 import PatientTypeSection from '../components/AddIntervention/PatientTypeSection';
 import InterventionFormFileInputs from '../components/AddIntervention/InterventionFormFileInputs';
 
+const VALID_FORMAT_CODES = new Set(['vid', 'img', 'pdf', 'web', 'aud', 'app', 'br', 'gfx']);
+
+/** Validate the {number}_{format} part of the ID (language is separate). */
+function validateExternalId(id: string): string {
+  if (!id) return '';
+  const parts = id.toLowerCase().split('_');
+  if (parts.length < 2) return 'Expected format: {number}_{format} e.g. 3500_web';
+  const num = parts.slice(0, -1).join('_');
+  const fmt = parts[parts.length - 1];
+  if (!/^\d{4,5}$/.test(num))
+    return 'Prefix must be 4 digits (original) or 5 digits (self-made).';
+  if (!VALID_FORMAT_CODES.has(fmt))
+    return `Unknown format code "${fmt}". Valid: ${[...VALID_FORMAT_CODES].sort().join(', ')} (vid=video, img/gfx=image, pdf/br=document, web=website, aud=audio, app=app).`;
+  return '';
+}
+
 const defaultForm = {
   title: '',
   description: '',
   contentType: 'blog',
+  externalId: '',
+  language: '',
   link: '',
+  primaryDiagnosis: [] as string[],
   mediaFile: null,
   patientTypes: [{ type: '', frequency: '', includeOption: null }],
 };
+
+const LANGUAGES = [
+  { value: 'de', label: 'DE — Deutsch' },
+  { value: 'fr', label: 'FR — Français' },
+  { value: 'it', label: 'IT — Italiano' },
+  { value: 'pt', label: 'PT — Português' },
+  { value: 'nl', label: 'NL — Nederlands' },
+  { value: 'en', label: 'EN — English' },
+];
 
 const AddInterventionView: React.FC = observer(() => {
   const { t } = useTranslation();
@@ -60,6 +88,16 @@ const AddInterventionView: React.FC = observer(() => {
     setFormData((prev) => ({ ...prev, mediaFile: file }));
   };
 
+  const handlePrimaryDiagnosisChange = (value: string) => {
+    setFormData((prev) => {
+      const current = prev.primaryDiagnosis;
+      const next = current.includes(value)
+        ? current.filter((v) => v !== value)
+        : [...current, value];
+      return { ...prev, primaryDiagnosis: next };
+    });
+  };
+
   const handlePatientTypeChange = (index: number, field: string, value: string | boolean) => {
     setFormData((prev) => {
       const updated = [...prev.patientTypes];
@@ -82,13 +120,27 @@ const AddInterventionView: React.FC = observer(() => {
     setIsSubmitting(true);
 
     try {
+      // client-side external_id validation
+      if (formData.externalId) {
+        const idErr = validateExternalId(formData.externalId);
+        if (idErr) { setError(idErr); setIsSubmitting(false); return; }
+      }
+
       const payload = new FormData();
       payload.append('title', formData.title);
       payload.append('description', formData.description);
       payload.append('contentType', formData.contentType);
+      if (formData.externalId) payload.append('external_id', formData.externalId.toLowerCase());
+      if (formData.language) payload.append('language', formData.language);
       if (formData.link) payload.append('link', formData.link);
       if (formData.mediaFile) payload.append('media_file', formData.mediaFile);
       payload.append('patientTypes', JSON.stringify(formData.patientTypes));
+      payload.append(
+        'taxonomy',
+        JSON.stringify({
+          ...(formData.primaryDiagnosis.length ? { primary_diagnosis: formData.primaryDiagnosis } : {}),
+        })
+      );
 
       const res = await apiClient.post('interventions/add', payload, {
         headers: { 'Content-Type': 'multipart/form-data' },
@@ -96,7 +148,7 @@ const AddInterventionView: React.FC = observer(() => {
 
       if (res.status === 200) {
         setSuccess(true);
-        setFormData({ ...defaultForm, mediaFile: null });
+        setFormData({ ...defaultForm, mediaFile: null, primaryDiagnosis: [], externalId: '' });
       }
     } catch (err) {
       if (axios.isAxiosError(err) && err.response) {
@@ -162,6 +214,66 @@ const AddInterventionView: React.FC = observer(() => {
                 ))}
               </Form.Control>
             </Form.Group>
+
+            <Form.Group controlId="externalId" className="mt-3">
+              <Form.Label>{t('ID')}</Form.Label>
+              <Form.Control
+                type="text"
+                placeholder="3500_web"
+                value={formData.externalId}
+                onChange={handleChange}
+                isInvalid={!!formData.externalId && !!validateExternalId(formData.externalId)}
+              />
+              <Form.Text className="text-muted">
+                {t('ID format')}{': '}
+                <code>3500_web</code> {t('(original)')} /{' '}
+                <code>30500_vid</code> {t('(self-made)')}
+                {' — '}
+                <code>vid, img, gfx, pdf, br, web, aud, app</code>
+              </Form.Text>
+              {formData.externalId && (
+                <Form.Control.Feedback type="invalid">
+                  {validateExternalId(formData.externalId)}
+                </Form.Control.Feedback>
+              )}
+            </Form.Group>
+
+            <Form.Group controlId="language" className="mt-3">
+              <Form.Label>{t('Language')}</Form.Label>
+              <Form.Select
+                id="language"
+                value={formData.language}
+                onChange={handleChange}
+              >
+                <option value="">{t('SelectType')}</option>
+                {LANGUAGES.map((l) => (
+                  <option key={l.value} value={l.value}>{l.label}</option>
+                ))}
+              </Form.Select>
+            </Form.Group>
+
+            {diagnoses.length > 0 && (
+              <Form.Group className="mt-3">
+                <Form.Label>{t('Diagnosis')}</Form.Label>
+                <div
+                  className="border rounded p-2"
+                  style={{ maxHeight: 160, overflowY: 'auto' }}
+                >
+                  {diagnoses.map((d: string) => (
+                    <Form.Check
+                      key={d}
+                      id={`pd-${d}`}
+                      label={t(d)}
+                      checked={formData.primaryDiagnosis.includes(d)}
+                      onChange={() => handlePrimaryDiagnosisChange(d)}
+                    />
+                  ))}
+                </div>
+                <Form.Text className="text-muted">
+                  {t('SelectDiagnosis')}
+                </Form.Text>
+              </Form.Group>
+            )}
 
             <Form.Group controlId="link" className="mt-3">
               <Form.Label>{t('Link')}</Form.Label>

--- a/nginx/conf/prod.reha-advisor.nginx.conf
+++ b/nginx/conf/prod.reha-advisor.nginx.conf
@@ -3,7 +3,7 @@
 server {
     listen 80;
     server_name reha-advisor.ch www.reha-advisor.ch;
-    client_max_body_size 100M;
+    client_max_body_size 500M;
 
     # Security headers (still applies — clients see HTTPS via gateway)
     add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;

--- a/nginx/dev.nginx.conf
+++ b/nginx/dev.nginx.conf
@@ -6,10 +6,10 @@
 server {
     listen 80;
     server_name dev.reha-advisor.ch;
-    client_max_body_size 50m;
+    client_max_body_size 500m;
 
     location /api/ {
-        client_max_body_size 50m;
+        client_max_body_size 500m;
         proxy_pass http://django:8000;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;

--- a/nginx/gateway.nginx.conf
+++ b/nginx/gateway.nginx.conf
@@ -33,7 +33,7 @@ server {
 server {
     listen 443 ssl;
     server_name reha-advisor.ch www.reha-advisor.ch;
-    client_max_body_size 100m;
+    client_max_body_size 500m;
 
     ssl_certificate /etc/letsencrypt/live/reha-advisor.ch/fullchain.pem;
     ssl_certificate_key /etc/letsencrypt/live/reha-advisor.ch/privkey.pem;
@@ -57,7 +57,7 @@ server {
 server {
     listen 443 ssl;
     server_name dev.reha-advisor.ch;
-    client_max_body_size 100m;
+    client_max_body_size 500m;
 
     ssl_certificate /etc/letsencrypt/live/dev.reha-advisor.ch/fullchain.pem;
     ssl_certificate_key /etc/letsencrypt/live/dev.reha-advisor.ch/privkey.pem;

--- a/nginx/local-prod.nginx.conf
+++ b/nginx/local-prod.nginx.conf
@@ -28,9 +28,9 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
         proxy_connect_timeout 60s;
-        proxy_read_timeout 120s;
-        proxy_send_timeout 120s;
-        client_max_body_size 100M;
+        proxy_read_timeout 300s;
+        proxy_send_timeout 300s;
+        client_max_body_size 500M;
     }
 
     location /static/ {
@@ -49,7 +49,7 @@ server {
 server {
     listen 443 ssl;
     server_name reha-advisor.ch www.reha-advisor.ch;
-    client_max_body_size 100M;
+    client_max_body_size 500M;
 
     ssl_certificate /etc/letsencrypt/live/reha-advisor.ch/fullchain.pem;
     ssl_certificate_key /etc/letsencrypt/live/reha-advisor.ch/privkey.pem;
@@ -66,9 +66,9 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-Proto https;
         proxy_connect_timeout 60s;
-        proxy_read_timeout 120s;
-        proxy_send_timeout 120s;
-        client_max_body_size 100M;
+        proxy_read_timeout 300s;
+        proxy_send_timeout 300s;
+        client_max_body_size 500M;
     }
 
     location /static/ {


### PR DESCRIPTION
# Content importing & manual upload improvements

## Summary

- New external ID format — supports 4-digit (original content, e.g. 3500_web) and 5-digit (self-made content, e.g. 30500_vid) numeric prefixes; language code is now a separate field instead of embedded in the ID suffix
- Excel import — backend parser updated to accept the new {number}_{format_code} + separate language column; validates format codes (vid, img, gfx, pdf, br, web, aud, app) and prefix length with detailed per-field error messages
- Frontend Excel validation — error details now specify whether the prefix length, format code, or language code is invalid, giving uploaders actionable feedback
- Manual upload modal (AddRecomendationPopUp) — Portuguese (pt) and Dutch (nl) added to the language dropdown (were missing); external ID field updated to new format with placeholder 3500_web, a format-code hint, and inline validation; Primary Diagnosis upgraded from a single text field to a multi-select tag input
- Add Intervention page (AddInterventionView) — same language list, ID format, and multi-select diagnosis improvements applied for consistency
- Video upload size limit — increased to accommodate larger video files

### Tests

- 6 new backend pytest tests: pt/nl language acceptance, new 4-digit ID format, 5-digit self-made ID format, primary_diagnosis stored as list, single-string diagnosis backwards compatibility
- 15 new frontend Jest tests across AddRecomendationPopUp, AddInterventionView, InterventionFormFileInputs, and PatientTypeSection: language options, default values, ID placeholder, hint text, inline validation errors, checkbox multi-select behaviour

### Checklist
 

- [ ] Backend tests pass: docker exec django pytest tests/ -v
- [ ]  Frontend tests pass: npm test inside frontend/
- [ ]  Manual: open Add Intervention modal → confirm PT and NL appear in language dropdown
- [ ]  Manual: enter 35_web in ID field → error about prefix length
- [ ]  Manual: enter 3500_xyz → "Unknown format code" error
- [ ]  Manual: enter 3500_web → no error
- [ ]  Manual: select multiple primary diagnoses → all are saved
- [ ]  Excel import: upload sheet with 30500_vid + pt column → imports correctly
- [ ]  Excel import: upload sheet with invalid format code → descriptive error returned