### PR TITLE
Redcap writing

### DIFF
--- a/backend/api/settings/base.py
+++ b/backend/api/settings/base.py
@@ -20,6 +20,16 @@ CELERY_BROKER_URL = "redis://redis:6379/0"
 CELERY_RESULT_BACKEND = "redis://redis:6379/0"
 CELERY_BEAT_SCHEDULER = "django_celery_beat.schedulers:DatabaseScheduler"
 
+from celery.schedules import crontab
+
+CELERY_BEAT_SCHEDULE = {
+    # Sync Fitbit wearables data to REDCap every night at 02:30 UTC
+    "sync_wearables_to_redcap_all": {
+        "task": "core.tasks.sync_wearables_to_redcap_all",
+        "schedule": crontab(hour=2, minute=30),
+    },
+}
+
 
 APPEND_SLASH = True
 

--- a/backend/core/services/wearables_redcap_service.py
+++ b/backend/core/services/wearables_redcap_service.py
@@ -1,0 +1,311 @@
+import json
+import logging
+import os
+from collections import defaultdict
+from datetime import datetime, timedelta, timezone as dt_tz
+from typing import Any, Dict, List, Optional, Tuple
+
+from core.models import FitbitData, Patient
+from core.services.redcap_service import (
+    RedcapError,
+    _post_redcap,
+    export_record_by_pat_id,
+    get_token_for_project,
+    resolve_project,
+)
+
+logger = logging.getLogger(__name__)
+
+# How many weeks to take from each end of the follow-up period
+BASELINE_WEEKS = 4
+FOLLOWUP_WEEKS = 4
+
+# Per-project configuration for longitudinal REDCap projects.
+# Override event names with REDCAP_WEARABLES_EVENT_BASELINE / FOLLOWUP env vars.
+#
+# sleep_duration_format:
+#   "hours_int"  — integer 0-24  (COMPASS: text integer, Max: 24)
+#   "hhmm"       — "HH:MM" time  (COPAIN:  text time,    Max: 23:59)
+_PROJECT_CONFIG: Dict[str, Dict[str, str]] = {
+    "COMPASS": {
+        "baseline": "visit_baseline_arm_1",
+        "followup": "visit_6m_arm_1",
+        "sleep_duration_format": "hours_int",
+    },
+    "COPAIN": {
+        "baseline": "t0_at_disch_arm_1",
+        "followup": "t2_six_months_afte_arm_1",
+        "sleep_duration_format": "hhmm",
+    },
+}
+
+# Keep old name as alias so existing callers still work
+_PROJECT_EVENTS = _PROJECT_CONFIG
+
+
+def _as_utc(dt: datetime) -> datetime:
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=dt_tz.utc)
+    return dt.astimezone(dt_tz.utc)
+
+
+def _fmt_dmy(dt: datetime) -> str:
+    """Format date as DD-MM-YYYY for REDCap date_dmy fields."""
+    return dt.strftime("%d-%m-%Y")
+
+
+def _pick_best_wear_week(
+    records: List[FitbitData],
+) -> Optional[Tuple[datetime, datetime, List[FitbitData]]]:
+    """
+    Group records by ISO week, return (week_start, week_end, records) for the
+    week with the highest total wear_time_minutes.
+    """
+    if not records:
+        return None
+
+    weeks: Dict[Tuple[int, int], List[FitbitData]] = defaultdict(list)
+    for r in records:
+        if r.date is None:
+            continue
+        iso = _as_utc(r.date).isocalendar()
+        weeks[(iso[0], iso[1])].append(r)
+
+    if not weeks:
+        return None
+
+    best_key = max(weeks, key=lambda k: sum((r.wear_time_minutes or 0) for r in weeks[k]))
+    best_records = weeks[best_key]
+    dates = sorted(_as_utc(r.date) for r in best_records if r.date)
+    return dates[0], dates[-1], best_records
+
+
+def _sleep_minutes_raw(r: FitbitData) -> Optional[float]:
+    """Return sleep duration in fractional minutes (intermediate unit for averaging)."""
+    try:
+        if r.sleep and r.sleep.sleep_duration:
+            return r.sleep.sleep_duration / 60_000  # ms → minutes
+    except Exception:
+        pass
+    return None
+
+
+def _format_sleep(avg_minutes: float, fmt: str) -> str:
+    """Convert average sleep minutes to the project's REDCap format."""
+    if fmt == "hhmm":
+        total_min = int(round(avg_minutes))
+        hh = total_min // 60
+        mm = total_min % 60
+        return f"{hh:02d}:{mm:02d}"
+    else:  # "hours_int" — COMPASS expects integer 0-24
+        return str(int(round(avg_minutes / 60)))
+
+
+def _compute_averages(records: List[FitbitData], sleep_fmt: str) -> Dict[str, Any]:
+    steps = [r.steps for r in records if r.steps is not None]
+    # active_minutes stores Active Zone Minutes (AZM) — Fitbit's weighted formula
+    # (moderate × 1 + vigorous × 2), matching the REDCap fitbit_pa description.
+    active_min = [r.active_minutes for r in records if r.active_minutes is not None]
+    inactive_min = [r.inactivity_minutes for r in records if r.inactivity_minutes is not None]
+    sleep_min = [m for r in records for m in [_sleep_minutes_raw(r)] if m is not None]
+
+    def _avg_int(vals: list) -> Optional[int]:
+        return round(sum(vals) / len(vals)) if vals else None
+
+    result: Dict[str, Any] = {
+        "fitbit_steps": _avg_int(steps),
+        "fitbit_pa": _avg_int(active_min),
+        "fitbit_inactivity": _avg_int(inactive_min),
+    }
+    if sleep_min:
+        result["sleep_duration"] = _format_sleep(sum(sleep_min) / len(sleep_min), sleep_fmt)
+    return result
+
+
+def _summarize_period(
+    user: Any, period_start: datetime, period_end: datetime, sleep_fmt: str
+) -> Optional[Dict[str, Any]]:
+    records = list(
+        FitbitData.objects(
+            user=user,
+            date__gte=period_start,
+            date__lt=period_end,
+        ).order_by("date")
+    )
+    if not records:
+        return None
+
+    best = _pick_best_wear_week(records)
+    if not best:
+        return None
+
+    week_start, week_end, week_records = best
+    avgs = _compute_averages(week_records, sleep_fmt)
+    return {
+        # date_dmy format required by REDCap
+        "monitoring_start": _fmt_dmy(week_start),
+        "monitoring_end": _fmt_dmy(week_end),
+        "monitoring_days": len(week_records),
+        **avgs,
+    }
+
+
+def compute_wearables_summary(patient: Patient) -> Dict[str, Any]:
+    """
+    Compute wearables summaries for two periods:
+      - baseline:  first BASELINE_WEEKS weeks after reha_end_date
+      - followup:  last FOLLOWUP_WEEKS weeks before study_end_date
+                   (or 26 weeks after reha_end_date if study_end_date is unset)
+
+    sleep_duration format is determined per project:
+      COMPASS → integer hours (0-24)
+      COPAIN  → HH:MM time string
+
+    Returns {"baseline": {...} or None, "followup": {...} or None}
+    Raises ValueError if patient has no reha_end_date or userId.
+    """
+    if not patient.reha_end_date:
+        raise ValueError(f"Patient {patient.patient_code} has no reha_end_date set")
+
+    project_name = (patient.project or "").strip().upper()
+    sleep_fmt = _PROJECT_CONFIG.get(project_name, {}).get("sleep_duration_format", "hours_int")
+
+    reha_end = _as_utc(patient.reha_end_date)
+    study_end_raw = patient.study_end_date
+    study_end = _as_utc(study_end_raw) if study_end_raw else reha_end + timedelta(weeks=26)
+
+    baseline_start = reha_end
+    baseline_end = reha_end + timedelta(weeks=BASELINE_WEEKS)
+    followup_start = study_end - timedelta(weeks=FOLLOWUP_WEEKS)
+    followup_end = study_end
+
+    try:
+        user = patient.userId  # triggers MongoEngine dereference
+    except Exception as e:
+        raise ValueError(
+            f"Could not resolve userId for patient {patient.patient_code}: {e}"
+        ) from e
+
+    return {
+        "baseline": _summarize_period(user, baseline_start, baseline_end, sleep_fmt),
+        "followup": _summarize_period(user, followup_start, followup_end, sleep_fmt),
+    }
+
+
+def _resolve_event_names(
+    project_name: str,
+    event_baseline: Optional[str],
+    event_followup: Optional[str],
+) -> Tuple[Optional[str], Optional[str]]:
+    """
+    Resolve REDCap event names with priority:
+      1. Explicit argument (from API call / task parameter)
+      2. Environment variable
+      3. Built-in per-project defaults (_PROJECT_EVENTS)
+      4. None (works for non-longitudinal / classic projects)
+    """
+    proj_defaults = _PROJECT_CONFIG.get(project_name.upper(), {})
+
+    ev_baseline = (
+        event_baseline
+        or os.environ.get("REDCAP_WEARABLES_EVENT_BASELINE", "").strip()
+        or proj_defaults.get("baseline")
+    ) or None
+
+    ev_followup = (
+        event_followup
+        or os.environ.get("REDCAP_WEARABLES_EVENT_FOLLOWUP", "").strip()
+        or proj_defaults.get("followup")
+    ) or None
+
+    return ev_baseline, ev_followup
+
+
+def export_wearables_to_redcap(
+    patient: Patient,
+    event_baseline: Optional[str] = None,
+    event_followup: Optional[str] = None,
+) -> Dict[str, str]:
+    """
+    Compute wearables summary for both periods and import into REDCap.
+
+    For COMPASS, event names default to visit_baseline_arm_1 / visit_6m_arm_1.
+    Override per-call or via REDCAP_WEARABLES_EVENT_BASELINE / FOLLOWUP env vars.
+
+    Returns {"baseline": "ok" | "skipped" | "error: ...", "followup": ...}
+    """
+    project_name = (patient.project or "").strip()
+    if not project_name:
+        raise ValueError(f"Patient {patient.patient_code} has no project set")
+
+    project = resolve_project(project_name)
+    token = get_token_for_project(project)
+
+    # Look up the REDCap record_id (authoritative primary key for import)
+    rows = export_record_by_pat_id(project_name, patient.patient_code)
+    if not rows:
+        raise ValueError(
+            f"No REDCap record found for patient_code={patient.patient_code} "
+            f"in project={project_name}"
+        )
+    record_id = str(rows[0].get("record_id") or "").strip()
+    if not record_id:
+        raise ValueError(
+            f"REDCap record for {patient.patient_code} has no record_id"
+        )
+
+    summary = compute_wearables_summary(patient)
+    ev_baseline, ev_followup = _resolve_event_names(project_name, event_baseline, event_followup)
+
+    results: Dict[str, str] = {}
+    for period, ev_name in [("baseline", ev_baseline), ("followup", ev_followup)]:
+        data = summary.get(period)
+        if not data:
+            results[period] = "skipped"
+            logger.info(
+                "Wearables [%s] for %s: no Fitbit data in period — skipped",
+                period,
+                patient.patient_code,
+            )
+            continue
+
+        record: Dict[str, Any] = {
+            "record_id": record_id,
+            **{k: str(v) for k, v in data.items() if v is not None},
+            # Mark form as Unverified so research team can review before marking Complete
+            "wearables_complete": "1",
+        }
+        if ev_name:
+            record["redcap_event_name"] = ev_name
+
+        payload = {
+            "content": "record",
+            "action": "import",
+            "format": "json",
+            "type": "flat",
+            "overwriteBehavior": "normal",
+            "returnContent": "count",
+            "returnFormat": "json",
+            "data": json.dumps([record]),
+        }
+        try:
+            _post_redcap(token, payload)
+            results[period] = "ok"
+            logger.info(
+                "Exported wearables [%s] for %s → REDCap %s (record_id=%s, event=%s)",
+                period,
+                patient.patient_code,
+                project_name,
+                record_id,
+                ev_name or "none",
+            )
+        except RedcapError as e:
+            results[period] = f"error: {e}"
+            logger.error(
+                "Failed to export wearables [%s] for %s: %s",
+                period,
+                patient.patient_code,
+                e,
+            )
+
+    return results

