### PR TITLE
Bug intervention translations

### DIFF
--- a/backend/core/views/patient_views.py
+++ b/backend/core/views/patient_views.py
@@ -969,9 +969,36 @@ def get_patient_plan(request, patient_id):
       - assignment fields (dates/notes/frequency/require_video_feedback)
       - completion_dates as YYYY-MM-DD
       - today's feedback entries (same as before)
+
+    Optional query param: ?lang=de  — if supplied, the best available language
+    variant of each intervention is returned instead of the stored assignment
+    variant, so the frontend can skip LibreTranslate auto-translation.
     """
     if request.method != "GET":
         return JsonResponse({"error": "Method not allowed"}, status=405)
+
+    ui_lang = (request.GET.get("lang") or "").strip().lower()[:5]
+
+    def _lang_chain(lang: str):
+        chain, seen = [], set()
+        for l in [lang, "en", "de"]:
+            if l and l not in seen:
+                chain.append(l)
+                seen.add(l)
+        return chain or ["en", "de"]
+
+    def _best_variant(base_intervention, lang: str):
+        """Return the lang-preferred variant of an intervention, or the original."""
+        if not lang:
+            return base_intervention
+        ext_id = getattr(base_intervention, "external_id", None)
+        if not ext_id:
+            return base_intervention
+        for l in _lang_chain(lang):
+            doc = Intervention.objects(external_id=ext_id, language=l).first()
+            if doc:
+                return doc
+        return base_intervention
 
     try:
         try:
@@ -990,14 +1017,19 @@ def get_patient_plan(request, patient_id):
         out = []
 
         for assignment in getattr(rehab_plan, "interventions", None) or []:
-            intervention = getattr(assignment, "interventionId", None)
-            if not intervention:
+            assigned_intervention = getattr(assignment, "interventionId", None)
+            if not assigned_intervention:
                 continue
+
+            # Use the language-preferred variant for title/metadata display, but
+            # always look up logs against the originally assigned document so that
+            # completion records are not lost when a language variant is swapped in.
+            intervention = _best_variant(assigned_intervention, ui_lang) if ui_lang else assigned_intervention
 
             logs = PatientInterventionLogs.objects(
                 userId=patient,
                 rehabilitationPlanId=rehab_plan,
-                interventionId=intervention,
+                interventionId=assigned_intervention,
             )
 
             completion_dates = _completion_day_keys_from_logs(logs)
@@ -1033,10 +1065,11 @@ def get_patient_plan(request, patient_id):
 
             out.append(
                 {
-                    # ✅ full intervention doc (as requested)
+                    # ✅ full intervention doc (language-preferred variant for display)
                     "intervention": _intervention_meta(intervention),
-                    # ✅ keep the older flat fields too (so you don't have to refactor all FE at once)
-                    "intervention_id": str(getattr(intervention, "id", "")),
+                    # intervention_id must stay as the originally assigned variant so
+                    # that completion logs posted by the frontend resolve correctly.
+                    "intervention_id": str(getattr(assigned_intervention, "id", "")),
                     "intervention_title": _as_str(getattr(intervention, "title", ""), ""),
                     "description": _as_str(getattr(intervention, "description", ""), ""),
                     "content_type": getattr(intervention, "content_type", "") or "",

--- a/backend/tests/patient_views/TESTING.md
+++ b/backend/tests/patient_views/TESTING.md
@@ -17,7 +17,7 @@ It also includes [`test_helpers.py`](test_helpers.py) for pure helper logic in
 | `/api/interventions/remove-from-patient/` | POST | `remove_intervention_from_patient` | 4 |
 | `/api/interventions/add-to-patient/` | POST | `add_intervention_to_patient` | 3 |
 | `/api/interventions/modify-patient/` | POST | `modify_intervention_from_date` | 13 |
-| `/api/patients/rehabilitation-plan/patient/<id>/` | GET | `get_patient_plan` | 11 |
+| `/api/patients/rehabilitation-plan/patient/<id>/` | GET | `get_patient_plan` | 16 |
 | `/api/patients/rehabilitation-plan/therapist/<id>/` | GET | `get_patient_plan_for_therapist` | 4 |
 | `/api/patients/get-questions/<type>/<id>/` | GET | `get_feedback_questions` | 7 |
 | `/api/users/<id>/initial-questionaire/` | GET, POST | `initial_patient_questionaire` | 7 |
@@ -26,7 +26,7 @@ It also includes [`test_helpers.py`](test_helpers.py) for pure helper logic in
 | `/api/patients/healthstatus-history/<id>/` | GET | `get_patient_healthstatus_history` | 3 |
 | `/api/patients/feedback/questionaire/` (audio) | POST | `submit_patient_feedback` | 1 |
 
-**Total: 93 tests**
+**Total: 98 tests**
 
 ---
 
@@ -197,6 +197,14 @@ JSON body: `{ patientId, interventionId, effectiveFrom, keep_current?, schedule?
 
 Returns the rehabilitation plan as a list of assignment rows, each containing full intervention metadata, scheduled dates, completion dates, and today's feedback.
 
+### `?lang=` query parameter
+
+An optional `?lang=<ISO 639-1>` query parameter (e.g. `?lang=de`) enables server-side language-variant selection.  When supplied, the endpoint looks up the best available `Intervention` document sharing the same `external_id` in the requested language, using the fallback chain `requested → en → de → any`.  The display fields (`intervention_title`, `description`, nested `intervention` object) are taken from the language-preferred variant.
+
+The `intervention_id` field in every row **always** refers to the originally assigned document, so completion logs posted by the frontend continue to resolve correctly regardless of which display variant was returned.
+
+**Motivation:** the frontend auto-translates titles via LibreTranslate when the stored language differs from the user's UI language.  Machine translations are sometimes poor (e.g. "Medication Reminder" → "Medizinische Erinnerung" instead of "Medikamentenerinnerung").  Returning a human-curated variant causes LibreTranslate to detect source == target and skip translation entirely.
+
 ### Tests (`test_patient_views.py`, `test_get_endpoints.py`)
 
 | Test | Scenario | Expected |
@@ -212,6 +220,11 @@ Returns the rehabilitation plan as a list of assignment rows, each containing fu
 | `test_get_patient_plan_multiple_assignments` | Two-assignment plan | Two rows returned |
 | `test_get_patient_plan_patient_not_found_404` | Unknown ObjectId | 404 |
 | `test_get_patient_plan_post_method_not_allowed` | POST | 405 |
+| `test_get_patient_plan_without_lang_returns_assigned_variant` | No `?lang=` | English title returned; backward-compatible |
+| `test_get_patient_plan_lang_de_returns_german_variant` | `?lang=de`, DE variant exists | German title in display fields; `intervention_id` stays as assigned EN doc |
+| `test_get_patient_plan_lang_fallback_to_en_when_no_variant` | `?lang=fr`, no FR variant | Falls back to EN title silently |
+| `test_get_patient_plan_lang_de_completion_logs_use_assigned_intervention` | `?lang=de`, log recorded against EN doc | Today's completion date visible despite display swap |
+| `test_get_patient_plan_lang_param_ignored_for_intervention_without_external_id` | `?lang=de`, intervention has empty `external_id` | Both rows returned without error |
 
 ---
 

--- a/backend/tests/patient_views/test_patient_views.py
+++ b/backend/tests/patient_views/test_patient_views.py
@@ -1495,7 +1495,7 @@ def test_get_patient_plan_lang_param_ignored_for_intervention_without_external_i
         title="No External ID",
         description="",
         content_type="Video",
-        external_id="",   # empty external_id — variant lookup will skip
+        external_id="",  # empty external_id — variant lookup will skip
         language="en",
     ).save()
 

--- a/backend/tests/patient_views/test_patient_views.py
+++ b/backend/tests/patient_views/test_patient_views.py
@@ -32,6 +32,27 @@ Resource not found (404)
 HTTP method enforcement (405)
   * Each endpoint refuses wrong HTTP verbs.
 
+Language-variant selection (?lang= query param)
+  * Without ``?lang=`` the originally assigned language variant is returned
+    (backward-compatible default behaviour).
+  * ``?lang=de`` returns the German variant's title/description when a document
+    with the same ``external_id`` and ``language="de"`` exists in the DB.
+  * Falls back to English (then ``de``) when the requested language variant is
+    absent, matching the ``_lang_chain`` fallback order.
+  * Completion logs are always queried against the originally assigned document,
+    so existing completion dates are not lost when a language variant is swapped
+    in for display.
+  * Interventions without an ``external_id`` are served as-is; ``?lang=`` is
+    silently ignored and no error is raised.
+
+Background
+  The frontend calls LibreTranslate to auto-translate intervention titles that
+  are not in the patient's UI language.  Machine translations are sometimes
+  incorrect (e.g. "Medication Reminder" → "Medizinische Erinnerung" instead of
+  "Medikamentenerinnerung").  By returning the correct language variant from the
+  DB, LibreTranslate detects a source == target match and skips translation,
+  showing the human-curated title instead.
+
 Framework: Django Test Client + pytest + mongomock
 """
 
