### PR TITLE
Update notifications to run twice a week and be translated

### DIFF
--- a/frontend/public/sw.js
+++ b/frontend/public/sw.js
@@ -1,3 +1,38 @@
+const NOTIFICATION_TRANSLATIONS = {
+  en: { title: 'Bearny Reminder', body: 'Time to check your rehabilitation progress!' },
+  de: { title: 'Bearny Erinnerung', body: 'Zeit, Ihren Rehabilitationsfortschritt zu überprüfen!' },
+  fr: { title: 'Rappel Bearny', body: 'Il est temps de vérifier vos progrès de rééducation!' },
+  it: { title: 'Promemoria Bearny', body: 'Controlla i progressi di riabilitazione!' },
+  pt: { title: 'Lembrete Bearny', body: 'Hora de verificar o seu progresso de reabilitação!' },
+  nl: { title: 'Bearny Herinnering', body: 'Tijd om uw revalidatievoortgang te controleren!' },
+};
+
+let currentLanguage = 'en';
+
+async function saveLanguage(lang) {
+  try {
+    const cache = await caches.open('sw-settings');
+    await cache.put('/sw-language', new Response(lang));
+  } catch (e) {
+    console.error('[SW] Error saving language:', e);
+  }
+}
+
+async function loadLanguage() {
+  try {
+    const cache = await caches.open('sw-settings');
+    const response = await cache.match('/sw-language');
+    if (response) {
+      const lang = await response.text();
+      if (lang && NOTIFICATION_TRANSLATIONS[lang]) {
+        currentLanguage = lang;
+      }
+    }
+  } catch (e) {
+    console.error('[SW] Error loading language:', e);
+  }
+}
+
 // Install event
 self.addEventListener('install', () => {
   console.log('[SW] Installing service worker...');
@@ -7,20 +42,40 @@ self.addEventListener('install', () => {
 // Activate event
 self.addEventListener('activate', (event) => {
   console.log('[SW] Activating service worker...');
-  event.waitUntil(self.clients.claim());
+  event.waitUntil(Promise.all([self.clients.claim(), loadLanguage()]));
 });
 
-// Periodic background sync for daily reminders (for installed PWAs)
+// Periodic background sync for reminders
 self.addEventListener('periodicsync', (event) => {
   console.log('[SW] Periodic sync triggered:', event.tag);
-  if (event.tag === 'daily-reminder') {
-    event.waitUntil(showNotification());
+  if (event.tag === 'twice-weekly-reminder') {
+    event.waitUntil(
+      (async () => {
+        const day = new Date().getDay();
+        if (day !== 1 && day !== 4) {
+          console.log('[SW] Not Monday or Thursday, skipping notification');
+          return;
+        }
+        await showNotification();
+      })()
+    );
   }
 });
 
 // Listen for messages from the main thread
 self.addEventListener('message', (event) => {
-  if (event.data && event.data.type === 'TEST_NOTIFICATION') {
+  if (!event.data) return;
+
+  if (event.data.type === 'SET_LANGUAGE') {
+    const lang = event.data.language;
+    if (lang && NOTIFICATION_TRANSLATIONS[lang]) {
+      currentLanguage = lang;
+      saveLanguage(lang);
+      console.log('[SW] Language set to', lang);
+    }
+  }
+
+  if (event.data.type === 'TEST_NOTIFICATION') {
     console.log('[SW] Testing notification');
     showNotification();
   }
@@ -28,17 +83,19 @@ self.addEventListener('message', (event) => {
 
 async function showNotification() {
   try {
-    const title = 'Bearny Reminder';
+    await loadLanguage();
+    const content = NOTIFICATION_TRANSLATIONS[currentLanguage] || NOTIFICATION_TRANSLATIONS.en;
     const options = {
-      body: 'Time to check your rehabilitation progress!',
+      body: content.body,
       icon: '/icons/pwa-192x192.png',
       badge: '/icons/pwa-96x96.png',
       tag: 'bearny-reminder',
       vibrate: [200, 100, 200],
       requireInteraction: false,
+      lang: currentLanguage,
     };
 
-    await self.registration.showNotification(title, options);
+    await self.registration.showNotification(content.title, options);
     console.log('[SW] Notification shown at', new Date().toLocaleTimeString());
   } catch (error) {
     console.error('[SW] Error showing notification:', error);

--- a/frontend/src/__tests__/hooks/useNotifications.test.ts
+++ b/frontend/src/__tests__/hooks/useNotifications.test.ts
@@ -1,6 +1,12 @@
 import { renderHook, act, waitFor } from '@testing-library/react';
 import { useNotifications } from '@/hooks/useNotifications';
 
+jest.mock('i18next', () => ({
+  language: 'en',
+  on: jest.fn(),
+  off: jest.fn(),
+}));
+
 describe('useNotifications', () => {
   let mockNotification: any;
   let mockServiceWorker: any;
@@ -149,7 +155,7 @@ describe('useNotifications', () => {
     });
 
     await waitFor(() => {
-      expect(mockRegister).toHaveBeenCalledWith('daily-reminder', {
+      expect(mockRegister).toHaveBeenCalledWith('twice-weekly-reminder', {
         minInterval: 24 * 60 * 60 * 1000,
       });
     });
@@ -173,7 +179,7 @@ describe('useNotifications', () => {
     });
 
     await waitFor(() => {
-      expect(mockUnregister).toHaveBeenCalledWith('daily-reminder');
+      expect(mockUnregister).toHaveBeenCalledWith('twice-weekly-reminder');
     });
   });
 

--- a/frontend/src/__tests__/pages/PatientProfile.test.tsx
+++ b/frontend/src/__tests__/pages/PatientProfile.test.tsx
@@ -147,7 +147,7 @@ describe('PatientProfile - Notifications', () => {
   it('renders notification settings card', () => {
     renderPatientProfile();
     expect(screen.getByText('Notifications')).toBeInTheDocument();
-    expect(screen.getByText('Receive daily reminders')).toBeInTheDocument();
+    expect(screen.getByText('Receive reminders')).toBeInTheDocument();
   });
 
   it('displays notification switch in unchecked state by default', () => {

--- a/frontend/src/assets/lang/de.json
+++ b/frontend/src/assets/lang/de.json
@@ -540,7 +540,7 @@
   "Settings": "Einstellungen",
   "Notifications": "Mitteilungen",
   "Language": "Sprache",
-  "Receive daily reminders": "Tägliche Erinnerungen erhalten",
+  "Receive reminders": "Erinnerungen erhalten",
   "Notification permission denied. Please enable in browser settings.": "Benachrichtigungsberechtigung verweigert. Bitte aktivieren Sie sie in den Browsereinstellungen.",
   "Background notifications not supported in this browser.": "Hintergrundbenachrichtigungen werden in diesem Browser nicht unterstützt.",
   "Putthedurationofthethattheinterventionshouldlasthereaproximatelyinminutes": "Geben Sie die ungefähre Dauer der Intervention in Minuten an",

--- a/frontend/src/assets/lang/en.json
+++ b/frontend/src/assets/lang/en.json
@@ -544,7 +544,7 @@
   "Settings": "Settings",
   "Notifications": "Notifications",
   "Language": "Language",
-  "Receive daily reminders": "Receive daily reminders",
+  "Receive reminders": "Receive reminders",
   "Notification permission denied. Please enable in browser settings.": "Notification permission denied. Please enable in browser settings.",
   "Background notifications not supported in this browser.": "Background notifications not supported in this browser.",
   "Putthedurationofthethattheinterventionshouldlasthereaproximatelyinminutes": "Put the duration of the that the intervention should last here aproximately in minutes",

--- a/frontend/src/assets/lang/fr.json
+++ b/frontend/src/assets/lang/fr.json
@@ -545,7 +545,7 @@
   "Settings": "Paramètres",
   "Notifications": "Notifications",
   "Language": "Langue",
-  "Receive daily reminders": "Recevoir des rappels quotidiens",
+  "Receive reminders": "Recevoir des rappels",
   "Notification permission denied. Please enable in browser settings.": "Autorisation de notification refusée. Veuillez l'activer dans les paramètres du navigateur.",
   "Background notifications not supported in this browser.": "Les notifications en arrière-plan ne sont pas prises en charge dans ce navigateur.",
   "Putthedurationofthethattheinterventionshouldlasthereaproximatelyinminutes": "Indiquez ici la durée approximative de l’intervention en minutes",

--- a/frontend/src/assets/lang/it.json
+++ b/frontend/src/assets/lang/it.json
@@ -548,7 +548,7 @@
   "Settings": "Impostazioni",
   "Notifications": "Notifiche",
   "Language": "Lingua",
-  "Receive daily reminders": "Ricevi promemoria giornalieri",
+  "Receive reminders": "Ricevi promemoria",
   "Notification permission denied. Please enable in browser settings.": "Autorizzazione notifica negata. Abilitala nelle impostazioni del browser.",
   "Background notifications not supported in this browser.": "Le notifiche in background non sono supportate in questo browser.",
   "Putthedurationofthethattheinterventionshouldlasthereaproximatelyinminutes": "Inserisci la durata approssimativa dell'intervento in minuti",

--- a/frontend/src/assets/lang/nl.json
+++ b/frontend/src/assets/lang/nl.json
@@ -544,7 +544,7 @@
   "Settings": "Instellingen",
   "Notifications": "Meldingen",
   "Language": "Taal",
-  "Receive daily reminders": "Dagelijkse herinneringen ontvangen",
+  "Receive reminders": "Herinneringen ontvangen",
   "Notification permission denied. Please enable in browser settings.": "Meldingspermissie geweigerd. Schakel in uw browserinstellingen in.",
   "Background notifications not supported in this browser.": "Achtergronsmeldingen worden niet ondersteund in deze browser.",
   "Putthedurationofthethattheinterventionshouldlasthereaproximatelyinminutes": "Voer de geschatte duur van de interventie in minuten in",

--- a/frontend/src/assets/lang/pt.json
+++ b/frontend/src/assets/lang/pt.json
@@ -544,7 +544,7 @@
   "Settings": "Definições",
   "Notifications": "Notificações",
   "Language": "Idioma",
-  "Receive daily reminders": "Receber lembretes diários",
+  "Receive reminders": "Receber lembretes",
   "Notification permission denied. Please enable in browser settings.": "Permissão de notificação negada. Por favor ative nas definições do navegador.",
   "Background notifications not supported in this browser.": "Notificações em segundo plano não suportadas neste navegador.",
   "Putthedurationofthethattheinterventionshouldlasthereaproximatelyinminutes": "Introduza a duração aproximada da intervenção em minutos",

--- a/frontend/src/hooks/useNotifications.ts
+++ b/frontend/src/hooks/useNotifications.ts
@@ -1,4 +1,14 @@
 import { useState, useEffect } from 'react';
+import i18n from 'i18next';
+
+function postLanguageToSW(lang: string) {
+  if ('serviceWorker' in navigator && navigator.serviceWorker.controller) {
+    navigator.serviceWorker.controller.postMessage({
+      type: 'SET_LANGUAGE',
+      language: lang.slice(0, 2),
+    });
+  }
+}
 
 export function useNotifications() {
   const [enabled, setEnabled] = useState<boolean>(false);
@@ -21,6 +31,16 @@ export function useNotifications() {
     if (saved === 'true' && Notification.permission === 'granted') {
       setEnabled(true);
     }
+
+    // Sync current language to SW on mount
+    postLanguageToSW(i18n.language);
+
+    // Keep SW language in sync whenever user changes language
+    const handleLanguageChanged = (lang: string) => postLanguageToSW(lang);
+    i18n.on('languageChanged', handleLanguageChanged);
+    return () => {
+      i18n.off('languageChanged', handleLanguageChanged);
+    };
   }, []);
 
   const requestPermission = async (): Promise<boolean> => {
@@ -43,10 +63,10 @@ export function useNotifications() {
       const registration = await navigator.serviceWorker.ready;
       if ('periodicSync' in registration) {
         // @ts-expect-error - periodicSync API
-        await registration.periodicSync.register('daily-reminder', {
-          minInterval: 24 * 60 * 60 * 1000, // 24 hours in milliseconds
+        await registration.periodicSync.register('twice-weekly-reminder', {
+          minInterval: 24 * 60 * 60 * 1000, // 24 h – fires daily; SW checks Mon/Thu before showing
         });
-        console.log('[Notifications] Periodic sync registered for daily reminders');
+        console.log('[Notifications] Periodic sync registered for twice-weekly reminders');
       }
     } catch (error) {
       console.error('[Notifications] Failed to register periodic sync:', error);
@@ -58,7 +78,7 @@ export function useNotifications() {
       const registration = await navigator.serviceWorker.ready;
       if ('periodicSync' in registration) {
         // @ts-expect-error - periodicSync API
-        await registration.periodicSync.unregister('daily-reminder');
+        await registration.periodicSync.unregister('twice-weekly-reminder');
         console.log('[Notifications] Periodic sync unregistered');
       }
     } catch (error) {
@@ -82,6 +102,8 @@ export function useNotifications() {
         setEnabled(true);
         localStorage.setItem('notifications-enabled', 'true');
         await registerPeriodicSync();
+        // Ensure SW knows the current language before test notification fires
+        postLanguageToSW(i18n.language);
         // Show a test notification
         testNotification();
       } else {

--- a/frontend/src/pages/PatientProfile.tsx
+++ b/frontend/src/pages/PatientProfile.tsx
@@ -138,7 +138,7 @@ const PatientProfile: React.FC = observer(() => {
               <div className="flex items-center justify-between">
                 <div className="flex flex-col">
                   <div className="font-bold text-lg leading-6 text-zinc-800">
-                    {t('Receive daily reminders')}
+                    {t('Receive reminders')}
                   </div>
                   {permission === 'denied' && (
                     <div className="text-red-600 text-xs">


### PR DESCRIPTION
## Description
This PR updates reminder notifications from daily behavior to a twice-weekly flow and adds notification localization.
It also aligns reminder text labels in the profile page and updates related frontend tests.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Related Issue
[Make Notification twice a week and add translations](https://www.notion.so/Make-Notification-twice-a-week-and-add-translations-33b61846b45080478733e3bdf5fc5cd7?source=copy_link)

## Changes Made
- Changed reminder sync tag to twice-weekly-reminder.
- Added service worker logic to send reminders on Monday and Thursday.
- Added localization support for notification title/body (EN, DE, FR, IT, NL, PT).
- Synced app language to service worker and persisted selected language.
- Updated profile reminder wording from daily text to neutral text.
- Updated frontend tests to match new tag name, i18n integration, and updated reminder label.
 
## Testing
### How to test
1. Enable notifications in the app.
2. Change app language and verify notification text follows the selected language.
3. Trigger test notification and confirm localized title/body is shown.
4. Verify periodic reminder registration uses twice-weekly-reminder.
5. Run frontend tests.

### Test Cases
- Notification hook registers/unregisters with twice-weekly-reminder.
- Notification hook handles i18n integration and language sync behavior.
- Patient profile test validates updated reminder label text.
- Manual check: service worker notification content is localized and language-aware.

## Checklist
- [x] Code follows style guidelines
- [x] Tests added/updated
- [x] Documentation updated (if applicable)
- [x] No new warnings generated