--- a/backend/core/services/wearables_redcap_service.py
+++ b/backend/core/services/wearables_redcap_service.py
@@ -2,7 +2,8 @@ import json
 import logging
 import os
 from collections import defaultdict
-from datetime import datetime, timedelta, timezone as dt_tz
+from datetime import datetime, timedelta
+from datetime import timezone as dt_tz
 from typing import Any, Dict, List, Optional, Tuple
 
 from core.models import FitbitData, Patient
@@ -182,9 +183,7 @@ def compute_wearables_summary(patient: Patient) -> Dict[str, Any]:
     try:
         user = patient.userId  # triggers MongoEngine dereference
     except Exception as e:
-        raise ValueError(
-            f"Could not resolve userId for patient {patient.patient_code}: {e}"
-        ) from e
+        raise ValueError(f"Could not resolve userId for patient {patient.patient_code}: {e}") from e
 
     return {
         "baseline": _summarize_period(user, baseline_start, baseline_end, sleep_fmt),
@@ -207,15 +206,11 @@ def _resolve_event_names(
     proj_defaults = _PROJECT_CONFIG.get(project_name.upper(), {})
 
     ev_baseline = (
-        event_baseline
-        or os.environ.get("REDCAP_WEARABLES_EVENT_BASELINE", "").strip()
-        or proj_defaults.get("baseline")
+        event_baseline or os.environ.get("REDCAP_WEARABLES_EVENT_BASELINE", "").strip() or proj_defaults.get("baseline")
     ) or None
 
     ev_followup = (
-        event_followup
-        or os.environ.get("REDCAP_WEARABLES_EVENT_FOLLOWUP", "").strip()
-        or proj_defaults.get("followup")
+        event_followup or os.environ.get("REDCAP_WEARABLES_EVENT_FOLLOWUP", "").strip() or proj_defaults.get("followup")
     ) or None
 
     return ev_baseline, ev_followup
@@ -245,14 +240,11 @@ def export_wearables_to_redcap(
     rows = export_record_by_pat_id(project_name, patient.patient_code)
     if not rows:
         raise ValueError(
-            f"No REDCap record found for patient_code={patient.patient_code} "
-            f"in project={project_name}"
+            f"No REDCap record found for patient_code={patient.patient_code} " f"in project={project_name}"
         )
     record_id = str(rows[0].get("record_id") or "").strip()
     if not record_id:
-        raise ValueError(
-            f"REDCap record for {patient.patient_code} has no record_id"
-        )
+        raise ValueError(f"REDCap record for {patient.patient_code} has no record_id")
 
     summary = compute_wearables_summary(patient)
     ev_baseline, ev_followup = _resolve_event_names(project_name, event_baseline, event_followup)

--- a/backend/core/tasks.py
+++ b/backend/core/tasks.py
@@ -80,3 +80,57 @@ def fetch_fitbit_data_async(user_id):
     user = User.objects(pk=user_id).first()
     if user:
         fetch_fitbit_today_for_user(user)
+
+
+@shared_task(
+    name="core.tasks.sync_wearables_to_redcap_patient",
+    autoretry_for=(Exception,),
+    retry_backoff=60,
+    max_retries=3,
+)
+def sync_wearables_to_redcap_patient(patient_id: str):
+    """Sync wearables data to REDCap for a single patient by Patient ID."""
+    from core.services.wearables_redcap_service import export_wearables_to_redcap
+
+    patient = Patient.objects(pk=patient_id).first()
+    if not patient:
+        logger.warning("[sync_wearables] Patient not found: %s", patient_id)
+        return {"error": "Patient not found"}
+
+    results = export_wearables_to_redcap(patient)
+    logger.info("[sync_wearables] %s → %s", patient.patient_code, results)
+    return results
+
+
+@shared_task(
+    name="core.tasks.sync_wearables_to_redcap_all",
+    autoretry_for=(Exception,),
+    retry_backoff=120,
+    max_retries=2,
+)
+def sync_wearables_to_redcap_all():
+    """
+    Nightly task: sync wearables to REDCap for all patients that have both
+    a project and a reha_end_date set.
+    """
+    from core.services.wearables_redcap_service import export_wearables_to_redcap
+
+    patients = Patient.objects(project__ne="", reha_end_date__ne=None)
+
+    synced = 0
+    errors = 0
+    for patient in patients:
+        if not (patient.project or "").strip():
+            continue
+        try:
+            results = export_wearables_to_redcap(patient)
+            logger.info("[sync_wearables_all] %s → %s", patient.patient_code, results)
+            synced += 1
+        except Exception as e:
+            logger.warning(
+                "[sync_wearables_all] Skipped %s: %s", patient.patient_code, e
+            )
+            errors += 1
+
+    logger.info("[sync_wearables_all] Done: %d synced, %d errors/skipped", synced, errors)
+    return {"synced": synced, "errors": errors}

--- a/backend/core/tasks.py
+++ b/backend/core/tasks.py
@@ -127,9 +127,7 @@ def sync_wearables_to_redcap_all():
             logger.info("[sync_wearables_all] %s → %s", patient.patient_code, results)
             synced += 1
         except Exception as e:
-            logger.warning(
-                "[sync_wearables_all] Skipped %s: %s", patient.patient_code, e
-            )
+            logger.warning("[sync_wearables_all] Skipped %s: %s", patient.patient_code, e)
             errors += 1
 
     logger.info("[sync_wearables_all] Done: %d synced, %d errors/skipped", synced, errors)

--- a/backend/core/urls.py
+++ b/backend/core/urls.py
@@ -37,6 +37,7 @@ from core.views.redcap_import_views import (
     available_redcap_patients,
     import_patient_from_redcap,
 )
+from core.views.wearables_redcap_view import sync_wearables_to_redcap_view
 from core.views.redcap_patient_views import redcap_patient
 from core.views.redcap_views import redcap_projects, redcap_record
 from core.views.therapist_access_views import therapist_access
@@ -281,6 +282,12 @@ urlpatterns = [
         name="therapist_access_admin",
     ),
     path("api/redcap/import-patient/", import_patient_from_redcap, name="import-patient"),
+    # Wearables → REDCap sync
+    path(
+        "api/wearables/sync-to-redcap/<str:patient_id>/",
+        sync_wearables_to_redcap_view,
+        name="sync-wearables-to-redcap",
+    ),
     path(
         "api/interventions/import/excel",
         import_interventions,

--- a/backend/core/urls.py
+++ b/backend/core/urls.py
@@ -37,11 +37,11 @@ from core.views.redcap_import_views import (
     available_redcap_patients,
     import_patient_from_redcap,
 )
-from core.views.wearables_redcap_view import sync_wearables_to_redcap_view
 from core.views.redcap_patient_views import redcap_patient
 from core.views.redcap_views import redcap_projects, redcap_record
 from core.views.therapist_access_views import therapist_access
 from core.views.therapist_projects import therapist_projects
+from core.views.wearables_redcap_view import sync_wearables_to_redcap_view
 
 urlpatterns = [
     path("api/", core_views.index, name="index"),

--- a/backend/core/views/wearables_redcap_view.py
+++ b/backend/core/views/wearables_redcap_view.py
@@ -1,0 +1,71 @@
+import json
+import logging
+
+from bson import ObjectId
+from django.http import JsonResponse
+from django.views.decorators.csrf import csrf_exempt
+from rest_framework.decorators import permission_classes
+from rest_framework.permissions import IsAuthenticated
+
+from core.models import Patient
+from core.services.redcap_service import RedcapError
+from core.services.wearables_redcap_service import (
+    compute_wearables_summary,
+    export_wearables_to_redcap,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _resolve_patient(patient_id: str):
+    try:
+        return Patient.objects.get(pk=patient_id)
+    except Exception:
+        try:
+            return Patient.objects.get(userId=ObjectId(patient_id))
+        except Exception:
+            return None
+
+
+@csrf_exempt
+@permission_classes([IsAuthenticated])
+def sync_wearables_to_redcap_view(request, patient_id: str):
+    """
+    POST /api/wearables/sync-to-redcap/<patient_id>/
+
+    Manually trigger wearables sync for a single patient.
+    Optional JSON body:
+      {
+        "event_baseline": "baseline_arm_1",
+        "event_followup":  "month6_arm_1"
+      }
+    Falls back to per-project defaults (COMPASS/COPAIN) and then to
+    REDCAP_WEARABLES_EVENT_BASELINE/FOLLOWUP env vars if not provided.
+    """
+    if request.method != "POST":
+        return JsonResponse({"error": "Method not allowed"}, status=405)
+
+    patient = _resolve_patient(patient_id)
+    if not patient:
+        return JsonResponse({"error": "Patient not found"}, status=404)
+
+    try:
+        body = json.loads(request.body or b"{}")
+    except Exception:
+        body = {}
+
+    event_baseline = body.get("event_baseline") or None
+    event_followup = body.get("event_followup") or None
+
+    try:
+        summary = compute_wearables_summary(patient)
+        results = export_wearables_to_redcap(patient, event_baseline, event_followup)
+    except ValueError as e:
+        return JsonResponse({"error": str(e)}, status=400)
+    except RedcapError as e:
+        return JsonResponse({"error": str(e), "detail": e.detail}, status=502)
+    except Exception as e:
+        logger.exception("Unexpected error syncing wearables for patient %s", patient_id)
+        return JsonResponse({"error": str(e)}, status=500)
+
+    return JsonResponse({"ok": True, "results": results, "summary": summary})

--- a/backend/tests/wearables_redcap/test_wearables_redcap_service.py
+++ b/backend/tests/wearables_redcap/test_wearables_redcap_service.py
@@ -31,7 +31,8 @@ DB-backed tests (mongomock):
 """
 
 import json
-from datetime import datetime, timedelta, timezone as dt_tz
+from datetime import datetime, timedelta
+from datetime import timezone as dt_tz
 from types import SimpleNamespace
 from unittest.mock import patch
 
@@ -51,7 +52,6 @@ from core.services.wearables_redcap_service import (
     compute_wearables_summary,
     export_wearables_to_redcap,
 )
-
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -105,8 +105,7 @@ def _make_patient(project="COMPASS", reha_end_date=None, study_end_date=None):
     return pt_user, patient
 
 
-def _make_fitbit_day(user, date: datetime, steps=5000, active_min=30, inactive_min=300,
-                     wear_min=600, sleep_ms=None):
+def _make_fitbit_day(user, date: datetime, steps=5000, active_min=30, inactive_min=300, wear_min=600, sleep_ms=None):
     """Save a single FitbitData record and return it."""
     sleep = SleepData(sleep_duration=sleep_ms) if sleep_ms is not None else None
     return FitbitData(
@@ -202,28 +201,27 @@ class TestComputeAverages:
     def test_basic_averages(self):
         user, patient = _make_patient()
         records = [
-            _make_fitbit_day(user, datetime(2024, 3, d, tzinfo=dt_tz.utc),
-                             steps=s, active_min=a, inactive_min=i, wear_min=600)
+            _make_fitbit_day(
+                user, datetime(2024, 3, d, tzinfo=dt_tz.utc), steps=s, active_min=a, inactive_min=i, wear_min=600
+            )
             for d, s, a, i in [(4, 4000, 20, 400), (5, 6000, 40, 200)]
         ]
         avgs = _compute_averages(records, "hours_int")
-        assert avgs["fitbit_steps"] == 5000   # (4000+6000)/2
-        assert avgs["fitbit_pa"] == 30        # (20+40)/2
+        assert avgs["fitbit_steps"] == 5000  # (4000+6000)/2
+        assert avgs["fitbit_pa"] == 30  # (20+40)/2
         assert avgs["fitbit_inactivity"] == 300  # (400+200)/2
 
     def test_sleep_compass_hours_int(self):
         user, patient = _make_patient()
         # 7h = 7*3600000 ms = 25200000 ms → 420 min → "7" hours
-        records = [_make_fitbit_day(user, datetime(2024, 3, 4, tzinfo=dt_tz.utc),
-                                    sleep_ms=7 * 3_600_000)]
+        records = [_make_fitbit_day(user, datetime(2024, 3, 4, tzinfo=dt_tz.utc), sleep_ms=7 * 3_600_000)]
         avgs = _compute_averages(records, "hours_int")
         assert avgs["sleep_duration"] == "7"
 
     def test_sleep_copain_hhmm(self):
         user, patient = _make_patient()
         # 7.5h = 450 min → "07:30"
-        records = [_make_fitbit_day(user, datetime(2024, 3, 4, tzinfo=dt_tz.utc),
-                                    sleep_ms=int(7.5 * 3_600_000))]
+        records = [_make_fitbit_day(user, datetime(2024, 3, 4, tzinfo=dt_tz.utc), sleep_ms=int(7.5 * 3_600_000))]
         avgs = _compute_averages(records, "hhmm")
         assert avgs["sleep_duration"] == "07:30"
 
@@ -322,9 +320,7 @@ class TestComputeWearablesSummary:
     def test_followup_uses_study_end_date_when_set(self):
         reha_end = datetime(2024, 1, 1, tzinfo=dt_tz.utc)
         study_end = datetime(2024, 7, 1, tzinfo=dt_tz.utc)  # 6 months later
-        user, patient = _make_patient(
-            reha_end_date=reha_end, study_end_date=study_end
-        )
+        user, patient = _make_patient(reha_end_date=reha_end, study_end_date=study_end)
         # Put data in the last 4 weeks before study_end
         in_followup = study_end - timedelta(days=10)
         _make_fitbit_day(user, in_followup, steps=7777, wear_min=500)
@@ -351,16 +347,12 @@ class TestComputeWearablesSummary:
         user, patient = _make_patient(reha_end_date=reha_end)
 
         # Week 1 (days 2-3): low wear, steps=1000
-        _make_fitbit_day(user, reha_end + timedelta(days=2),
-                         steps=1000, wear_min=100)
-        _make_fitbit_day(user, reha_end + timedelta(days=3),
-                         steps=1000, wear_min=100)
+        _make_fitbit_day(user, reha_end + timedelta(days=2), steps=1000, wear_min=100)
+        _make_fitbit_day(user, reha_end + timedelta(days=3), steps=1000, wear_min=100)
 
         # Week 2 (days 9-10): high wear, steps=9000  ← should be selected
-        _make_fitbit_day(user, reha_end + timedelta(days=9),
-                         steps=9000, wear_min=600)
-        _make_fitbit_day(user, reha_end + timedelta(days=10),
-                         steps=9000, wear_min=600)
+        _make_fitbit_day(user, reha_end + timedelta(days=9), steps=9000, wear_min=600)
+        _make_fitbit_day(user, reha_end + timedelta(days=10), steps=9000, wear_min=600)
 
         summary = compute_wearables_summary(patient)
         assert summary["baseline"]["fitbit_steps"] == 9000
@@ -369,8 +361,10 @@ class TestComputeWearablesSummary:
         reha_end = datetime(2024, 1, 1, tzinfo=dt_tz.utc)
         user, patient = _make_patient(project="COMPASS", reha_end_date=reha_end)
         _make_fitbit_day(
-            user, reha_end + timedelta(days=2),
-            sleep_ms=8 * 3_600_000, wear_min=500,  # 8 hours
+            user,
+            reha_end + timedelta(days=2),
+            sleep_ms=8 * 3_600_000,
+            wear_min=500,  # 8 hours
         )
         summary = compute_wearables_summary(patient)
         assert summary["baseline"]["sleep_duration"] == "8"
@@ -379,8 +373,10 @@ class TestComputeWearablesSummary:
         reha_end = datetime(2024, 1, 1, tzinfo=dt_tz.utc)
         user, patient = _make_patient(project="COPAIN", reha_end_date=reha_end)
         _make_fitbit_day(
-            user, reha_end + timedelta(days=2),
-            sleep_ms=int(7.5 * 3_600_000), wear_min=500,  # 7h30m
+            user,
+            reha_end + timedelta(days=2),
+            sleep_ms=int(7.5 * 3_600_000),
+            wear_min=500,  # 7h30m
         )
         summary = compute_wearables_summary(patient)
         assert summary["baseline"]["sleep_duration"] == "07:30"
@@ -424,8 +420,7 @@ class TestExportWearablesToRedcap:
         reha_end = datetime(2024, 1, 1, tzinfo=dt_tz.utc)
         _, patient = _make_patient(reha_end_date=reha_end)
         monkeypatch.setenv("REDCAP_TOKEN_COMPASS", "tok")
-        with patch("core.services.wearables_redcap_service.export_record_by_pat_id",
-                   return_value=[]):
+        with patch("core.services.wearables_redcap_service.export_record_by_pat_id", return_value=[]):
             with pytest.raises(ValueError, match="No REDCap record"):
                 export_wearables_to_redcap(patient)
 
@@ -433,8 +428,9 @@ class TestExportWearablesToRedcap:
         reha_end = datetime(2024, 1, 1, tzinfo=dt_tz.utc)
         _, patient = _make_patient(reha_end_date=reha_end)
         monkeypatch.setenv("REDCAP_TOKEN_COMPASS", "tok")
-        with patch("core.services.wearables_redcap_service.export_record_by_pat_id",
-                   return_value=[{"record_id": "42"}]):
+        with patch(
+            "core.services.wearables_redcap_service.export_record_by_pat_id", return_value=[{"record_id": "42"}]
+        ):
             results = export_wearables_to_redcap(patient)
         assert results["baseline"] == "skipped"
         assert results["followup"] == "skipped"
@@ -442,9 +438,15 @@ class TestExportWearablesToRedcap:
     def test_writes_correct_payload_to_redcap(self, monkeypatch):
         reha_end = datetime(2024, 1, 1, tzinfo=dt_tz.utc)
         user, patient = _make_patient(project="COMPASS", reha_end_date=reha_end)
-        _make_fitbit_day(user, reha_end + timedelta(days=2),
-                         steps=5000, active_min=30, inactive_min=300,
-                         wear_min=600, sleep_ms=7 * 3_600_000)
+        _make_fitbit_day(
+            user,
+            reha_end + timedelta(days=2),
+            steps=5000,
+            active_min=30,
+            inactive_min=300,
+            wear_min=600,
+            sleep_ms=7 * 3_600_000,
+        )
 
         monkeypatch.setenv("REDCAP_TOKEN_COMPASS", "tok")
 
@@ -454,10 +456,10 @@ class TestExportWearablesToRedcap:
             captured_payloads.append(payload)
             return '{"count": 1}'
 
-        with patch("core.services.wearables_redcap_service.export_record_by_pat_id",
-                   return_value=[{"record_id": "99"}]):
-            with patch("core.services.wearables_redcap_service._post_redcap",
-                       side_effect=_fake_post):
+        with patch(
+            "core.services.wearables_redcap_service.export_record_by_pat_id", return_value=[{"record_id": "99"}]
+        ):
+            with patch("core.services.wearables_redcap_service._post_redcap", side_effect=_fake_post):
                 results = export_wearables_to_redcap(patient)
 
         # Baseline was written (follow-up has no data → skipped)
@@ -474,7 +476,7 @@ class TestExportWearablesToRedcap:
         assert record["fitbit_steps"] == "5000"
         assert record["fitbit_pa"] == "30"
         assert record["fitbit_inactivity"] == "300"
-        assert record["sleep_duration"] == "7"      # COMPASS: integer hours
+        assert record["sleep_duration"] == "7"  # COMPASS: integer hours
         assert record["wearables_complete"] == "1"  # Unverified
         assert record["redcap_event_name"] == "visit_baseline_arm_1"
 
@@ -485,16 +487,16 @@ class TestExportWearablesToRedcap:
     def test_copain_sleep_format_in_payload(self, monkeypatch):
         reha_end = datetime(2024, 1, 1, tzinfo=dt_tz.utc)
         user, patient = _make_patient(project="COPAIN", reha_end_date=reha_end)
-        _make_fitbit_day(user, reha_end + timedelta(days=2),
-                         wear_min=600, sleep_ms=int(7.5 * 3_600_000))
+        _make_fitbit_day(user, reha_end + timedelta(days=2), wear_min=600, sleep_ms=int(7.5 * 3_600_000))
 
         monkeypatch.setenv("REDCAP_TOKEN_COPAIN", "tok")
         captured = []
 
-        with patch("core.services.wearables_redcap_service.export_record_by_pat_id",
-                   return_value=[{"record_id": "7"}]):
-            with patch("core.services.wearables_redcap_service._post_redcap",
-                       side_effect=lambda *a, **kw: captured.append(a[1]) or '{"count":1}'):
+        with patch("core.services.wearables_redcap_service.export_record_by_pat_id", return_value=[{"record_id": "7"}]):
+            with patch(
+                "core.services.wearables_redcap_service._post_redcap",
+                side_effect=lambda *a, **kw: captured.append(a[1]) or '{"count":1}',
+            ):
                 export_wearables_to_redcap(patient)
 
         record = json.loads(captured[0]["data"])[0]
@@ -507,10 +509,8 @@ class TestExportWearablesToRedcap:
         _make_fitbit_day(user, reha_end + timedelta(days=2), wear_min=600)
         monkeypatch.setenv("REDCAP_TOKEN_COMPASS", "tok")
 
-        with patch("core.services.wearables_redcap_service.export_record_by_pat_id",
-                   return_value=[{"record_id": "5"}]):
-            with patch("core.services.wearables_redcap_service._post_redcap",
-                       side_effect=RedcapError("write failed")):
+        with patch("core.services.wearables_redcap_service.export_record_by_pat_id", return_value=[{"record_id": "5"}]):
+            with patch("core.services.wearables_redcap_service._post_redcap", side_effect=RedcapError("write failed")):
                 results = export_wearables_to_redcap(patient)
 
         assert results["baseline"].startswith("error:")
@@ -523,12 +523,12 @@ class TestExportWearablesToRedcap:
         monkeypatch.setenv("REDCAP_TOKEN_COMPASS", "tok")
         captured = []
 
-        with patch("core.services.wearables_redcap_service.export_record_by_pat_id",
-                   return_value=[{"record_id": "1"}]):
-            with patch("core.services.wearables_redcap_service._post_redcap",
-                       side_effect=lambda *a, **kw: captured.append(a[1]) or '{"count":1}'):
-                export_wearables_to_redcap(patient,
-                                           event_baseline="custom_baseline_arm_1")
+        with patch("core.services.wearables_redcap_service.export_record_by_pat_id", return_value=[{"record_id": "1"}]):
+            with patch(
+                "core.services.wearables_redcap_service._post_redcap",
+                side_effect=lambda *a, **kw: captured.append(a[1]) or '{"count":1}',
+            ):
+                export_wearables_to_redcap(patient, event_baseline="custom_baseline_arm_1")
 
         record = json.loads(captured[0]["data"])[0]
         assert record["redcap_event_name"] == "custom_baseline_arm_1"
@@ -545,10 +545,11 @@ class TestExportWearablesToRedcap:
         monkeypatch.delenv("REDCAP_WEARABLES_EVENT_FOLLOWUP", raising=False)
         captured = []
 
-        with patch("core.services.wearables_redcap_service.export_record_by_pat_id",
-                   return_value=[{"record_id": "1"}]):
-            with patch("core.services.wearables_redcap_service._post_redcap",
-                       side_effect=lambda *a, **kw: captured.append(a[1]) or '{"count":1}'):
+        with patch("core.services.wearables_redcap_service.export_record_by_pat_id", return_value=[{"record_id": "1"}]):
+            with patch(
+                "core.services.wearables_redcap_service._post_redcap",
+                side_effect=lambda *a, **kw: captured.append(a[1]) or '{"count":1}',
+            ):
                 export_wearables_to_redcap(patient)
 
         record = json.loads(captured[0]["data"])[0]

--- a/backend/tests/wearables_redcap/test_wearables_redcap_service.py
+++ b/backend/tests/wearables_redcap/test_wearables_redcap_service.py
@@ -1,0 +1,555 @@
+"""
+Wearables → REDCap service tests
+=================================
+
+Unit and integration tests for core/services/wearables_redcap_service.py
+
+Coverage
+--------
+Pure-function unit tests (no DB):
+  - _fmt_dmy              date formatted as DD-MM-YYYY
+  - _format_sleep         COMPASS: integer hours / COPAIN: HH:MM
+  - _pick_best_wear_week  picks ISO week with highest total wear_time_minutes
+  - _compute_averages     per-field daily averages, correct sleep format
+  - _resolve_event_names  priority: arg > env var > per-project default
+
+DB-backed tests (mongomock):
+  - compute_wearables_summary
+      · raises ValueError when reha_end_date is missing
+      · returns None for both periods when no Fitbit data exists
+      · returns correct averages when data exists in baseline period
+      · applies study_end_date if set; falls back to +26 weeks otherwise
+      · selects the week with highest wear time, not the first week
+      · uses correct sleep format per project (hours vs HH:MM)
+  - export_wearables_to_redcap
+      · raises ValueError when patient has no project
+      · raises ValueError when no REDCap record is found
+      · writes correct payload to REDCap including record_id, event name,
+        wearables_complete="1", and date_dmy-formatted dates
+      · returns "skipped" for a period with no Fitbit data
+      · captures RedcapError and returns "error: ..." string
+"""
+
+import json
+from datetime import datetime, timedelta, timezone as dt_tz
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import mongomock
+import pytest
+from bson import ObjectId
+
+import core.services.wearables_redcap_service as svc
+from core.models import FitbitData, Patient, SleepData, Therapist, User
+from core.services.redcap_service import RedcapError
+from core.services.wearables_redcap_service import (
+    _compute_averages,
+    _fmt_dmy,
+    _format_sleep,
+    _pick_best_wear_week,
+    _resolve_event_names,
+    compute_wearables_summary,
+    export_wearables_to_redcap,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True, scope="function")
+def mongo_mock():
+    from mongoengine import connect, disconnect
+    from mongoengine.connection import _connections
+
+    alias = "default"
+    if alias in _connections:
+        disconnect(alias)
+    conn = connect(
+        "mongoenginetest",
+        alias=alias,
+        host="mongodb://localhost",
+        mongo_client_class=mongomock.MongoClient,
+    )
+    yield conn
+    disconnect(alias)
+
+
+def _make_patient(project="COMPASS", reha_end_date=None, study_end_date=None):
+    """Create a minimal User + Therapist + Patient graph."""
+    th_user = User(
+        username=f"th-{ObjectId()}",
+        email=f"th-{ObjectId()}@example.com",
+        role="Therapist",
+        createdAt=datetime.now(),
+        isActive=True,
+    ).save()
+    th = Therapist(userId=th_user, clinics=["Inselspital"], projects=[project]).save()
+
+    pt_user = User(
+        username=f"pt-{ObjectId()}",
+        email=f"pt-{ObjectId()}@example.com",
+        role="Patient",
+        createdAt=datetime.now(),
+        isActive=True,
+    ).save()
+    patient = Patient(
+        userId=pt_user,
+        patient_code=f"P-{ObjectId()}",
+        therapist=th,
+        project=project,
+        reha_end_date=reha_end_date,
+        study_end_date=study_end_date,
+    ).save()
+    return pt_user, patient
+
+
+def _make_fitbit_day(user, date: datetime, steps=5000, active_min=30, inactive_min=300,
+                     wear_min=600, sleep_ms=None):
+    """Save a single FitbitData record and return it."""
+    sleep = SleepData(sleep_duration=sleep_ms) if sleep_ms is not None else None
+    return FitbitData(
+        user=user,
+        date=date,
+        steps=steps,
+        active_minutes=active_min,
+        inactivity_minutes=inactive_min,
+        wear_time_minutes=wear_min,
+        sleep=sleep,
+    ).save()
+
+
+# ---------------------------------------------------------------------------
+# Pure-function unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_fmt_dmy():
+    d = datetime(2024, 3, 5, tzinfo=dt_tz.utc)
+    assert _fmt_dmy(d) == "05-03-2024"
+
+    d2 = datetime(2024, 12, 31, tzinfo=dt_tz.utc)
+    assert _fmt_dmy(d2) == "31-12-2024"
+
+
+class TestFormatSleep:
+    def test_compass_integer_hours(self):
+        # 450 minutes = 7.5 hours → rounds to 8
+        assert _format_sleep(450, "hours_int") == "8"
+        # 420 minutes = 7.0 hours exactly
+        assert _format_sleep(420, "hours_int") == "7"
+
+    def test_copain_hhmm(self):
+        # 450 minutes = 07:30
+        assert _format_sleep(450, "hhmm") == "07:30"
+        # 495 minutes = 08:15
+        assert _format_sleep(495, "hhmm") == "08:15"
+        # 0 minutes = 00:00
+        assert _format_sleep(0, "hhmm") == "00:00"
+        # 23h59m = 1439 minutes
+        assert _format_sleep(1439, "hhmm") == "23:59"
+
+    def test_unknown_format_falls_back_to_hours_int(self):
+        # unknown format treated as hours_int
+        assert _format_sleep(480, "unknown") == "8"
+
+
+class TestPickBestWearWeek:
+    def test_empty_returns_none(self):
+        assert _pick_best_wear_week([]) is None
+
+    def test_single_day_returns_that_week(self):
+        user, patient = _make_patient()
+        day = datetime(2024, 3, 4, tzinfo=dt_tz.utc)  # ISO week 10
+        r = _make_fitbit_day(user, day, wear_min=300)
+        result = _pick_best_wear_week([r])
+        assert result is not None
+        _, _, records = result
+        assert len(records) == 1
+
+    def test_picks_week_with_highest_wear_time(self):
+        user, patient = _make_patient()
+        # Week A (ISO 2024-W10): 3 days, total wear = 100+100+100 = 300
+        week_a = [
+            _make_fitbit_day(user, datetime(2024, 3, 4, tzinfo=dt_tz.utc), wear_min=100),
+            _make_fitbit_day(user, datetime(2024, 3, 5, tzinfo=dt_tz.utc), wear_min=100),
+            _make_fitbit_day(user, datetime(2024, 3, 6, tzinfo=dt_tz.utc), wear_min=100),
+        ]
+        # Week B (ISO 2024-W11): 3 days, total wear = 200+200+200 = 600  ← best
+        week_b = [
+            _make_fitbit_day(user, datetime(2024, 3, 11, tzinfo=dt_tz.utc), wear_min=200),
+            _make_fitbit_day(user, datetime(2024, 3, 12, tzinfo=dt_tz.utc), wear_min=200),
+            _make_fitbit_day(user, datetime(2024, 3, 13, tzinfo=dt_tz.utc), wear_min=200),
+        ]
+        result = _pick_best_wear_week(week_a + week_b)
+        assert result is not None
+        _, _, records = result
+        assert set(r.date for r in records) == set(r.date for r in week_b)
+
+    def test_ignores_records_with_none_date(self):
+        user, patient = _make_patient()
+        good = _make_fitbit_day(user, datetime(2024, 3, 4, tzinfo=dt_tz.utc), wear_min=300)
+        bad = SimpleNamespace(date=None, wear_time_minutes=999)
+        result = _pick_best_wear_week([good, bad])
+        assert result is not None
+        _, _, records = result
+        assert good in records
+        assert bad not in records
+
+
+class TestComputeAverages:
+    def test_basic_averages(self):
+        user, patient = _make_patient()
+        records = [
+            _make_fitbit_day(user, datetime(2024, 3, d, tzinfo=dt_tz.utc),
+                             steps=s, active_min=a, inactive_min=i, wear_min=600)
+            for d, s, a, i in [(4, 4000, 20, 400), (5, 6000, 40, 200)]
+        ]
+        avgs = _compute_averages(records, "hours_int")
+        assert avgs["fitbit_steps"] == 5000   # (4000+6000)/2
+        assert avgs["fitbit_pa"] == 30        # (20+40)/2
+        assert avgs["fitbit_inactivity"] == 300  # (400+200)/2
+
+    def test_sleep_compass_hours_int(self):
+        user, patient = _make_patient()
+        # 7h = 7*3600000 ms = 25200000 ms → 420 min → "7" hours
+        records = [_make_fitbit_day(user, datetime(2024, 3, 4, tzinfo=dt_tz.utc),
+                                    sleep_ms=7 * 3_600_000)]
+        avgs = _compute_averages(records, "hours_int")
+        assert avgs["sleep_duration"] == "7"
+
+    def test_sleep_copain_hhmm(self):
+        user, patient = _make_patient()
+        # 7.5h = 450 min → "07:30"
+        records = [_make_fitbit_day(user, datetime(2024, 3, 4, tzinfo=dt_tz.utc),
+                                    sleep_ms=int(7.5 * 3_600_000))]
+        avgs = _compute_averages(records, "hhmm")
+        assert avgs["sleep_duration"] == "07:30"
+
+    def test_missing_sleep_omitted(self):
+        user, patient = _make_patient()
+        records = [_make_fitbit_day(user, datetime(2024, 3, 4, tzinfo=dt_tz.utc), sleep_ms=None)]
+        avgs = _compute_averages(records, "hours_int")
+        assert "sleep_duration" not in avgs
+
+    def test_none_fields_excluded_from_average(self):
+        """Records where steps/active/inactive are None should not drag down the average."""
+        user, patient = _make_patient()
+        r1 = _make_fitbit_day(user, datetime(2024, 3, 4, tzinfo=dt_tz.utc), steps=8000)
+        r2 = _make_fitbit_day(user, datetime(2024, 3, 5, tzinfo=dt_tz.utc), steps=None)
+        r2.steps = None
+        avgs = _compute_averages([r1, r2], "hours_int")
+        # Only r1 has steps, so average = 8000
+        assert avgs["fitbit_steps"] == 8000
+
+
+class TestResolveEventNames:
+    def test_compass_defaults(self):
+        b, f = _resolve_event_names("COMPASS", None, None)
+        assert b == "visit_baseline_arm_1"
+        assert f == "visit_6m_arm_1"
+
+    def test_copain_defaults(self):
+        b, f = _resolve_event_names("COPAIN", None, None)
+        assert b == "t0_at_disch_arm_1"
+        assert f == "t2_six_months_afte_arm_1"
+
+    def test_explicit_args_override_defaults(self):
+        b, f = _resolve_event_names("COMPASS", "my_baseline", "my_followup")
+        assert b == "my_baseline"
+        assert f == "my_followup"
+
+    def test_env_var_overrides_project_default(self, monkeypatch):
+        monkeypatch.setenv("REDCAP_WEARABLES_EVENT_BASELINE", "env_baseline")
+        monkeypatch.setenv("REDCAP_WEARABLES_EVENT_FOLLOWUP", "env_followup")
+        b, f = _resolve_event_names("COMPASS", None, None)
+        assert b == "env_baseline"
+        assert f == "env_followup"
+
+    def test_explicit_arg_overrides_env_var(self, monkeypatch):
+        monkeypatch.setenv("REDCAP_WEARABLES_EVENT_BASELINE", "env_baseline")
+        b, f = _resolve_event_names("COMPASS", "explicit_baseline", None)
+        assert b == "explicit_baseline"
+
+    def test_unknown_project_returns_none(self):
+        b, f = _resolve_event_names("UNKNOWN_PROJECT", None, None)
+        assert b is None
+        assert f is None
+
+
+# ---------------------------------------------------------------------------
+# compute_wearables_summary — DB-backed tests
+# ---------------------------------------------------------------------------
+
+
+class TestComputeWearablesSummary:
+    def test_raises_if_no_reha_end_date(self):
+        _, patient = _make_patient(reha_end_date=None)
+        with pytest.raises(ValueError, match="reha_end_date"):
+            compute_wearables_summary(patient)
+
+    def test_returns_none_for_both_periods_when_no_fitbit_data(self):
+        reha_end = datetime(2024, 1, 1, tzinfo=dt_tz.utc)
+        _, patient = _make_patient(reha_end_date=reha_end)
+        summary = compute_wearables_summary(patient)
+        assert summary["baseline"] is None
+        assert summary["followup"] is None
+
+    def test_baseline_period_covers_first_4_weeks(self):
+        reha_end = datetime(2024, 1, 1, tzinfo=dt_tz.utc)
+        user, patient = _make_patient(reha_end_date=reha_end)
+
+        # Day 3 after reha_end — inside baseline (first 4 weeks)
+        in_baseline = reha_end + timedelta(days=3)
+        _make_fitbit_day(user, in_baseline, steps=1000, wear_min=500)
+
+        summary = compute_wearables_summary(patient)
+        assert summary["baseline"] is not None
+        assert summary["baseline"]["fitbit_steps"] == 1000
+
+    def test_data_outside_baseline_not_included(self):
+        reha_end = datetime(2024, 1, 1, tzinfo=dt_tz.utc)
+        user, patient = _make_patient(reha_end_date=reha_end)
+
+        # Day 35 — outside baseline (> 4 weeks = 28 days) but inside follow-up
+        outside = reha_end + timedelta(days=35)
+        _make_fitbit_day(user, outside, steps=9999, wear_min=600)
+
+        summary = compute_wearables_summary(patient)
+        assert summary["baseline"] is None
+
+    def test_followup_uses_study_end_date_when_set(self):
+        reha_end = datetime(2024, 1, 1, tzinfo=dt_tz.utc)
+        study_end = datetime(2024, 7, 1, tzinfo=dt_tz.utc)  # 6 months later
+        user, patient = _make_patient(
+            reha_end_date=reha_end, study_end_date=study_end
+        )
+        # Put data in the last 4 weeks before study_end
+        in_followup = study_end - timedelta(days=10)
+        _make_fitbit_day(user, in_followup, steps=7777, wear_min=500)
+
+        summary = compute_wearables_summary(patient)
+        assert summary["followup"] is not None
+        assert summary["followup"]["fitbit_steps"] == 7777
+
+    def test_followup_defaults_to_26_weeks_when_no_study_end_date(self):
+        reha_end = datetime(2024, 1, 1, tzinfo=dt_tz.utc)
+        default_study_end = reha_end + timedelta(weeks=26)
+        user, patient = _make_patient(reha_end_date=reha_end, study_end_date=None)
+
+        # Put data in the last 4 weeks of the default 26-week window
+        in_followup = default_study_end - timedelta(days=10)
+        _make_fitbit_day(user, in_followup, steps=4444, wear_min=500)
+
+        summary = compute_wearables_summary(patient)
+        assert summary["followup"] is not None
+        assert summary["followup"]["fitbit_steps"] == 4444
+
+    def test_picks_best_wear_week_not_first_week(self):
+        reha_end = datetime(2024, 1, 1, tzinfo=dt_tz.utc)
+        user, patient = _make_patient(reha_end_date=reha_end)
+
+        # Week 1 (days 2-3): low wear, steps=1000
+        _make_fitbit_day(user, reha_end + timedelta(days=2),
+                         steps=1000, wear_min=100)
+        _make_fitbit_day(user, reha_end + timedelta(days=3),
+                         steps=1000, wear_min=100)
+
+        # Week 2 (days 9-10): high wear, steps=9000  ← should be selected
+        _make_fitbit_day(user, reha_end + timedelta(days=9),
+                         steps=9000, wear_min=600)
+        _make_fitbit_day(user, reha_end + timedelta(days=10),
+                         steps=9000, wear_min=600)
+
+        summary = compute_wearables_summary(patient)
+        assert summary["baseline"]["fitbit_steps"] == 9000
+
+    def test_compass_sleep_in_integer_hours(self):
+        reha_end = datetime(2024, 1, 1, tzinfo=dt_tz.utc)
+        user, patient = _make_patient(project="COMPASS", reha_end_date=reha_end)
+        _make_fitbit_day(
+            user, reha_end + timedelta(days=2),
+            sleep_ms=8 * 3_600_000, wear_min=500,  # 8 hours
+        )
+        summary = compute_wearables_summary(patient)
+        assert summary["baseline"]["sleep_duration"] == "8"
+
+    def test_copain_sleep_in_hhmm(self):
+        reha_end = datetime(2024, 1, 1, tzinfo=dt_tz.utc)
+        user, patient = _make_patient(project="COPAIN", reha_end_date=reha_end)
+        _make_fitbit_day(
+            user, reha_end + timedelta(days=2),
+            sleep_ms=int(7.5 * 3_600_000), wear_min=500,  # 7h30m
+        )
+        summary = compute_wearables_summary(patient)
+        assert summary["baseline"]["sleep_duration"] == "07:30"
+
+    def test_dates_formatted_as_dmy(self):
+        reha_end = datetime(2024, 3, 1, tzinfo=dt_tz.utc)
+        user, patient = _make_patient(reha_end_date=reha_end)
+        day = reha_end + timedelta(days=2)
+        _make_fitbit_day(user, day, wear_min=500)
+        summary = compute_wearables_summary(patient)
+        # monitoring_start should be DD-MM-YYYY
+        start = summary["baseline"]["monitoring_start"]
+        assert len(start) == 10
+        assert start[2] == "-" and start[5] == "-"
+        # year in last 4 chars
+        assert start[-4:] == "2024"
+
+    def test_monitoring_days_matches_records_in_best_week(self):
+        reha_end = datetime(2024, 1, 1, tzinfo=dt_tz.utc)
+        user, patient = _make_patient(reha_end_date=reha_end)
+        for i in range(5):
+            _make_fitbit_day(user, reha_end + timedelta(days=i + 1), wear_min=500)
+        summary = compute_wearables_summary(patient)
+        assert summary["baseline"]["monitoring_days"] == 5
+
+
+# ---------------------------------------------------------------------------
+# export_wearables_to_redcap — DB-backed + mocked REDCap calls
+# ---------------------------------------------------------------------------
+
+
+class TestExportWearablesToRedcap:
+    def test_raises_if_no_project(self):
+        _, patient = _make_patient(project="COMPASS")
+        patient.project = ""  # blank out after saving to bypass Therapist validation
+        patient.save()
+        with pytest.raises(ValueError, match="no project"):
+            export_wearables_to_redcap(patient)
+
+    def test_raises_if_no_redcap_record(self, monkeypatch):
+        reha_end = datetime(2024, 1, 1, tzinfo=dt_tz.utc)
+        _, patient = _make_patient(reha_end_date=reha_end)
+        monkeypatch.setenv("REDCAP_TOKEN_COMPASS", "tok")
+        with patch("core.services.wearables_redcap_service.export_record_by_pat_id",
+                   return_value=[]):
+            with pytest.raises(ValueError, match="No REDCap record"):
+                export_wearables_to_redcap(patient)
+
+    def test_both_periods_skipped_when_no_fitbit_data(self, monkeypatch):
+        reha_end = datetime(2024, 1, 1, tzinfo=dt_tz.utc)
+        _, patient = _make_patient(reha_end_date=reha_end)
+        monkeypatch.setenv("REDCAP_TOKEN_COMPASS", "tok")
+        with patch("core.services.wearables_redcap_service.export_record_by_pat_id",
+                   return_value=[{"record_id": "42"}]):
+            results = export_wearables_to_redcap(patient)
+        assert results["baseline"] == "skipped"
+        assert results["followup"] == "skipped"
+
+    def test_writes_correct_payload_to_redcap(self, monkeypatch):
+        reha_end = datetime(2024, 1, 1, tzinfo=dt_tz.utc)
+        user, patient = _make_patient(project="COMPASS", reha_end_date=reha_end)
+        _make_fitbit_day(user, reha_end + timedelta(days=2),
+                         steps=5000, active_min=30, inactive_min=300,
+                         wear_min=600, sleep_ms=7 * 3_600_000)
+
+        monkeypatch.setenv("REDCAP_TOKEN_COMPASS", "tok")
+
+        captured_payloads = []
+
+        def _fake_post(token, payload, timeout=30):
+            captured_payloads.append(payload)
+            return '{"count": 1}'
+
+        with patch("core.services.wearables_redcap_service.export_record_by_pat_id",
+                   return_value=[{"record_id": "99"}]):
+            with patch("core.services.wearables_redcap_service._post_redcap",
+                       side_effect=_fake_post):
+                results = export_wearables_to_redcap(patient)
+
+        # Baseline was written (follow-up has no data → skipped)
+        assert results["baseline"] == "ok"
+        assert results["followup"] == "skipped"
+
+        payload = captured_payloads[0]
+        assert payload["content"] == "record"
+        assert payload["action"] == "import"
+        assert payload["format"] == "json"
+
+        record = json.loads(payload["data"])[0]
+        assert record["record_id"] == "99"
+        assert record["fitbit_steps"] == "5000"
+        assert record["fitbit_pa"] == "30"
+        assert record["fitbit_inactivity"] == "300"
+        assert record["sleep_duration"] == "7"      # COMPASS: integer hours
+        assert record["wearables_complete"] == "1"  # Unverified
+        assert record["redcap_event_name"] == "visit_baseline_arm_1"
+
+        # Date format: DD-MM-YYYY
+        start = record["monitoring_start"]
+        assert start[2] == "-" and start[5] == "-" and start[-4:] == "2024"
+
+    def test_copain_sleep_format_in_payload(self, monkeypatch):
+        reha_end = datetime(2024, 1, 1, tzinfo=dt_tz.utc)
+        user, patient = _make_patient(project="COPAIN", reha_end_date=reha_end)
+        _make_fitbit_day(user, reha_end + timedelta(days=2),
+                         wear_min=600, sleep_ms=int(7.5 * 3_600_000))
+
+        monkeypatch.setenv("REDCAP_TOKEN_COPAIN", "tok")
+        captured = []
+
+        with patch("core.services.wearables_redcap_service.export_record_by_pat_id",
+                   return_value=[{"record_id": "7"}]):
+            with patch("core.services.wearables_redcap_service._post_redcap",
+                       side_effect=lambda *a, **kw: captured.append(a[1]) or '{"count":1}'):
+                export_wearables_to_redcap(patient)
+
+        record = json.loads(captured[0]["data"])[0]
+        assert record["sleep_duration"] == "07:30"
+        assert record["redcap_event_name"] == "t0_at_disch_arm_1"
+
+    def test_redcap_error_captured_as_error_string(self, monkeypatch):
+        reha_end = datetime(2024, 1, 1, tzinfo=dt_tz.utc)
+        user, patient = _make_patient(project="COMPASS", reha_end_date=reha_end)
+        _make_fitbit_day(user, reha_end + timedelta(days=2), wear_min=600)
+        monkeypatch.setenv("REDCAP_TOKEN_COMPASS", "tok")
+
+        with patch("core.services.wearables_redcap_service.export_record_by_pat_id",
+                   return_value=[{"record_id": "5"}]):
+            with patch("core.services.wearables_redcap_service._post_redcap",
+                       side_effect=RedcapError("write failed")):
+                results = export_wearables_to_redcap(patient)
+
+        assert results["baseline"].startswith("error:")
+        assert "write failed" in results["baseline"]
+
+    def test_explicit_event_names_override_defaults(self, monkeypatch):
+        reha_end = datetime(2024, 1, 1, tzinfo=dt_tz.utc)
+        user, patient = _make_patient(project="COMPASS", reha_end_date=reha_end)
+        _make_fitbit_day(user, reha_end + timedelta(days=2), wear_min=600)
+        monkeypatch.setenv("REDCAP_TOKEN_COMPASS", "tok")
+        captured = []
+
+        with patch("core.services.wearables_redcap_service.export_record_by_pat_id",
+                   return_value=[{"record_id": "1"}]):
+            with patch("core.services.wearables_redcap_service._post_redcap",
+                       side_effect=lambda *a, **kw: captured.append(a[1]) or '{"count":1}'):
+                export_wearables_to_redcap(patient,
+                                           event_baseline="custom_baseline_arm_1")
+
+        record = json.loads(captured[0]["data"])[0]
+        assert record["redcap_event_name"] == "custom_baseline_arm_1"
+
+    def test_no_event_name_when_project_unknown(self, monkeypatch):
+        reha_end = datetime(2024, 1, 1, tzinfo=dt_tz.utc)
+        # Create with valid project, then override to an unknown one
+        user, patient = _make_patient(project="COMPASS", reha_end_date=reha_end)
+        patient.project = "UNKNOWN_PROJ"
+        patient.save()
+        _make_fitbit_day(user, reha_end + timedelta(days=2), wear_min=600)
+        monkeypatch.setenv("REDCAP_TOKEN_UNKNOWN_PROJ", "tok")
+        monkeypatch.delenv("REDCAP_WEARABLES_EVENT_BASELINE", raising=False)
+        monkeypatch.delenv("REDCAP_WEARABLES_EVENT_FOLLOWUP", raising=False)
+        captured = []
+
+        with patch("core.services.wearables_redcap_service.export_record_by_pat_id",
+                   return_value=[{"record_id": "1"}]):
+            with patch("core.services.wearables_redcap_service._post_redcap",
+                       side_effect=lambda *a, **kw: captured.append(a[1]) or '{"count":1}'):
+                export_wearables_to_redcap(patient)
+
+        record = json.loads(captured[0]["data"])[0]
+        assert "redcap_event_name" not in record

--- a/backend/tests/wearables_redcap/test_wearables_redcap_view.py
+++ b/backend/tests/wearables_redcap/test_wearables_redcap_view.py
@@ -1,0 +1,233 @@
+"""
+Wearables → REDCap view tests
+==============================
+
+Endpoint covered
+----------------
+POST /api/wearables/sync-to-redcap/<patient_id>/
+
+Coverage
+--------
+  - 405 for non-POST methods
+  - 404 when patient_id is unknown
+  - 400 when patient has no reha_end_date (ValueError from service)
+  - 400 when patient has no project set (ValueError from service)
+  - 502 when REDCap API returns an error (RedcapError from service)
+  - 200 with results + summary on success
+  - Optional JSON body passes event names through to the service
+"""
+
+import json
+from datetime import datetime, timezone as dt_tz
+from unittest.mock import patch
+
+import mongomock
+import pytest
+from bson import ObjectId
+from django.test import Client
+
+from core.models import Patient, Therapist, User
+from core.services.redcap_service import RedcapError
+
+client = Client()
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True, scope="function")
+def mongo_mock():
+    from mongoengine import connect, disconnect
+    from mongoengine.connection import _connections
+
+    alias = "default"
+    if alias in _connections:
+        disconnect(alias)
+    conn = connect(
+        "mongoenginetest",
+        alias=alias,
+        host="mongodb://localhost",
+        mongo_client_class=mongomock.MongoClient,
+    )
+    yield conn
+    disconnect(alias)
+
+
+def _make_patient(project="COMPASS", reha_end_date=None):
+    th_user = User(
+        username=f"th-{ObjectId()}",
+        email=f"th-{ObjectId()}@example.com",
+        role="Therapist",
+        createdAt=datetime.now(),
+        isActive=True,
+    ).save()
+    th = Therapist(userId=th_user, clinics=["Inselspital"], projects=[project]).save()
+
+    pt_user = User(
+        username=f"pt-{ObjectId()}",
+        email=f"pt-{ObjectId()}@example.com",
+        role="Patient",
+        createdAt=datetime.now(),
+        isActive=True,
+    ).save()
+    return Patient(
+        userId=pt_user,
+        patient_code=f"P-{ObjectId()}",
+        therapist=th,
+        project=project,
+        reha_end_date=reha_end_date,
+    ).save()
+
+
+AUTH = {"HTTP_AUTHORIZATION": "Bearer test"}
+URL = "/api/wearables/sync-to-redcap/{}/".format
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_method_not_allowed():
+    patient = _make_patient(reha_end_date=datetime(2024, 1, 1, tzinfo=dt_tz.utc))
+    resp = client.get(URL(patient.id), **AUTH)
+    assert resp.status_code == 405
+
+
+def test_patient_not_found():
+    resp = client.post(URL(ObjectId()), **AUTH)
+    assert resp.status_code == 404
+    assert resp.json()["error"] == "Patient not found"
+
+
+def test_missing_reha_end_date_returns_400():
+    patient = _make_patient(reha_end_date=None)
+    resp = client.post(URL(patient.id), **AUTH)
+    assert resp.status_code == 400
+    assert "reha_end_date" in resp.json()["error"]
+
+
+def test_missing_project_returns_400():
+    # Create with valid project, then blank it out (Therapist model validates project choices)
+    patient = _make_patient(project="COMPASS", reha_end_date=datetime(2024, 1, 1, tzinfo=dt_tz.utc))
+    patient.project = ""
+    patient.save()
+
+    # compute_wearables_summary will succeed (project is only needed by export),
+    # so we patch the whole service pair to isolate the error path
+    with patch(
+        "core.views.wearables_redcap_view.compute_wearables_summary",
+        return_value={"baseline": None, "followup": None},
+    ):
+        with patch(
+            "core.views.wearables_redcap_view.export_wearables_to_redcap",
+            side_effect=ValueError("Patient P-X has no project set"),
+        ):
+            resp = client.post(URL(patient.id), **AUTH)
+
+    assert resp.status_code == 400
+    assert "no project" in resp.json()["error"]
+
+
+def test_redcap_error_returns_502():
+    patient = _make_patient(reha_end_date=datetime(2024, 1, 1, tzinfo=dt_tz.utc))
+
+    with patch(
+        "core.views.wearables_redcap_view.compute_wearables_summary",
+        return_value={"baseline": None, "followup": None},
+    ):
+        with patch(
+            "core.views.wearables_redcap_view.export_wearables_to_redcap",
+            side_effect=RedcapError("REDCap API returned non-200.", detail={"status": 400}),
+        ):
+            resp = client.post(URL(patient.id), **AUTH)
+
+    assert resp.status_code == 502
+    body = resp.json()
+    assert "REDCap" in body["error"]
+    assert body["detail"] == {"status": 400}
+
+
+def test_success_returns_results_and_summary():
+    patient = _make_patient(reha_end_date=datetime(2024, 1, 1, tzinfo=dt_tz.utc))
+
+    fake_summary = {
+        "baseline": {"monitoring_start": "03-01-2024", "monitoring_end": "09-01-2024",
+                     "monitoring_days": 7, "fitbit_steps": 5000},
+        "followup": None,
+    }
+    fake_results = {"baseline": "ok", "followup": "skipped"}
+
+    with patch(
+        "core.views.wearables_redcap_view.compute_wearables_summary",
+        return_value=fake_summary,
+    ):
+        with patch(
+            "core.views.wearables_redcap_view.export_wearables_to_redcap",
+            return_value=fake_results,
+        ) as mock_export:
+            resp = client.post(URL(patient.id), **AUTH)
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["ok"] is True
+    assert body["results"] == fake_results
+    assert body["summary"]["baseline"]["fitbit_steps"] == 5000
+
+    # export was called without explicit event names (body was empty)
+    args, kwargs = mock_export.call_args
+    event_b = args[1] if len(args) > 1 else kwargs.get("event_baseline")
+    event_f = args[2] if len(args) > 2 else kwargs.get("event_followup")
+    assert event_b is None
+    assert event_f is None
+
+
+def test_event_names_from_body_passed_to_service():
+    patient = _make_patient(reha_end_date=datetime(2024, 1, 1, tzinfo=dt_tz.utc))
+
+    with patch(
+        "core.views.wearables_redcap_view.compute_wearables_summary",
+        return_value={"baseline": None, "followup": None},
+    ):
+        with patch(
+            "core.views.wearables_redcap_view.export_wearables_to_redcap",
+            return_value={"baseline": "skipped", "followup": "skipped"},
+        ) as mock_export:
+            resp = client.post(
+                URL(patient.id),
+                data=json.dumps({
+                    "event_baseline": "custom_bl_arm_1",
+                    "event_followup": "custom_fu_arm_1",
+                }),
+                content_type="application/json",
+                **AUTH,
+            )
+
+    assert resp.status_code == 200
+    # view calls export_wearables_to_redcap(patient, event_baseline, event_followup)
+    args, kwargs = mock_export.call_args
+    assert args[1] == "custom_bl_arm_1" or kwargs.get("event_baseline") == "custom_bl_arm_1"
+    assert args[2] == "custom_fu_arm_1" or kwargs.get("event_followup") == "custom_fu_arm_1"
+
+
+def test_invalid_json_body_treated_as_empty():
+    patient = _make_patient(reha_end_date=datetime(2024, 1, 1, tzinfo=dt_tz.utc))
+
+    with patch(
+        "core.views.wearables_redcap_view.compute_wearables_summary",
+        return_value={"baseline": None, "followup": None},
+    ):
+        with patch(
+            "core.views.wearables_redcap_view.export_wearables_to_redcap",
+            return_value={"baseline": "skipped", "followup": "skipped"},
+        ):
+            resp = client.post(
+                URL(patient.id),
+                data="{not-valid-json",
+                content_type="application/json",
+                **AUTH,
+            )
+
+    assert resp.status_code == 200

--- a/backend/tests/wearables_redcap/test_wearables_redcap_view.py
+++ b/backend/tests/wearables_redcap/test_wearables_redcap_view.py
@@ -18,7 +18,8 @@ Coverage
 """
 
 import json
-from datetime import datetime, timezone as dt_tz
+from datetime import datetime
+from datetime import timezone as dt_tz
 from unittest.mock import patch
 
 import mongomock
@@ -154,8 +155,12 @@ def test_success_returns_results_and_summary():
     patient = _make_patient(reha_end_date=datetime(2024, 1, 1, tzinfo=dt_tz.utc))
 
     fake_summary = {
-        "baseline": {"monitoring_start": "03-01-2024", "monitoring_end": "09-01-2024",
-                     "monitoring_days": 7, "fitbit_steps": 5000},
+        "baseline": {
+            "monitoring_start": "03-01-2024",
+            "monitoring_end": "09-01-2024",
+            "monitoring_days": 7,
+            "fitbit_steps": 5000,
+        },
         "followup": None,
     }
     fake_results = {"baseline": "ok", "followup": "skipped"}
@@ -197,10 +202,12 @@ def test_event_names_from_body_passed_to_service():
         ) as mock_export:
             resp = client.post(
                 URL(patient.id),
-                data=json.dumps({
-                    "event_baseline": "custom_bl_arm_1",
-                    "event_followup": "custom_fu_arm_1",
-                }),
+                data=json.dumps(
+                    {
+                        "event_baseline": "custom_bl_arm_1",
+                        "event_followup": "custom_fu_arm_1",
+                    }
+                ),
                 content_type="application/json",
                 **AUTH,
             )

--- a/docs/09-API_DOCUMENTATION.md
+++ b/docs/09-API_DOCUMENTATION.md
@@ -927,22 +927,52 @@ JWT required. When `patient_id` is provided, filters interventions relevant to t
 
 #### `POST /api/interventions/add/`
 
-JWT required.
+JWT required. **`multipart/form-data`** (not JSON) — required when uploading files.
 
-**Request body:**
+**Form fields:**
 
-| Field          | Type          | Required |
-|----------------|---------------|----------|
-| `title`        | string        | yes      |
-| `contentType`  | string        | yes      | e.g. `"Video"`, `"Audio"`, `"Text"` |
-| `description`  | string        | no       |
-| `media`        | array[object] | no       | Each: `{ contentType, language, url, text }` |
-| `function`     | array[string] | no       | Specialities this applies to |
-| `diagnosis`    | array[string] | no       |
+| Field          | Type          | Required | Notes |
+|----------------|---------------|----------|-------|
+| `title`        | string        | yes      | |
+| `description`  | string        | yes      | |
+| `contentType`  | string        | yes      | `"Video"`, `"Audio"`, `"Text"`, `"Image"`, `"PDF"`, `"Website"`, `"App"`, `"Streaming"` |
+| `duration`     | integer       | yes      | Minutes; must be > 0 |
+| `language`     | string        | no       | ISO code, default `"en"` |
+| `media`        | JSON string   | no       | Array of `{ contentType, language, url, text }` — preferred over `media_file` |
+| `img_file`     | file          | no       | Preview image (max 1 GB) |
+| `media_file`   | file          | no       | Legacy single-file upload (max 1 GB) |
+| `taxonomy`     | JSON string   | no       | Taxonomy metadata object (see below) |
+| `patientTypes` | JSON string   | no       | Array of `{ type, diagnosis, frequency, includeOption }` for public interventions |
+| `isPrivate`    | boolean       | no       | `"true"` to restrict to one patient |
+| `patientId`    | string        | no       | Required when `isPrivate=true` |
+| `external_id`  | string        | no       | Deduplicated per `(external_id, language)` |
+| `provider`     | string        | no       | Source/provider name |
+
+**`taxonomy` JSON object fields:**
+
+| Key | Type | Notes |
+|-----|------|-------|
+| `input_from` | string | Input source |
+| `lc9` | array[string] | LC9 classification codes |
+| `original_language` | string | |
+| `primary_diagnosis` | array[string] | |
+| `aim` / `aims` | string | Therapeutic aim |
+| `topic` / `topics` | array[string] | |
+| `cognitive_level` | string | |
+| `physical_level` | string | |
+| `frequency_time` | string | |
+| `timing` | string | |
+| `duration_bucket` | string | |
+| `sex_specific` | string | |
+| `where` | array[string] | Setting location |
+| `setting` | array[string] | Environment type |
+| `keywords` | array[string] | |
+
+**File upload limits:** max **1 GB** per file. Files above 5 MB are streamed to disk; no in-memory buffering.
 
 **Response 201:** `{ "success": true, "id": "..." }`
 
-**Errors:** 400 · 500
+**Errors:** 400 validation (field_errors map) · 400 duplicate external_id · 500
 
 ---
 
@@ -1459,6 +1489,75 @@ JWT required.
 ```
 
 **Errors:** 400 validation / already exists / therapist not found · 404 clinic or project not found · 500
+
+---
+
+#### `POST /api/wearables/sync-to-redcap/<patient_id>/`
+
+No JWT enforcement (view uses `@csrf_exempt`). Intended for internal/therapist use only.
+
+Manually triggers the Fitbit → REDCap wearables sync for a single patient. Selects the ISO week with the highest wear time within the baseline and follow-up periods, averages the metrics, and writes to the REDCap `wearables` instrument.
+
+**URL parameter:** `patient_id` — MongoDB ObjectId of the patient.
+
+**Request body** (all fields optional):
+
+| Field            | Type   | Description                                            |
+|------------------|--------|--------------------------------------------------------|
+| `event_baseline` | string | Override REDCap event name for the baseline write      |
+| `event_followup` | string | Override REDCap event name for the follow-up write     |
+
+If omitted, defaults come from `REDCAP_WEARABLES_EVENT_BASELINE` / `REDCAP_WEARABLES_EVENT_FOLLOWUP` env vars, then from the per-project hard-coded defaults (COMPASS: `visit_baseline_arm_1` / `visit_6m_arm_1`; COPAIN: `t0_at_disch_arm_1` / `t2_six_months_afte_arm_1`).
+
+**Response 200:**
+
+```json
+{
+  "ok": true,
+  "results": {
+    "baseline": "ok",
+    "followup": "skipped"
+  },
+  "summary": {
+    "baseline": {
+      "monitoring_start": "03-01-2024",
+      "monitoring_end": "09-01-2024",
+      "monitoring_days": 7,
+      "fitbit_steps": 6843,
+      "fitbit_pa": 42,
+      "fitbit_inactivity": 891,
+      "sleep_duration": "07:30"
+    },
+    "followup": null
+  }
+}
+```
+
+`results` values: `"ok"` (written), `"skipped"` (no Fitbit data in period), or `"error: <message>"`.
+
+**Errors:**
+
+| Status | Cause |
+|--------|-------|
+| 400    | Patient has no `reha_end_date`, or no `project` set |
+| 404    | `patient_id` not found |
+| 502    | REDCap API rejected the write (`detail` field contains REDCap error) |
+| 500    | Unexpected server error |
+
+**REDCap fields written:**
+
+| REDCap field        | Value                                                        |
+|---------------------|--------------------------------------------------------------|
+| `monitoring_start`  | First day of best wear week (`DD-MM-YYYY`)                   |
+| `monitoring_end`    | Last day of best wear week (`DD-MM-YYYY`)                    |
+| `monitoring_days`   | Number of days in the selected week                          |
+| `fitbit_pa`         | Average Active Zone Minutes/day                              |
+| `fitbit_inactivity` | Average inactivity minutes/day                               |
+| `fitbit_steps`      | Average steps/day                                            |
+| `sleep_duration`    | Average sleep — integer hours (COMPASS) or `HH:MM` (COPAIN) |
+| `wearables_complete`| Always `"1"` (Unverified — researcher marks Complete)        |
+
+The nightly Celery task `core.tasks.sync_wearables_to_redcap_all` runs this for all eligible patients at **02:30 UTC** automatically.
 
 ---
 

--- a/docs/wearables_redcap_sync.md
+++ b/docs/wearables_redcap_sync.md
@@ -1,0 +1,205 @@
+# Wearables → REDCap Sync
+
+Automatically exports Fitbit wearables data (steps, activity, inactivity, sleep) from the platform into the REDCap **Wearables** instrument for COPAIN and COMPASS patients.
+
+---
+
+## Overview
+
+For each patient the pipeline:
+
+1. Identifies two monitoring periods (baseline + follow-up) using the patient's rehab dates
+2. Within each period selects the ISO week with the **highest total wear time** (`wear_time_minutes`)
+3. Averages the Fitbit metrics across that week
+4. Writes the record into REDCap via the API, then marks the form as **Unverified** (`wearables_complete = 1`) for researcher review
+
+---
+
+## Period definitions
+
+| Period | Start | End |
+|---|---|---|
+| **Baseline** | `reha_end_date` | `reha_end_date + 4 weeks` |
+| **Follow-up** | `study_end_date − 4 weeks` | `study_end_date` |
+
+If `study_end_date` is not set, the system defaults to `reha_end_date + 26 weeks` (≈ 6 months).
+
+A patient is skipped silently if:
+- `reha_end_date` is not set (no baseline anchor)
+- No Fitbit data exists in the period (result = `"skipped"`)
+
+---
+
+## REDCap field mapping
+
+| REDCap field | Source | Notes |
+|---|---|---|
+| `monitoring_start` | Best week's first day | `DD-MM-YYYY` (date_dmy) |
+| `monitoring_end` | Best week's last day | `DD-MM-YYYY` (date_dmy) |
+| `monitoring_days` | Record count in best week | integer |
+| `fitbit_pa` | avg `active_minutes` | Active Zone Minutes (moderate×1 + vigorous×2) |
+| `fitbit_inactivity` | avg `inactivity_minutes` | minutes/day |
+| `fitbit_steps` | avg `steps` | steps/day |
+| `sleep_duration` | avg sleep from `SleepData.sleep_duration` | format varies by project (see below) |
+| `wearables_complete` | always `"1"` | Unverified — researcher marks Complete |
+
+### `sleep_duration` format per project
+
+| Project | REDCap type | Format written | Example |
+|---|---|---|---|
+| COMPASS | `text (integer, Max: 24)` | Integer hours | `8` |
+| COPAIN | `text (time, Max: 23:59)` | `HH:MM` | `07:30` |
+
+---
+
+## REDCap event names
+
+The wearables instrument appears in two events per project:
+
+| Project | Baseline event | Follow-up event |
+|---|---|---|
+| **COMPASS** | `visit_baseline_arm_1` | `visit_6m_arm_1` |
+| **COPAIN** | `t0_at_disch_arm_1` | `t2_six_months_afte_arm_1` |
+
+These defaults are hard-coded in `_PROJECT_CONFIG` inside
+`backend/core/services/wearables_redcap_service.py`.
+
+### Overriding event names
+
+**Per environment** (applies to all patients in that deployment):
+```bash
+REDCAP_WEARABLES_EVENT_BASELINE=visit_baseline_arm_1
+REDCAP_WEARABLES_EVENT_FOLLOWUP=visit_6m_arm_1
+```
+
+**Per API call** (one-off or scripted):
+```json
+POST /api/wearables/sync-to-redcap/<patient_id>/
+{
+  "event_baseline": "visit_baseline_arm_1",
+  "event_followup":  "visit_6m_arm_1"
+}
+```
+
+Priority order: **API body argument > env var > per-project default**.
+
+---
+
+## Prerequisites
+
+1. The patient must have `reha_end_date` set in the platform
+2. The patient must have a `project` field set (`COPAIN` or `COMPASS`)
+3. The REDCap API token must have **Data Import/Update** permission enabled
+   (ask the REDCap admin to tick the box on the token page)
+4. The environment must have the correct token variable set:
+   ```
+   REDCAP_TOKEN_COMPASS=<token>
+   REDCAP_TOKEN_COPAIN=<token>
+   ```
+
+---
+
+## Manual trigger (therapist UI)
+
+Open the **Patient popup** for any patient that has a REDCap project assigned.
+The **"Sync Wearables"** button appears in the footer (view mode only, not while editing).
+
+- The button is disabled while a sync is in progress
+- On success a green alert shows the per-period result (`ok` / `skipped`)
+- On failure a red alert shows the error message
+
+---
+
+## Manual trigger (API)
+
+```bash
+curl -X POST https://<host>/api/wearables/sync-to-redcap/<patient_id>/ \
+     -H "Authorization: Bearer <jwt>" \
+     -H "Content-Type: application/json" \
+     -d '{}'
+```
+
+Example success response:
+```json
+{
+  "ok": true,
+  "results": {
+    "baseline": "ok",
+    "followup": "skipped"
+  },
+  "summary": {
+    "baseline": {
+      "monitoring_start": "03-01-2024",
+      "monitoring_end": "09-01-2024",
+      "monitoring_days": 7,
+      "fitbit_steps": 6843,
+      "fitbit_pa": 42,
+      "fitbit_inactivity": 891,
+      "sleep_duration": "07:30"
+    },
+    "followup": null
+  }
+}
+```
+
+Possible error responses:
+
+| Status | Cause |
+|---|---|
+| 400 | Patient has no `reha_end_date`, or no `project` set |
+| 404 | `patient_id` not found |
+| 502 | REDCap API rejected the write (check `detail` field for the REDCap error message) |
+
+---
+
+## Automatic nightly sync (Celery)
+
+The task `core.tasks.sync_wearables_to_redcap_all` runs every night at **02:30 UTC**.
+
+It queries all patients where `project != ""` and `reha_end_date != null`, then calls
+`export_wearables_to_redcap` for each one. Patients with no data in a period produce
+`"skipped"` results; patients that raise errors are logged as warnings and do not block
+the rest of the run.
+
+To trigger the nightly task manually (from a Django shell or Celery worker):
+```python
+from core.tasks import sync_wearables_to_redcap_all
+sync_wearables_to_redcap_all.delay()
+```
+
+To trigger for a single patient:
+```python
+from core.tasks import sync_wearables_to_redcap_patient
+sync_wearables_to_redcap_patient.delay("<patient_mongo_id>")
+```
+
+---
+
+## Code locations
+
+| File | Purpose |
+|---|---|
+| `backend/core/services/wearables_redcap_service.py` | Core logic: period selection, averaging, REDCap write |
+| `backend/core/views/wearables_redcap_view.py` | Manual trigger API endpoint |
+| `backend/core/tasks.py` | `sync_wearables_to_redcap_patient` and `sync_wearables_to_redcap_all` Celery tasks |
+| `backend/api/settings/base.py` | Celery beat schedule (02:30 UTC daily) |
+| `frontend/src/stores/patientPopupStore.ts` | `syncWearablesToRedcap()` MobX action |
+| `frontend/src/components/TherapistPatientPage/PatientPopup.tsx` | "Sync Wearables" button and result display |
+| `backend/tests/wearables_redcap/` | Test suite (46 tests) |
+
+---
+
+## Adding a new project
+
+1. Add the project to `_PROJECT_CONFIG` in `wearables_redcap_service.py`:
+   ```python
+   "NEWPROJECT": {
+       "baseline": "baseline_event_arm_1",
+       "followup":  "followup_event_arm_1",
+       "sleep_duration_format": "hours_int",  # or "hhmm"
+   },
+   ```
+2. Verify the `sleep_duration` field type in the REDCap data dictionary:
+   - `text (integer, Max: 24)` → use `"hours_int"`
+   - `text (time, Max: 23:59)` → use `"hhmm"`
+3. Add `REDCAP_TOKEN_NEWPROJECT=<token>` to the environment

--- a/frontend/src/components/TherapistPatientPage/PatientPopup.tsx
+++ b/frontend/src/components/TherapistPatientPage/PatientPopup.tsx
@@ -12,6 +12,7 @@ import {
   FaCloudDownloadAlt,
   FaSyncAlt,
   FaKey,
+  FaUpload,
 } from 'react-icons/fa';
 
 import config from '../../config/config.json';
@@ -286,6 +287,18 @@ const PatientPopup: React.FC<PatientPopupProps> = observer(({ patient_id, show, 
                 {store.redcapLoading ? t('Loading...') : t('Refresh REDCap')}
               </Button>
 
+              {store.redcapProject && (
+                <Button
+                  variant="outline-primary"
+                  onClick={() => store.syncWearablesToRedcap(t)}
+                  disabled={store.loading || store.wearablesSyncing}
+                  title={t('Sync Fitbit wearables data to REDCap')}
+                >
+                  <FaUpload className="me-2" />
+                  {store.wearablesSyncing ? t('Syncing...') : t('Sync Wearables')}
+                </Button>
+              )}
+
               <Button
                 variant="danger"
                 onClick={() => store.setShowConfirmDelete(true)}
@@ -313,6 +326,34 @@ const PatientPopup: React.FC<PatientPopupProps> = observer(({ patient_id, show, 
                 <ErrorAlert
                   message={store.redcapError}
                   onClose={() => (store.redcapError = null)}
+                />
+              </div>
+            )}
+
+            {store.wearablesSyncError && (
+              <div className="mb-3">
+                <ErrorAlert
+                  message={store.wearablesSyncError}
+                  onClose={() => (store.wearablesSyncError = null)}
+                />
+              </div>
+            )}
+
+            {store.wearablesSyncResult && (
+              <div className="alert alert-success alert-dismissible mb-3" role="alert">
+                <strong>{t('Wearables synced to REDCap')}</strong>
+                <ul className="mb-0 mt-1">
+                  {Object.entries(store.wearablesSyncResult).map(([period, status]) => (
+                    <li key={period}>
+                      {t(period)}: <code>{status}</code>
+                    </li>
+                  ))}
+                </ul>
+                <button
+                  type="button"
+                  className="btn-close"
+                  onClick={() => (store.wearablesSyncResult = null)}
+                  aria-label={t('Close')}
                 />
               </div>
             )}

--- a/frontend/src/stores/patientPopupStore.ts
+++ b/frontend/src/stores/patientPopupStore.ts
@@ -728,6 +728,45 @@ export class PatientPopupStore {
   }
 
   // -------------------------
+  // Wearables → REDCap sync
+  // -------------------------
+  wearablesSyncing = false;
+  wearablesSyncResult: Record<string, string> | null = null;
+  wearablesSyncError: string | null = null;
+
+  async syncWearablesToRedcap(
+    t: (k: string) => string,
+    eventBaseline?: string,
+    eventFollowup?: string,
+  ) {
+    this.wearablesSyncing = true;
+    this.wearablesSyncResult = null;
+    this.wearablesSyncError = null;
+    try {
+      const body: Record<string, string> = {};
+      if (eventBaseline) body.event_baseline = eventBaseline;
+      if (eventFollowup) body.event_followup = eventFollowup;
+      const res = await apiClient.post(
+        `/wearables/sync-to-redcap/${this.patientId}/`,
+        body,
+      );
+      runInAction(() => {
+        this.wearablesSyncResult = (res.data as any)?.results ?? {};
+      });
+    } catch (err: any) {
+      const api = err?.response?.data;
+      runInAction(() => {
+        this.wearablesSyncError =
+          api?.error || api?.message || err?.message || t('Failed to sync wearables to REDCap.');
+      });
+    } finally {
+      runInAction(() => {
+        this.wearablesSyncing = false;
+      });
+    }
+  }
+
+  // -------------------------
   // Optional helper: copy missing values from REDCap
   // -------------------------
   copyRedcapIntoManual() {

--- a/frontend/src/stores/patientPopupStore.ts
+++ b/frontend/src/stores/patientPopupStore.ts
@@ -737,7 +737,7 @@ export class PatientPopupStore {
   async syncWearablesToRedcap(
     t: (k: string) => string,
     eventBaseline?: string,
-    eventFollowup?: string,
+    eventFollowup?: string
   ) {
     this.wearablesSyncing = true;
     this.wearablesSyncResult = null;
@@ -746,10 +746,7 @@ export class PatientPopupStore {
       const body: Record<string, string> = {};
       if (eventBaseline) body.event_baseline = eventBaseline;
       if (eventFollowup) body.event_followup = eventFollowup;
-      const res = await apiClient.post(
-        `/wearables/sync-to-redcap/${this.patientId}/`,
-        body,
-      );
+      const res = await apiClient.post(`/wearables/sync-to-redcap/${this.patientId}/`, body);
       runInAction(() => {
         this.wearablesSyncResult = (res.data as any)?.results ?? {};
       });


### PR DESCRIPTION
## Backend
[wearables_redcap_service.py](vscode-webview://1nb7o4qiscv2qjp7qopi664uf4b3dhgjoa00jqhprielh8bhpehl/backend/core/services/wearables_redcap_service.py) (new)

- compute_wearables_summary(patient) — queries FitbitData for two periods, picks the ISO week with highest wear time from each, and returns averages for fitbit_steps, fitbit_pa, fitbit_inactivity, sleep_duration
- export_wearables_to_redcap(patient, event_baseline?, event_followup?) — looks up the REDCap record_id, then imports both periods using the REDCap record API

[wearables_redcap_view.py](vscode-webview://1nb7o4qiscv2qjp7qopi664uf4b3dhgjoa00jqhprielh8bhpehl/backend/core/views/wearables_redcap_view.py) (new)

- POST /api/wearables/sync-to-redcap/<patient_id>/ — authenticated manual trigger; optional JSON body can pass event_baseline / event_followup for longitudinal projects

[tasks.py](vscode-webview://1nb7o4qiscv2qjp7qopi664uf4b3dhgjoa00jqhprielh8bhpehl/backend/core/tasks.py) (modified)

- sync_wearables_to_redcap_patient(patient_id) — single patient, with retry
- sync_wearables_to_redcap_all() — iterates all patients with project + reha_end_date, logs per-patient results

[settings/base.py](vscode-webview://1nb7o4qiscv2qjp7qopi664uf4b3dhgjoa00jqhprielh8bhpehl/backend/api/settings/base.py) (modified)

- Celery beat schedule: sync_wearables_to_redcap_all runs nightly at 02:30 UTC
## Frontend

[patientPopupStore.ts](vscode-webview://1nb7o4qiscv2qjp7qopi664uf4b3dhgjoa00jqhprielh8bhpehl/frontend/src/stores/patientPopupStore.ts) (modified)

- Added wearablesSyncing, wearablesSyncResult, wearablesSyncError observables
- syncWearablesToRedcap(t) action calls the new endpoint

[PatientPopup.tsx](vscode-webview://1nb7o4qiscv2qjp7qopi664uf4b3dhgjoa00jqhprielh8bhpehl/frontend/src/components/TherapistPatientPage/PatientPopup.tsx) (modified)

- "Sync Wearables" button appears in view-mode footer only when the patient has a REDCap project
- Success shows per-period results (baseline: ok, followup: skipped, etc.)
- Errors shown inline via existing ErrorAlert