@@ -1333,3 +1354,167 @@ def test_get_patient_plan_unknown_id_returns_404(mongo_mock):
     )
     assert resp.status_code == 404
     assert "Patient not found" in resp.json().get("error", "")
+
+
+# ===========================================================================
+# ?lang= language-variant selection in get_patient_plan
+# ===========================================================================
+
+
+def _setup_plan_with_multilang_intervention():
+    """
+    Creates a patient + plan where the assigned intervention is the English
+    variant, but a German variant (same external_id) also exists in the DB.
+    Returns (patient, en_intervention, de_intervention).
+    """
+    patient, therapist, en_intervention, _ = setup_patient_with_plan()
+
+    de_intervention = Intervention(
+        title="Dehnübungen",
+        description="Dehnübungen Beschreibung",
+        content_type="Video",
+        external_id="INT_STRETCH_001",  # same external_id as the EN variant
+        language="de",
+    ).save()
+
+    return patient, en_intervention, de_intervention
+
+
+def test_get_patient_plan_without_lang_returns_assigned_variant(mongo_mock):
+    """
+    Without ?lang= the endpoint returns the originally assigned language variant
+    (English), preserving the existing behaviour.
+    """
+    patient, en_intervention, _ = _setup_plan_with_multilang_intervention()
+
+    resp = client.get(
+        f"/api/patients/rehabilitation-plan/patient/{patient.userId.id}/",
+        HTTP_AUTHORIZATION="Bearer test",
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data) == 1
+
+    row = data[0]
+    assert row["intervention_title"] == "Stretching"
+    assert row["intervention"]["title"] == "Stretching"
+    # intervention_id must still point to the assigned (EN) document
+    assert row["intervention_id"] == str(en_intervention.id)
+
+
+def test_get_patient_plan_lang_de_returns_german_variant(mongo_mock):
+    """
+    With ?lang=de the endpoint substitutes the German variant for display
+    fields (title, description) while intervention_id stays as the originally
+    assigned document so completion logs resolve correctly.
+    """
+    patient, en_intervention, de_intervention = _setup_plan_with_multilang_intervention()
+
+    resp = client.get(
+        f"/api/patients/rehabilitation-plan/patient/{patient.userId.id}/?lang=de",
+        HTTP_AUTHORIZATION="Bearer test",
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data) == 1
+
+    row = data[0]
+    # Display fields come from the DE variant
+    assert row["intervention_title"] == "Dehnübungen"
+    assert row["intervention"]["title"] == "Dehnübungen"
+    # intervention_id must remain the originally assigned EN document
+    assert row["intervention_id"] == str(en_intervention.id)
+
+
+def test_get_patient_plan_lang_fallback_to_en_when_no_variant(mongo_mock):
+    """
+    With ?lang=fr when no French variant exists, the endpoint falls back to the
+    English variant (next in the fallback chain: fr → en → de).
+    """
+    patient, en_intervention, _ = _setup_plan_with_multilang_intervention()
+
+    resp = client.get(
+        f"/api/patients/rehabilitation-plan/patient/{patient.userId.id}/?lang=fr",
+        HTTP_AUTHORIZATION="Bearer test",
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data) == 1
+
+    row = data[0]
+    # No FR variant exists, falls back to EN
+    assert row["intervention_title"] == "Stretching"
+    assert row["intervention_id"] == str(en_intervention.id)
+
+
+def test_get_patient_plan_lang_de_completion_logs_use_assigned_intervention(mongo_mock):
+    """
+    Even when ?lang=de swaps the display variant, completion logs are still
+    fetched against the originally assigned (EN) document, so existing
+    completion dates are not lost.
+    """
+    patient, en_intervention, de_intervention = _setup_plan_with_multilang_intervention()
+    rehab_plan = RehabilitationPlan.objects(patientId=patient).first()
+
+    # Store a log against the EN intervention (the assigned one)
+    PatientInterventionLogs(
+        userId=patient,
+        interventionId=en_intervention,
+        rehabilitationPlanId=rehab_plan,
+        date=_mk_dt_aware(days_offset=0, hour=9),
+        status=["completed"],
+        feedback=[],
+        comments="",
+    ).save()
+
+    resp = client.get(
+        f"/api/patients/rehabilitation-plan/patient/{patient.userId.id}/?lang=de",
+        HTTP_AUTHORIZATION="Bearer test",
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data) == 1
+
+    row = data[0]
+    # Display title is German
+    assert row["intervention_title"] == "Dehnübungen"
+    # But the completion date logged against the EN variant is still visible
+    today_key = timezone.localdate().isoformat()
+    assert today_key in row["completion_dates"]
+
+
+def test_get_patient_plan_lang_param_ignored_for_intervention_without_external_id(mongo_mock):
+    """
+    If an intervention has no external_id (edge case), ?lang= is silently
+    ignored and the assigned document is returned as-is.
+    """
+    patient, _, _, _ = setup_patient_with_plan()
+
+    # Patch the assigned intervention to have no external_id
+    intervention_no_ext = Intervention(
+        title="No External ID",
+        description="",
+        content_type="Video",
+        external_id="",   # empty external_id — variant lookup will skip
+        language="en",
+    ).save()
+
+    rehab_plan = RehabilitationPlan.objects(patientId=patient).first()
+    # Add a second assignment for the no-ext intervention
+    rehab_plan.interventions.append(
+        InterventionAssignment(
+            interventionId=intervention_no_ext,
+            frequency="Weekly",
+            notes="",
+            dates=[],
+        )
+    )
+    rehab_plan.save()
+
+    resp = client.get(
+        f"/api/patients/rehabilitation-plan/patient/{patient.userId.id}/?lang=de",
+        HTTP_AUTHORIZATION="Bearer test",
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data) == 2  # both assignments returned without error

