### PR TITLE
Bug manual tests

### DIFF
--- a/frontend/babel.config.js
+++ b/frontend/babel.config.js
@@ -5,4 +5,29 @@ module.exports = {
     '@babel/preset-react',
     '@babel/preset-typescript', // if you're using TypeScript
   ],
+  plugins: [
+    // Replace `import.meta` with `{ env: {} }` so Jest (CommonJS mode) can
+    // handle Vite-specific `import.meta.env.VITE_*` references at test time.
+    function ({ types: t }) {
+      return {
+        visitor: {
+          MetaProperty(path) {
+            if (
+              path.node.meta.name === 'import' &&
+              path.node.property.name === 'meta'
+            ) {
+              path.replaceWith(
+                t.objectExpression([
+                  t.objectProperty(
+                    t.identifier('env'),
+                    t.objectExpression([])
+                  ),
+                ])
+              );
+            }
+          },
+        },
+      };
+    },
+  ],
 };

--- a/frontend/babel.config.js
+++ b/frontend/babel.config.js
@@ -12,17 +12,9 @@ module.exports = {
       return {
         visitor: {
           MetaProperty(path) {
-            if (
-              path.node.meta.name === 'import' &&
-              path.node.property.name === 'meta'
-            ) {
+            if (path.node.meta.name === 'import' && path.node.property.name === 'meta') {
               path.replaceWith(
-                t.objectExpression([
-                  t.objectProperty(
-                    t.identifier('env'),
-                    t.objectExpression([])
-                  ),
-                ])
+                t.objectExpression([t.objectProperty(t.identifier('env'), t.objectExpression([]))])
               );
             }
           },

--- a/frontend/jest.config.ts
+++ b/frontend/jest.config.ts
@@ -5,7 +5,7 @@ const config: Config = {
   testEnvironment: 'jsdom', // More common way of writing this
   setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
   transform: {
-    '^.+\\.(ts|tsx)$': 'ts-jest',
+    '^.+\\.(ts|tsx)$': ['ts-jest', { babelConfig: true }],
     '^.+\\.(js|jsx)$': 'babel-jest',
   },
   moduleNameMapper: {

--- a/frontend/src/__tests__/components/TherapistIntervention/ImportInterventionsModal.test.tsx
+++ b/frontend/src/__tests__/components/TherapistIntervention/ImportInterventionsModal.test.tsx
@@ -71,8 +71,8 @@ beforeEach(() => {
 describe('Tab rendering', () => {
   it('renders the modal with both tab links visible', () => {
     render(<ImportInterventionsModal {...defaultProps} />);
-    expect(screen.getByRole('link', { name: /Excel Import/i })).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: /Upload Media/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Excel Import/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Upload Media/i })).toBeInTheDocument();
   });
 
   it('shows Excel content by default', () => {
@@ -83,30 +83,31 @@ describe('Tab rendering', () => {
 
   it('switches to Upload Media tab and shows upload UI', () => {
     render(<ImportInterventionsModal {...defaultProps} />);
-    fireEvent.click(screen.getByRole('link', { name: /Upload Media/i }));
+    fireEvent.click(screen.getByRole('button', { name: /Upload Media/i }));
     expect(screen.getByText(/Drag & drop/i)).toBeInTheDocument();
     expect(screen.queryByText(/Excel file/i)).not.toBeInTheDocument();
   });
 
   it('switching back to Excel tab restores Excel UI', () => {
     render(<ImportInterventionsModal {...defaultProps} />);
-    fireEvent.click(screen.getByRole('link', { name: /Upload Media/i }));
-    fireEvent.click(screen.getByRole('link', { name: /Excel Import/i }));
+    fireEvent.click(screen.getByRole('button', { name: /Upload Media/i }));
+    fireEvent.click(screen.getByRole('button', { name: /Excel Import/i }));
     expect(screen.getByText(/Excel file/i)).toBeInTheDocument();
     expect(screen.queryByText(/Drag & drop/i)).not.toBeInTheDocument();
   });
 
   it('shows the naming convention help text on the media tab', () => {
     render(<ImportInterventionsModal {...defaultProps} />);
-    fireEvent.click(screen.getByRole('link', { name: /Upload Media/i }));
+    fireEvent.click(screen.getByRole('button', { name: /Upload Media/i }));
     expect(screen.getByText(/Naming convention/i)).toBeInTheDocument();
     expect(screen.getByText(/3500_web_de\.mp4/)).toBeInTheDocument();
   });
 
   it('shows valid extensions on the media tab', () => {
     render(<ImportInterventionsModal {...defaultProps} />);
-    fireEvent.click(screen.getByRole('link', { name: /Upload Media/i }));
-    expect(screen.getByText(/mp4.*mp3.*wav.*pdf.*jpg/i)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /Upload Media/i }));
+    // Target the <code> element specifically — the drop-zone div also matches the regex
+    expect(screen.getByText(/mp4.*mp3.*wav.*pdf.*jpg/i, { selector: 'code' })).toBeInTheDocument();
   });
 });
 
@@ -121,7 +122,7 @@ describe('Footer buttons', () => {
 
   it('shows Upload button on media tab', () => {
     render(<ImportInterventionsModal {...defaultProps} />);
-    fireEvent.click(screen.getByRole('link', { name: /Upload Media/i }));
+    fireEvent.click(screen.getByRole('button', { name: /Upload Media/i }));
     expect(screen.getByRole('button', { name: /^Upload$/i })).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: /^Import$/i })).not.toBeInTheDocument();
   });
@@ -133,7 +134,7 @@ describe('Footer buttons', () => {
 
   it('Upload button is disabled when no files are selected', () => {
     render(<ImportInterventionsModal {...defaultProps} />);
-    fireEvent.click(screen.getByRole('link', { name: /Upload Media/i }));
+    fireEvent.click(screen.getByRole('button', { name: /Upload Media/i }));
     expect(screen.getByRole('button', { name: /^Upload$/i })).toBeDisabled();
   });
 });
@@ -143,7 +144,7 @@ describe('Footer buttons', () => {
 describe('Media file validation', () => {
   function openMediaTab() {
     render(<ImportInterventionsModal {...defaultProps} />);
-    fireEvent.click(screen.getByRole('link', { name: /Upload Media/i }));
+    fireEvent.click(screen.getByRole('button', { name: /Upload Media/i }));
   }
 
   function addFile(file: File) {
@@ -174,35 +175,36 @@ describe('Media file validation', () => {
     openMediaTab();
     addFile(new File(['data'], '3500_web_de.mp4', { type: 'video/mp4' }));
     expect(screen.getByText('✓')).toBeInTheDocument();
-    expect(screen.getByText(/3500_web/)).toBeInTheDocument();
+    // Exact match on the extracted external_id — the naming convention also has "3500_web_de.mp4"
+    expect(screen.getByText('3500_web')).toBeInTheDocument();
   });
 
   it('shows ✓ badge for valid mp3', () => {
     openMediaTab();
     addFile(new File(['data'], '3500_aud_de.mp3', { type: 'audio/mpeg' }));
     expect(screen.getByText('✓')).toBeInTheDocument();
-    expect(screen.getByText(/3500_aud/)).toBeInTheDocument();
+    expect(screen.getByText('3500_aud')).toBeInTheDocument();
   });
 
   it('shows ✓ badge for valid pdf', () => {
     openMediaTab();
     addFile(new File(['data'], '3500_pdf_fr.pdf', { type: 'application/pdf' }));
     expect(screen.getByText('✓')).toBeInTheDocument();
-    expect(screen.getByText(/3500_pdf/)).toBeInTheDocument();
+    expect(screen.getByText('3500_pdf')).toBeInTheDocument();
   });
 
   it('shows ✓ badge for valid jpg image', () => {
     openMediaTab();
     addFile(new File(['data'], '3500_img_it.jpg', { type: 'image/jpeg' }));
     expect(screen.getByText('✓')).toBeInTheDocument();
-    expect(screen.getByText(/3500_img/)).toBeInTheDocument();
+    expect(screen.getByText('3500_img')).toBeInTheDocument();
   });
 
   it('shows ✓ badge for valid self-made format', () => {
     openMediaTab();
     addFile(new File(['data'], '30500_vid_pt.mp4', { type: 'video/mp4' }));
     expect(screen.getByText('✓')).toBeInTheDocument();
-    expect(screen.getByText(/30500_vid/)).toBeInTheDocument();
+    expect(screen.getByText('30500_vid')).toBeInTheDocument();
   });
 
   it('Upload button becomes enabled after a valid file is added', () => {
@@ -234,9 +236,11 @@ describe('Media file validation', () => {
   it('remove button deletes the file from the list', () => {
     openMediaTab();
     addFile(new File(['data'], '3500_web_de.mp4', { type: 'video/mp4' }));
-    expect(screen.getByText('3500_web_de.mp4')).toBeInTheDocument();
+    // The filename appears in both the file row span and the naming-convention code example,
+    // so use the data-testid to count actual file rows instead.
+    expect(screen.getAllByTestId('video-file-row')).toHaveLength(1);
     fireEvent.click(screen.getByRole('button', { name: /Remove file/i }));
-    expect(screen.queryByText('3500_web_de.mp4')).not.toBeInTheDocument();
+    expect(screen.queryAllByTestId('video-file-row')).toHaveLength(0);
   });
 
   it('shows ⚠ badge and size info for a valid-name file that exceeds the 1 GB limit', () => {
@@ -295,7 +299,7 @@ describe('Upload results display', () => {
     ];
 
     render(<ImportInterventionsModal {...defaultProps} />);
-    fireEvent.click(screen.getByRole('link', { name: /Upload Media/i }));
+    fireEvent.click(screen.getByRole('button', { name: /Upload Media/i }));
 
     expect(screen.getByText(/Upload results/i)).toBeInTheDocument();
     expect(screen.getByText(/Updated 1 intervention/i)).toBeInTheDocument();
@@ -314,9 +318,10 @@ describe('Upload results display', () => {
     ];
 
     render(<ImportInterventionsModal {...defaultProps} />);
-    fireEvent.click(screen.getByRole('link', { name: /Upload Media/i }));
+    fireEvent.click(screen.getByRole('button', { name: /Upload Media/i }));
 
-    expect(screen.getByText(/fr/)).toBeInTheDocument();
-    expect(screen.getByText(/3500_pdf/)).toBeInTheDocument();
+    // Exact matches avoid collisions with naming-convention example text
+    expect(screen.getByText('fr')).toBeInTheDocument();
+    expect(screen.getByText('3500_pdf')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary

- Fix `FitbitStatus.test.tsx` suite failing with `SyntaxError: Cannot use 'import.meta' outside a module`: ts-jest compiles TypeScript to CommonJS but leaves Vite-specific `import.meta.env` syntax in the output, which Node.js rejects at runtime. Fixed by adding an inline Babel plugin to `babel.config.js` that replaces `import.meta` with `{ env: {} }` during compilation, and enabling the Babel post-pass in ts-jest via `babelConfig: true`.
- Fix `ImportInterventionsModal.test.tsx` suite: React-Bootstrap `Nav.Link` renders with `role="button"` in JSDOM (not `"link"` or `"tab"`), causing all tab-click queries to fail. Additionally, the naming-convention help text contains example filenames (e.g. `<code>3500_web_de.mp4</code>`) that collided with file-list queries, causing "Found multiple elements" errors. Fixed by correcting ARIA role queries, using exact-string matches for external IDs, scoping the extensions query to `{ selector: 'code' }`, and asserting on `data-testid="video-file-row"` row counts for the remove-button test.

## Changed files

| File | Change |
|---|---|
| `frontend/babel.config.js` | Inline Babel plugin to replace `import.meta` with `{ env: {} }` for Jest compatibility |
| `frontend/jest.config.ts` | Add `babelConfig: true` to ts-jest transform so the Babel pass runs after TypeScript compilation |
| `frontend/src/__tests__/components/TherapistIntervention/ImportInterventionsModal.test.tsx` | Fix role queries (`"link"` → `"button"`), exact-match external IDs, scope extension query to `code` selector, use `data-testid` for remove-button assertions |

## Test plan

- [ ] `npx jest --testPathPattern='FitbitStatus'` — all 5 tests pass
- [ ] `npx jest --testPathPattern='ImportInterventionsModal'` — all 27 tests pass
- [ ] Full Jest suite — no regressions introduced by the Babel config change
