### PR TITLE
Add skeleton loader for home page

### DIFF
--- a/frontend/src/components/skeletons/HomeSkeleton.tsx
+++ b/frontend/src/components/skeletons/HomeSkeleton.tsx
@@ -1,0 +1,33 @@
+import { Skeleton } from '@/components/ui/skeleton';
+
+export default function HomeSkeleton() {
+  return (
+    <div className="d-flex flex-column min-vh-100 bg-[#F2F2F7]">
+      {/* Header placeholder */}
+      <div className="d-flex align-items-center px-4 py-3 border-bottom bg-white">
+        <Skeleton className="h-8 w-32" />
+        <div className="ms-auto">
+          <Skeleton className="h-8 w-24" />
+        </div>
+      </div>
+
+      {/* Hero placeholder */}
+      <div className="flex-grow-1 d-flex align-items-center py-5">
+        <div className="container-md px-4 px-sm-5">
+          <div className="d-flex flex-column gap-3" style={{ maxWidth: '480px' }}>
+            <Skeleton className="h-10 w-3/4" />
+            <Skeleton className="h-5 w-full" />
+            <Skeleton className="h-5 w-5/6" />
+            <Skeleton className="h-12 w-36 mt-2" />
+            <Skeleton className="h-5 w-48" />
+          </div>
+        </div>
+      </div>
+
+      {/* Footer placeholder */}
+      <div className="d-flex align-items-center justify-content-center px-4 py-3 border-top bg-white">
+        <Skeleton className="h-4 w-48" />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/routes/index.tsx
+++ b/frontend/src/routes/index.tsx
@@ -2,6 +2,7 @@ import { createElement, lazy, Suspense } from 'react';
 import { createBrowserRouter, RouterProvider, Navigate } from 'react-router-dom';
 
 import RootLayout from '@/RootLayout';
+import HomeSkeleton from '@/components/skeletons/HomeSkeleton';
 import PatientSkeleton from '@/components/skeletons/PatientSkeleton';
 import PatientPlanSkeleton from '@/components/skeletons/PatientPlanSkeleton';
 import PatientInterventionsLibrarySkeleton from '@/components/skeletons/PatientInterventionsLibrarySkeleton';
@@ -51,7 +52,7 @@ const withSuspense = (
 export const router = createBrowserRouter([
   {
     path: '/',
-    element: withSuspense(createElement(Home)),
+    element: withSuspense(createElement(Home), createElement(HomeSkeleton)),
   },
   {
     path: '/error',


### PR DESCRIPTION
## Description
Adds a simple loading skeleton for the Home page.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Related Issue
[Home loading skeleton](https://www.notion.so/Home-loading-skeleton-33c61846b45080ba9b79dd1c18407a9f?source=copy_link)

## Changes Made
- Added a new HomeSkeleton component.
- Integrated the skeleton loader into Home route rendering logic.
- Updated Home route behavior to show placeholder UI during loading.
 
## Testing
### How to test
Run the frontend and open the Home page with a slow network (or refresh during data loading) to verify the skeleton appears before content loads.

### Test Cases
- Home page shows skeleton while loading.
- Skeleton disappears when content is ready.
- Home page renders normally after loading.

## Checklist
- [x] Code follows style guidelines
- [x] Tests added/updated
- [x] Documentation updated (if applicable)
- [x] No new warnings generated