--- a/frontend/src/stores/patientInterventionsStore.ts
+++ b/frontend/src/stores/patientInterventionsStore.ts
@@ -87,10 +87,9 @@ class PatientInterventionsStore {
 
     try {
       const lang = (uiLang || 'en').slice(0, 2);
-      const { data } = await apiClient.get(
-        `/patients/rehabilitation-plan/patient/${patientId}/`,
-        { params: { lang } }
-      );
+      const { data } = await apiClient.get(`/patients/rehabilitation-plan/patient/${patientId}/`, {
+        params: { lang },
+      });
       const list = asArray<any>(data);
 
       const translated: PatientRec[] = await Promise.all(

--- a/frontend/src/stores/patientInterventionsStore.ts
+++ b/frontend/src/stores/patientInterventionsStore.ts
@@ -86,10 +86,12 @@ class PatientInterventionsStore {
     this.clearError();
 
     try {
-      const { data } = await apiClient.get(`/patients/rehabilitation-plan/patient/${patientId}/`);
-      const list = asArray<any>(data);
-
       const lang = (uiLang || 'en').slice(0, 2);
+      const { data } = await apiClient.get(
+        `/patients/rehabilitation-plan/patient/${patientId}/`,
+        { params: { lang } }
+      );
+      const list = asArray<any>(data);
 
       const translated: PatientRec[] = await Promise.all(
         list.map(async (row: any) => {


### PR DESCRIPTION
## Summary

- Add optional `?lang=<ISO 639-1>` query parameter to `GET /api/patients/rehabilitation-plan/patient/<id>/`. When supplied, the endpoint looks up the best available language variant of each intervention (same `external_id`, preferred language → `en` → `de` → any) and returns that variant's title and description instead of the originally assigned document's.
- `intervention_id` in every response row always remains the originally assigned document's ID, so completion logs posted by the frontend continue to resolve correctly.
- Frontend `patientInterventionsStore.fetchPlan` now passes `?lang=<uiLang>` with every plan request. When the backend returns a title already in the user's language, LibreTranslate detects source == target and skips auto-translation, surfacing the human-curated title instead of a machine-generated one (e.g. "Medikamentenerinnerung" instead of "Medizinische Erinnerung").

## Background

The frontend auto-translates intervention titles via LibreTranslate when the stored language does not match the user's UI language. Machine translations are sometimes incorrect — "Medication Reminder" was being rendered as "Medizinische Erinnerung" in German instead of "Medikamentenerinnerung". The fix avoids auto-translation entirely for interventions that have a correct language variant stored in the database.

## Changed files

| File | Change |
|---|---|
| `backend/core/views/patient_views.py` | `get_patient_plan`: read `?lang=`, define `_lang_chain` / `_best_variant` helpers, substitute display variant while keeping assigned variant for log queries and `intervention_id` |
| `frontend/src/stores/patientInterventionsStore.ts` | Pass `{ params: { lang } }` to the plan API call |
| `backend/tests/patient_views/test_patient_views.py` | 5 new tests + updated module docstring covering `?lang=` behaviour, fallback chain, log isolation, and edge case (empty `external_id`) |
| `backend/tests/patient_views/TESTING.md` | Updated endpoint table (11 → 16 tests, total 93 → 98), new `?lang=` parameter section with motivation |

## Test plan

- [ ] Patient with UI language set to DE — intervention that has a DE variant in the DB shows correct German title without passing through LibreTranslate
- [ ] Patient with UI language set to FR — intervention with no FR variant falls back to EN title; LibreTranslate still translates as before
- [ ] Completion dates recorded before this change remain visible after the language swap (log lookup still uses the assigned variant)
- [ ] `pytest tests/patient_views/test_patient_views.py -k lang` — all 5 new tests pass
- [ ] Full patient-views test suite — no regressions (`pytest tests/patient_views/ -v`)
