### PR TITLE
Preload and cache patient data

### DIFF
--- a/frontend/src/RootLayout.tsx
+++ b/frontend/src/RootLayout.tsx
@@ -1,12 +1,12 @@
 // src/components/RootLayout.tsx
 import React from 'react';
-import LogoutListener from './LogoutListener';
-import PatientDataBootstrap from './components/PatientDataBootstrap';
+import LogoutListener from '@/LogoutListener';
+import PatientDataBootstrap from '@/components/PatientDataBootstrap';
 
 const RootLayout: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   return (
     <>
-      <LogoutListener /> {/* ✅ Listener is now always active */}
+      <LogoutListener />
       <PatientDataBootstrap />
       {children}
     </>

--- a/frontend/src/RootLayout.tsx
+++ b/frontend/src/RootLayout.tsx
@@ -1,11 +1,13 @@
 // src/components/RootLayout.tsx
 import React from 'react';
 import LogoutListener from './LogoutListener';
+import PatientDataBootstrap from './components/PatientDataBootstrap';
 
 const RootLayout: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   return (
     <>
       <LogoutListener /> {/* ✅ Listener is now always active */}
+      <PatientDataBootstrap />
       {children}
     </>
   );

--- a/frontend/src/__tests__/PatientDataBootstrap.test.tsx
+++ b/frontend/src/__tests__/PatientDataBootstrap.test.tsx
@@ -1,0 +1,100 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import PatientDataBootstrap from '@/components/PatientDataBootstrap';
+
+jest.mock('@/api/client', () => require('@/__mocks__/api/client'));
+
+const mockInitPatientData = jest.fn();
+const mockResetPatientDataInit = jest.fn();
+
+jest.mock('@/services/patientDataService', () => ({
+  initPatientData: (...args: unknown[]) => mockInitPatientData(...args),
+  resetPatientDataInit: () => mockResetPatientDataInit(),
+}));
+
+// Auth store mock: object defined inside factory, mutated via jest.requireMock
+jest.mock('@/stores/authStore', () => ({
+  __esModule: true,
+  default: { isAuthenticated: false, userType: '', id: '' },
+}));
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ i18n: { language: 'en' } }),
+}));
+
+// mobx-react-lite observer is a passthrough in tests
+jest.mock('mobx-react-lite', () => ({
+  observer: (c: unknown) => c,
+}));
+
+// Shorthand to grab the mutable auth state at runtime (avoids hoist TDZ issue)
+const getAuthState = () =>
+  jest.requireMock('@/stores/authStore').default as {
+    isAuthenticated: boolean;
+    userType: string;
+    id: string;
+  };
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  const s = getAuthState();
+  s.isAuthenticated = false;
+  s.userType = '';
+  s.id = '';
+});
+
+describe('PatientDataBootstrap', () => {
+  it('calls initPatientData when authenticated Patient with id', () => {
+    const s = getAuthState();
+    s.isAuthenticated = true;
+    s.userType = 'Patient';
+    s.id = 'patient-1';
+
+    render(<PatientDataBootstrap />);
+
+    expect(mockInitPatientData).toHaveBeenCalledWith('patient-1', 'en');
+    expect(mockResetPatientDataInit).not.toHaveBeenCalled();
+  });
+
+  it('calls resetPatientDataInit when not authenticated', () => {
+    getAuthState().isAuthenticated = false;
+
+    render(<PatientDataBootstrap />);
+
+    expect(mockResetPatientDataInit).toHaveBeenCalled();
+    expect(mockInitPatientData).not.toHaveBeenCalled();
+  });
+
+  it('does not call initPatientData for non-Patient user types', () => {
+    const s = getAuthState();
+    s.isAuthenticated = true;
+    s.userType = 'Therapist';
+    s.id = 'therapist-1';
+
+    render(<PatientDataBootstrap />);
+
+    expect(mockInitPatientData).not.toHaveBeenCalled();
+  });
+
+  it('does not call initPatientData when id is empty', () => {
+    const s = getAuthState();
+    s.isAuthenticated = true;
+    s.userType = 'Patient';
+    s.id = '';
+
+    render(<PatientDataBootstrap />);
+
+    expect(mockInitPatientData).not.toHaveBeenCalled();
+  });
+
+  it('renders nothing', () => {
+    const s = getAuthState();
+    s.isAuthenticated = true;
+    s.userType = 'Patient';
+    s.id = 'patient-1';
+
+    const { container } = render(<PatientDataBootstrap />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/frontend/src/__tests__/RootLayout.test.tsx
+++ b/frontend/src/__tests__/RootLayout.test.tsx
@@ -8,6 +8,9 @@ jest.mock('@/LogoutListener', () => () => (
   <div data-testid="logout-listener-mock">LogoutListener Active</div>
 ));
 
+// Mock PatientDataBootstrap — it is a null-render side-effect component
+jest.mock('@/components/PatientDataBootstrap', () => () => null);
+
 describe('RootLayout', () => {
   it('renders LogoutListener and children', () => {
     render(

--- a/frontend/src/__tests__/pages/PatientProfile.test.tsx
+++ b/frontend/src/__tests__/pages/PatientProfile.test.tsx
@@ -89,16 +89,6 @@ jest.mock('@/components/Layout', () => ({
   default: require('@/__mocks__/components/Layout').default,
 }));
 
-// Mock HelpCenter
-jest.mock('@/components/help/HelpCenter', () => ({
-  __esModule: true,
-  default: ({ open, onClose }: { open: boolean; onClose: () => void }) => (
-    <div data-testid="help-center" data-open={open}>
-      <button onClick={onClose}>Close Help</button>
-    </div>
-  ),
-}));
-
 // Mock FitbitConnectButton
 jest.mock('@/components/PatientPage/FitbitStatus', () => ({
   __esModule: true,
@@ -234,9 +224,10 @@ describe('PatientProfile - General UI', () => {
 
   it('renders all patient profile sections', () => {
     renderPatientProfile();
-    expect(screen.getByText('Notifications')).toBeInTheDocument();
     expect(screen.getByText('Language')).toBeInTheDocument();
-    expect(screen.getAllByText('Help')[0]).toBeInTheDocument(); // Title
+    expect(screen.getByText('Notifications')).toBeInTheDocument();
+    expect(screen.getByText('Fitness Tracker')).toBeInTheDocument();
+    expect(screen.getByText('Contact')).toBeInTheDocument();
   });
 
   it('shows logout button when authenticated', () => {
@@ -272,14 +263,6 @@ describe('PatientProfile - General UI', () => {
     await waitFor(() => {
       expect(mockAuthStore.logout).toHaveBeenCalled();
     });
-  });
-
-  it('opens help center when help button is clicked', () => {
-    renderPatientProfile();
-    fireEvent.click(screen.getByText('Help'));
-
-    const helpCenter = screen.getByTestId('help-center');
-    expect(helpCenter).toHaveAttribute('data-open', 'true');
   });
 });
 

--- a/frontend/src/__tests__/pages/PatientProfile.test.tsx
+++ b/frontend/src/__tests__/pages/PatientProfile.test.tsx
@@ -228,6 +228,7 @@ describe('PatientProfile - General UI', () => {
     expect(screen.getByText('Notifications')).toBeInTheDocument();
     expect(screen.getByText('Fitness Tracker')).toBeInTheDocument();
     expect(screen.getByText('Contact')).toBeInTheDocument();
+    expect(screen.getByText('Logout')).toBeInTheDocument();
   });
 
   it('shows logout button when authenticated', () => {

--- a/frontend/src/__tests__/pages/PatientView.test.tsx
+++ b/frontend/src/__tests__/pages/PatientView.test.tsx
@@ -273,7 +273,6 @@ describe('PatientView', () => {
   it('loads critical patient home data on mount', async () => {
     const fitbitStore = getFitbitStore();
     const questionnairesStore = getQuestionnairesStore();
-    const vitalsStore = getVitalsStore();
     const interventionsStore = getInterventionsStore();
 
     render(<PatientView />);
@@ -284,7 +283,6 @@ describe('PatientView', () => {
       expect(interventionsStore.fetchPlan).toHaveBeenCalledWith('p1', 'en');
       expect(questionnairesStore.checkInitialQuestionnaire).toHaveBeenCalledWith('p1');
       expect(questionnairesStore.loadHealthQuestionnaire).toHaveBeenCalledWith('p1', 'en');
-      expect(vitalsStore.checkExists).toHaveBeenCalledWith('p1');
     });
   });
 

--- a/frontend/src/__tests__/patientDataService.test.ts
+++ b/frontend/src/__tests__/patientDataService.test.ts
@@ -1,0 +1,118 @@
+import { initPatientData, resetPatientDataInit } from '@/services/patientDataService';
+
+jest.mock('@/api/client', () => require('@/__mocks__/api/client'));
+
+const mockFetchStatus = jest.fn();
+const mockFetchSummary = jest.fn();
+const mockFetchPlan = jest.fn();
+const mockFetchAll = jest.fn();
+const mockFetchCombinedHistoryForPatient = jest.fn();
+
+jest.mock('@/stores/patientFitbitStore', () => ({
+  patientFitbitStore: {
+    fetchStatus: (...args: unknown[]) => mockFetchStatus(...args),
+    fetchSummary: (...args: unknown[]) => mockFetchSummary(...args),
+  },
+}));
+
+jest.mock('@/stores/patientInterventionsStore', () => ({
+  patientInterventionsStore: {
+    fetchPlan: (...args: unknown[]) => mockFetchPlan(...args),
+  },
+}));
+
+jest.mock('@/stores/interventionsLibraryStore', () => ({
+  patientInterventionsLibraryStore: {
+    fetchAll: (...args: unknown[]) => mockFetchAll(...args),
+  },
+}));
+
+jest.mock('@/stores/healthPageStore', () => ({
+  healthPageStore: {
+    fetchCombinedHistoryForPatient: (...args: unknown[]) =>
+      mockFetchCombinedHistoryForPatient(...args),
+  },
+}));
+
+jest.mock('@/hooks/usePatientProcess', () => ({
+  getDateWindow: (filter: string) =>
+    filter === 'week'
+      ? { from: '2026-04-05', to: '2026-04-11' }
+      : { from: '2026-03-13', to: '2026-04-11' },
+}));
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  resetPatientDataInit();
+});
+
+describe('initPatientData', () => {
+  it('fires all store fetches with correct arguments', () => {
+    initPatientData('patient-1', 'de');
+
+    expect(mockFetchStatus).toHaveBeenCalledWith('patient-1');
+    expect(mockFetchSummary).toHaveBeenCalledWith('patient-1', 7);
+    expect(mockFetchSummary).toHaveBeenCalledWith('patient-1', 30);
+    expect(mockFetchPlan).toHaveBeenCalledWith('patient-1', 'de');
+    expect(mockFetchAll).toHaveBeenCalledWith({ mode: 'patient', lang: 'de' });
+    expect(mockFetchCombinedHistoryForPatient).toHaveBeenCalledWith(
+      'patient-1',
+      '2026-04-05',
+      '2026-04-11'
+    );
+    expect(mockFetchCombinedHistoryForPatient).toHaveBeenCalledWith(
+      'patient-1',
+      '2026-03-13',
+      '2026-04-11'
+    );
+  });
+
+  it('slices lang to 2 chars for fetchAll', () => {
+    initPatientData('patient-1', 'de-CH');
+
+    expect(mockFetchAll).toHaveBeenCalledWith({ mode: 'patient', lang: 'de' });
+    // fetchPlan and loadHealthQuestionnaire receive the full lang string
+    expect(mockFetchPlan).toHaveBeenCalledWith('patient-1', 'de-CH');
+  });
+
+  it('is a no-op when called a second time with the same patientId', () => {
+    initPatientData('patient-1', 'en');
+    initPatientData('patient-1', 'en');
+
+    expect(mockFetchStatus).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-fires after resetPatientDataInit', () => {
+    initPatientData('patient-1', 'en');
+    resetPatientDataInit();
+    initPatientData('patient-1', 'en');
+
+    expect(mockFetchStatus).toHaveBeenCalledTimes(2);
+  });
+
+  it('fires for a different patientId without reset', () => {
+    initPatientData('patient-1', 'en');
+    initPatientData('patient-2', 'en');
+
+    expect(mockFetchStatus).toHaveBeenCalledWith('patient-1');
+    expect(mockFetchStatus).toHaveBeenCalledWith('patient-2');
+    expect(mockFetchStatus).toHaveBeenCalledTimes(2);
+  });
+
+  it('does nothing when patientId is empty', () => {
+    initPatientData('', 'en');
+
+    expect(mockFetchStatus).not.toHaveBeenCalled();
+  });
+});
+
+describe('resetPatientDataInit', () => {
+  it('allows initPatientData to fire again for the same id', () => {
+    initPatientData('patient-1', 'en');
+    expect(mockFetchStatus).toHaveBeenCalledTimes(1);
+
+    resetPatientDataInit();
+    initPatientData('patient-1', 'en');
+    expect(mockFetchStatus).toHaveBeenCalledTimes(2);
+  });
+});

--- a/frontend/src/__tests__/stores/authStore.test.ts
+++ b/frontend/src/__tests__/stores/authStore.test.ts
@@ -5,6 +5,7 @@ jest.mock('@/api/client', () => require('@/__mocks__/api/client'));
 
 describe('authStore', () => {
   beforeEach(() => {
+    sessionStorage.clear();
     localStorage.clear();
     jest.clearAllMocks();
     authStore.reset();
@@ -30,6 +31,11 @@ describe('authStore', () => {
   });
 
   it('logs out and resets state', async () => {
+    localStorage.setItem('authToken', 'tok');
+    localStorage.setItem('i18nextLng', 'de');
+    localStorage.setItem('notifications-enabled', 'true');
+    sessionStorage.setItem('healthPageStore', '{"key":"value"}');
+
     authStore.setId('1');
     authStore.setFirstName('Name');
     const callback = jest.fn();
@@ -39,6 +45,16 @@ describe('authStore', () => {
 
     expect(authStore.firstName).toBe('');
     expect(callback).toHaveBeenCalled();
+
+    // sessionStorage must be fully cleared
+    expect(sessionStorage.length).toBe(0);
+
+    // auth keys must be gone from localStorage
+    expect(localStorage.getItem('authToken')).toBeNull();
+
+    // language and notification prefs must be preserved
+    expect(localStorage.getItem('i18nextLng')).toBe('de');
+    expect(localStorage.getItem('notifications-enabled')).toBe('true');
   });
 
   it('restores session if session is still valid', () => {

--- a/frontend/src/__tests__/stores/authStore.test.ts
+++ b/frontend/src/__tests__/stores/authStore.test.ts
@@ -48,10 +48,8 @@ describe('authStore', () => {
 
     // sessionStorage must be fully cleared
     expect(sessionStorage.length).toBe(0);
-
     // auth keys must be gone from localStorage
     expect(localStorage.getItem('authToken')).toBeNull();
-
     // language and notification prefs must be preserved
     expect(localStorage.getItem('i18nextLng')).toBe('de');
     expect(localStorage.getItem('notifications-enabled')).toBe('true');

--- a/frontend/src/components/PatientDataBootstrap.tsx
+++ b/frontend/src/components/PatientDataBootstrap.tsx
@@ -1,0 +1,22 @@
+import { useEffect } from 'react';
+import { observer } from 'mobx-react-lite';
+import { useTranslation } from 'react-i18next';
+import authStore from '@/stores/authStore';
+import { initPatientData, resetPatientDataInit } from '@/services/patientDataService';
+
+const PatientDataBootstrap: React.FC = observer(() => {
+  const { i18n } = useTranslation();
+  const { isAuthenticated, userType, id } = authStore;
+
+  useEffect(() => {
+    if (!isAuthenticated) {
+      resetPatientDataInit();
+    } else if (userType === 'Patient' && id) {
+      initPatientData(id, i18n.language);
+    }
+  }, [isAuthenticated, userType, id, i18n.language]);
+
+  return null;
+});
+
+export default PatientDataBootstrap;

--- a/frontend/src/components/PatientPage/ActivitySection.tsx
+++ b/frontend/src/components/PatientPage/ActivitySection.tsx
@@ -101,7 +101,9 @@ const ActivitySection: React.FC<ActivitySectionProps> = ({
 
           <div className="flex items-end">
             <div className="flex-1">
-              <div className="font-bold text-[28px] text-zinc-900 leading-[110%] tracking-[-1.1%]">{stepsToday || '--'}</div>
+              <div className="font-bold text-[28px] text-zinc-900 leading-[110%] tracking-[-1.1%]">
+                {stepsToday || '--'}
+              </div>
               <div className="font-medium text-sm text-zinc-500">
                 {t('Goal')}: {stepsGoal || '--'}
               </div>

--- a/frontend/src/components/PatientPage/ActivitySection.tsx
+++ b/frontend/src/components/PatientPage/ActivitySection.tsx
@@ -101,7 +101,7 @@ const ActivitySection: React.FC<ActivitySectionProps> = ({
 
           <div className="flex items-end">
             <div className="flex-1">
-              <div className="font-bold text-[28px] text-zinc-900">{stepsToday || '--'}</div>
+              <div className="font-bold text-[28px] text-zinc-900 leading-[110%] tracking-[-1.1%]">{stepsToday || '--'}</div>
               <div className="font-medium text-sm text-zinc-500">
                 {t('Goal')}: {stepsGoal || '--'}
               </div>
@@ -146,7 +146,7 @@ const ActivitySection: React.FC<ActivitySectionProps> = ({
                 </div>
               </div>
               <div>
-                <div className="font-bold text-[28px] text-zinc-900">
+                <div className="font-bold text-[28px] text-zinc-900 leading-[110%] tracking-[-1.1%]">
                   {formatMinutesToHM(activeMinutes)}
                 </div>
                 <div className="font-medium text-sm text-zinc-500">
@@ -163,7 +163,7 @@ const ActivitySection: React.FC<ActivitySectionProps> = ({
                 </div>
               </div>
               <div>
-                <div className="font-bold text-[28px] text-zinc-900">
+                <div className="font-bold text-[28px] text-zinc-900 leading-[110%] tracking-[-1.1%]">
                   {formatMinutesToHM(sleepMinutes)}
                 </div>
                 <div className="font-medium text-sm text-zinc-500">

--- a/frontend/src/components/PatientPage/HealthCheckInSection.tsx
+++ b/frontend/src/components/PatientPage/HealthCheckInSection.tsx
@@ -65,7 +65,7 @@ const HealthCheckInSection: React.FC<HealthCheckInSectionProps> = ({
             </div>
           </div>
 
-          <div className="font-bold text-[28px] text-zinc-900">
+          <div className="font-bold text-[28px] text-zinc-900 leading-[110%] tracking-[-1.1%]">
             {weightKg || '--'} {t('WeightUnit').toLocaleLowerCase()}
           </div>
         </div>
@@ -89,7 +89,7 @@ const HealthCheckInSection: React.FC<HealthCheckInSectionProps> = ({
             </div>
           </div>
 
-          <div className="font-bold text-[28px] text-zinc-900">
+          <div className="font-bold text-[28px] text-zinc-900 leading-[110%] tracking-[-1.1%]">
             {bpSys || '--'}
             <br />/{bpDia || '--'} mmHg
           </div>

--- a/frontend/src/components/PatientPage/InterventionItem.tsx
+++ b/frontend/src/components/PatientPage/InterventionItem.tsx
@@ -59,7 +59,9 @@ const InterventionItem: React.FC<InterventionItemProps> = ({
               <span aria-label={t('Duration')}>{duration}</span>min
             </div>
           )}
-          <div className="font-bold font-lg leading-5 text-zinc-800 break-words">{title}</div>
+          <div className="font-bold font-lg leading-5 text-zinc-800 break-words lg:line-clamp-2">
+            {title}
+          </div>
         </div>
       </div>
       <div

--- a/frontend/src/components/PatientPage/ManualBloodPressureSheet.tsx
+++ b/frontend/src/components/PatientPage/ManualBloodPressureSheet.tsx
@@ -66,45 +66,47 @@ const ManualBloodPressureSheet: React.FC<ManualBloodPressureSheetProps> = ({
           <SheetDescription>{dateLabel}</SheetDescription>
         </SheetHeader>
 
-        <div className="flex-1 flex flex-col gap-4 items-center justify-center">
-          <Field className="w-fit gap-1">
-            <FieldLabel htmlFor="systolic" className="font-medium text-lg text-zinc-600">
-              {t('Systolic (mmHg)')}
-            </FieldLabel>
-            <Input
-              id="systolic"
-              type="number"
-              inputMode="numeric"
-              step="1"
-              min="60"
-              max="250"
-              placeholder="120"
-              onChange={(e) => setBpSysInput(e.target.value)}
-              className="h-20 !w-[200px] rounded-3xl border-none bg-zinc-100 py-1 px-6 font-medium !text-4xl placeholder:text-zinc-300 shadow-none"
-            />
-            <FieldDescription className="text-sm text-zinc-500">
-              {t('systolicHint')}
-            </FieldDescription>
-          </Field>
-          <Field className="w-fit gap-1">
-            <FieldLabel htmlFor="diastolic" className="font-medium text-lg text-zinc-600">
-              {t('Diastolic (mmHg)')}
-            </FieldLabel>
-            <Input
-              id="diastolic"
-              type="number"
-              inputMode="numeric"
-              step="1"
-              min="40"
-              max="150"
-              placeholder="80"
-              onChange={(e) => setBpDiaInput(e.target.value)}
-              className="h-20 !w-[200px] rounded-3xl border-none bg-zinc-100 py-1 px-6 font-medium !text-4xl placeholder:text-zinc-300 shadow-none"
-            />
-            <FieldDescription className="text-sm text-zinc-500">
-              {t('diastolicHint')}
-            </FieldDescription>
-          </Field>
+        <div className="flex-1 flex flex-col items-center justify-center">
+          <div className="flex flex-col gap-4">
+            <Field className="w-fit gap-1">
+              <FieldLabel htmlFor="systolic" className="font-medium text-lg text-zinc-600">
+                {t('Systolic (mmHg)')}
+              </FieldLabel>
+              <Input
+                id="systolic"
+                type="number"
+                inputMode="numeric"
+                step="1"
+                min="60"
+                max="250"
+                placeholder="120"
+                onChange={(e) => setBpSysInput(e.target.value)}
+                className="h-20 !w-[200px] rounded-3xl border-none bg-zinc-100 py-1 px-6 font-medium !text-4xl placeholder:text-zinc-300 shadow-none"
+              />
+              <FieldDescription className="text-sm text-zinc-500">
+                {t('systolicHint')}
+              </FieldDescription>
+            </Field>
+            <Field className="w-fit gap-1">
+              <FieldLabel htmlFor="diastolic" className="font-medium text-lg text-zinc-600">
+                {t('Diastolic (mmHg)')}
+              </FieldLabel>
+              <Input
+                id="diastolic"
+                type="number"
+                inputMode="numeric"
+                step="1"
+                min="40"
+                max="150"
+                placeholder="80"
+                onChange={(e) => setBpDiaInput(e.target.value)}
+                className="h-20 !w-[200px] rounded-3xl border-none bg-zinc-100 py-1 px-6 font-medium !text-4xl placeholder:text-zinc-300 shadow-none"
+              />
+              <FieldDescription className="text-sm text-zinc-500">
+                {t('diastolicHint')}
+              </FieldDescription>
+            </Field>
+          </div>
         </div>
 
         {error && <Alert variant="danger">{t(error)}</Alert>}

--- a/frontend/src/components/PatientProcess/BloodPressureCard.tsx
+++ b/frontend/src/components/PatientProcess/BloodPressureCard.tsx
@@ -53,7 +53,7 @@ const BloodPressureCard: React.FC<Props> = ({
 
       <div className="flex items-end">
         <div className="flex-1">
-          <div className="font-bold text-[28px] text-zinc-900">
+          <div className="font-bold text-[28px] text-zinc-900 leading-[110%] tracking-[-1.1%]">
             {bpSys !== null ? bpSys : '--'}
             <br />/{bpDia !== null ? bpDia : '--'} mmHg
           </div>

--- a/frontend/src/components/PatientProcess/MetricBarCard.tsx
+++ b/frontend/src/components/PatientProcess/MetricBarCard.tsx
@@ -49,7 +49,9 @@ const MetricBarCard: React.FC<Props> = ({
 
       <div className="flex items-end">
         <div className="flex-1">
-          <div className="font-bold text-[28px] text-zinc-900">{average}</div>
+          <div className="font-bold text-[28px] text-zinc-900 leading-[110%] tracking-[-1.1%]">
+            {average}
+          </div>
         </div>
 
         <div className="flex-1">

--- a/frontend/src/components/PatientProcess/RecommendationsCard.tsx
+++ b/frontend/src/components/PatientProcess/RecommendationsCard.tsx
@@ -34,7 +34,7 @@ const RecommendationsCard: React.FC<Props> = ({
 
       <div className="flex items-end">
         <div className="flex-1">
-          <div className="font-bold text-[28px] text-zinc-900">
+          <div className="font-bold text-[28px] text-zinc-900 leading-[110%] tracking-[-1.1%]">
             {recommendationsPct !== null ? `${recommendationsPct}%` : '--%'}
           </div>
         </div>

--- a/frontend/src/components/skeletons/PatientPlanSkeleton.tsx
+++ b/frontend/src/components/skeletons/PatientPlanSkeleton.tsx
@@ -18,7 +18,7 @@ export default function PatientPlanSkeleton() {
         </div>
       </div>
 
-      <div className="mt-6 flex flex-col gap-2 lg:grid lg:grid-cols-2 lg:items-start">
+      <div className="mt-6 flex flex-col gap-2 lg:grid lg:grid-cols-3 lg:items-start">
         {Array.from({ length: 7 }).map((_, dayIndex) => (
           <Section key={dayIndex}>
             <div className="flex p-2 pl-4 justify-between w-full">

--- a/frontend/src/components/skeletons/PatientProfileSkeleton.tsx
+++ b/frontend/src/components/skeletons/PatientProfileSkeleton.tsx
@@ -60,7 +60,7 @@ export default function PatientProfileSkeleton() {
         <Skeleton className="h-[40px] w-[160px]" />
       </div>
 
-      <div className="flex flex-col gap-3 mt-16">
+      <div className="flex flex-col gap-1 mt-16">
         <Skeleton className="h-5 w-36" />
         <Skeleton className="h-5 w-28" />
         <Skeleton className="h-5 w-52" />

--- a/frontend/src/components/skeletons/PatientProfileSkeleton.tsx
+++ b/frontend/src/components/skeletons/PatientProfileSkeleton.tsx
@@ -33,31 +33,37 @@ export default function PatientProfileSkeleton() {
         </Section>
 
         <Section>
-          <div className="flex justify-between items-center p-2 pl-4">
+          <div className="p-2 pl-4">
             <Skeleton className="h-7 w-20" />
-            <Skeleton className="h-8 w-20 rounded-full" />
           </div>
 
-          <div className="border border-accent p-4 rounded-3xl flex flex-col items-start gap-3">
-            <div className="flex flex-col gap-1">
-              <Skeleton className="h-6 w-32" />
-              <Skeleton className="h-6 w-48" />
-            </div>
-            <Skeleton className="h-10 w-44 rounded-xl" />
+          <div className="border border-accent p-4 rounded-3xl flex flex-col items-start gap-2">
+            <Skeleton className="h-6 w-48" />
+            <Skeleton className="h-8 w-36 rounded-xl" />
           </div>
         </Section>
 
-        <div className="flex flex-col gap-2">
-          <Section>
-            <Skeleton className="h-14 w-full rounded-full" />
-          </Section>
-
-          <div className="flex flex-col items-center gap-6 mt-4 mb-12 lg:hidden">
-            <Skeleton className="h-[80px] w-[80px]" />
-            <Skeleton className="h-[40px] w-[160px]" />
-            <Skeleton className="h-[40px] w-[160px]" />
-          </div>
+        <div className="flex flex-col items-center gap-6 mt-4 mb-12 lg:hidden">
+          <Skeleton className="h-[50px] w-[80px]" />
+          <Skeleton className="h-[40px] w-[160px]" />
+          <Skeleton className="h-[40px] w-[160px]" />
         </div>
+
+        <Section>
+          <Skeleton className="h-14 w-full rounded-full" />
+        </Section>
+      </div>
+
+      <div className="hidden lg:flex lg:items-end lg:justify-start lg:gap-6 lg:mt-16">
+        <Skeleton className="h-[50px] w-[80px]" />
+        <Skeleton className="h-[40px] w-[160px]" />
+        <Skeleton className="h-[40px] w-[160px]" />
+      </div>
+
+      <div className="flex flex-col gap-3 mt-16">
+        <Skeleton className="h-5 w-36" />
+        <Skeleton className="h-5 w-28" />
+        <Skeleton className="h-5 w-52" />
       </div>
     </Layout>
   );

--- a/frontend/src/hooks/usePatientProcess.ts
+++ b/frontend/src/hooks/usePatientProcess.ts
@@ -141,17 +141,17 @@ export function usePatientProcess() {
   const patientId = localStorage.getItem('id') || authStore.id || '';
 
   const { from, to } = useMemo(() => getDateWindow(processFilter), [processFilter]);
+  const days = processFilter === 'week' ? 7 : 30;
 
   useEffect(() => {
     let alive = true;
 
-    const days = processFilter === 'week' ? 7 : 30;
-
     const loadData = async () => {
       if (!patientId || !isAllowed) return;
+      setLoading(true);
       setError('');
 
-      // Fire both fetches — stores synchronously seed from cache before the network call
+      // Fire both fetches
       const healthPromise = healthPageStore.fetchCombinedHistoryForPatient(patientId, from, to);
       const fitbitPromise = patientFitbitStore.fetchSummary(patientId, days);
 
@@ -159,15 +159,16 @@ export function usePatientProcess() {
       const cachedAdherence = healthPageStore.adherenceData;
       const cachedFitbit =
         patientFitbitStore.summary?.period?.days === days ? patientFitbitStore.summary : null;
+      const hasCachedData = cachedAdherence.length > 0 || !!cachedFitbit;
 
-      if (cachedAdherence.length > 0) setAdherenceItems(cachedAdherence as AdherenceItem[]);
+      if (cachedAdherence.length > 0) {
+        setAdherenceItems(cachedAdherence as AdherenceItem[]);
+      }
       if (cachedFitbit) {
         setFitbitSummary(cachedFitbit as FitbitSummaryResponse | null);
         setThresholds((cachedFitbit.thresholds ?? null) as ThresholdsResponse | null);
       }
       setLoading(cachedAdherence.length === 0 || !cachedFitbit);
-
-      const hasCachedData = cachedAdherence.length > 0 || !!cachedFitbit;
 
       try {
         await Promise.all([healthPromise, fitbitPromise]);
@@ -181,15 +182,6 @@ export function usePatientProcess() {
         setThresholds(
           (patientFitbitStore.summary?.thresholds ?? null) as ThresholdsResponse | null
         );
-
-        // Silently prefetch the alternate filter to warm the cache
-        if (alive) {
-          const otherFilter: ProcessFilter = processFilter === 'week' ? 'month' : 'week';
-          const otherDays = otherFilter === 'week' ? 7 : 30;
-          const { from: otherFrom, to: otherTo } = getDateWindow(otherFilter);
-          void healthPageStore.fetchCombinedHistoryForPatient(patientId, otherFrom, otherTo);
-          void patientFitbitStore.fetchSummary(patientId, otherDays);
-        }
       } catch {
         if (!alive) return;
         if (!hasCachedData) {

--- a/frontend/src/hooks/usePatientProcess.ts
+++ b/frontend/src/hooks/usePatientProcess.ts
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import { usePatientAuthGate } from '@/hooks/usePatientAuthGate';
 import authStore from '@/stores/authStore';
-import HealthPageStore from '@/stores/healthPageStore';
+import { healthPageStore } from '@/stores/healthPageStore';
 import { patientFitbitStore } from '@/stores/patientFitbitStore';
 
 export type ProcessFilter = 'week' | 'month';
@@ -118,7 +118,7 @@ const formatMinutesToHM = (minutes: number | null) => {
   return `${hours}h ${remainingMinutes}min`;
 };
 
-const getDateWindow = (filter: ProcessFilter) => {
+export const getDateWindow = (filter: ProcessFilter) => {
   const days = filter === 'week' ? 7 : 30;
   const to = new Date();
   const from = new Date(to);
@@ -141,45 +141,63 @@ export function usePatientProcess() {
   const patientId = localStorage.getItem('id') || authStore.id || '';
 
   const { from, to } = useMemo(() => getDateWindow(processFilter), [processFilter]);
-  const healthStore = useMemo(() => new HealthPageStore(), []);
 
   useEffect(() => {
     let alive = true;
 
+    const days = processFilter === 'week' ? 7 : 30;
+
     const loadData = async () => {
       if (!patientId || !isAllowed) return;
-
-      setLoading(true);
       setError('');
 
-      try {
-        await Promise.all([
-          healthStore.fetchCombinedHistoryForPatient(patientId, from, to),
-          patientFitbitStore.fetchSummary(patientId, processFilter === 'week' ? 7 : 30),
-        ]);
+      // Fire both fetches — stores synchronously seed from cache before the network call
+      const healthPromise = healthPageStore.fetchCombinedHistoryForPatient(patientId, from, to);
+      const fitbitPromise = patientFitbitStore.fetchSummary(patientId, days);
 
+      // Seed state from cache while fetches are in-flight
+      const cachedAdherence = healthPageStore.adherenceData;
+      const cachedFitbit =
+        patientFitbitStore.summary?.period?.days === days ? patientFitbitStore.summary : null;
+
+      if (cachedAdherence.length > 0) setAdherenceItems(cachedAdherence as AdherenceItem[]);
+      if (cachedFitbit) {
+        setFitbitSummary(cachedFitbit as FitbitSummaryResponse | null);
+        setThresholds((cachedFitbit.thresholds ?? null) as ThresholdsResponse | null);
+      }
+      setLoading(cachedAdherence.length === 0 || !cachedFitbit);
+
+      const hasCachedData = cachedAdherence.length > 0 || !!cachedFitbit;
+
+      try {
+        await Promise.all([healthPromise, fitbitPromise]);
         if (!alive) return;
 
-        const storeError = healthStore.error || patientFitbitStore.error;
-        if (storeError) {
-          setAdherenceItems([]);
-          setFitbitSummary(null);
-          setThresholds(null);
-          setError(storeError);
-          return;
-        }
+        const storeError = healthPageStore.error || patientFitbitStore.error;
+        if (storeError) throw storeError;
 
-        setAdherenceItems(healthStore.adherenceData);
+        setAdherenceItems(healthPageStore.adherenceData);
         setFitbitSummary(patientFitbitStore.summary as FitbitSummaryResponse | null);
         setThresholds(
           (patientFitbitStore.summary?.thresholds ?? null) as ThresholdsResponse | null
         );
+
+        // Silently prefetch the alternate filter to warm the cache
+        if (alive) {
+          const otherFilter: ProcessFilter = processFilter === 'week' ? 'month' : 'week';
+          const otherDays = otherFilter === 'week' ? 7 : 30;
+          const { from: otherFrom, to: otherTo } = getDateWindow(otherFilter);
+          void healthPageStore.fetchCombinedHistoryForPatient(patientId, otherFrom, otherTo);
+          void patientFitbitStore.fetchSummary(patientId, otherDays);
+        }
       } catch {
         if (!alive) return;
-        setAdherenceItems([]);
-        setFitbitSummary(null);
-        setThresholds(null);
-        setError(healthStore.error || patientFitbitStore.error || 'Request failed');
+        if (!hasCachedData) {
+          setAdherenceItems([]);
+          setFitbitSummary(null);
+          setThresholds(null);
+        }
+        setError(healthPageStore.error || patientFitbitStore.error || 'Request failed');
       } finally {
         if (alive) setLoading(false);
       }
@@ -190,7 +208,7 @@ export function usePatientProcess() {
     return () => {
       alive = false;
     };
-  }, [patientId, isAllowed, from, to, processFilter, healthStore]);
+  }, [patientId, isAllowed, from, to, processFilter]);
 
   const dailyMetrics = useMemo<DailyMetricsDatum[]>(() => {
     const byDay = new Map<string, Omit<DailyMetricsDatum, 'date'>>();

--- a/frontend/src/hooks/usePatientProcess.ts
+++ b/frontend/src/hooks/usePatientProcess.ts
@@ -148,7 +148,6 @@ export function usePatientProcess() {
 
     const loadData = async () => {
       if (!patientId || !isAllowed) return;
-      setLoading(true);
       setError('');
 
       // Fire both fetches

--- a/frontend/src/hooks/usePatientProcess.ts
+++ b/frontend/src/hooks/usePatientProcess.ts
@@ -1,7 +1,8 @@
 import { useEffect, useMemo, useState } from 'react';
-import apiClient from '@/api/client';
 import { usePatientAuthGate } from '@/hooks/usePatientAuthGate';
 import authStore from '@/stores/authStore';
+import HealthPageStore from '@/stores/healthPageStore';
+import { patientFitbitStore } from '@/stores/patientFitbitStore';
 
 export type ProcessFilter = 'week' | 'month';
 export type BarMetricKey = 'steps' | 'activeMinutes' | 'sleepMinutes';
@@ -140,6 +141,7 @@ export function usePatientProcess() {
   const patientId = localStorage.getItem('id') || authStore.id || '';
 
   const { from, to } = useMemo(() => getDateWindow(processFilter), [processFilter]);
+  const healthStore = useMemo(() => new HealthPageStore(), []);
 
   useEffect(() => {
     let alive = true;
@@ -151,34 +153,33 @@ export function usePatientProcess() {
       setError('');
 
       try {
-        const [combinedHistoryRes, fitbitSummaryRes] = await Promise.all([
-          apiClient.get<CombinedHealthResponse>(`/patients/health-combined-history/${patientId}/`, {
-            params: { from, to },
-          }),
-          apiClient.get<FitbitSummaryResponse>(`/fitbit/summary/${patientId}/`, {
-            params: { days: processFilter === 'week' ? 7 : 30 },
-          }),
+        await Promise.all([
+          healthStore.fetchCombinedHistoryForPatient(patientId, from, to),
+          patientFitbitStore.fetchSummary(patientId, processFilter === 'week' ? 7 : 30),
         ]);
 
         if (!alive) return;
-        setAdherenceItems(
-          Array.isArray(combinedHistoryRes?.data?.adherence)
-            ? combinedHistoryRes.data.adherence
-            : []
-        );
-        setFitbitSummary(fitbitSummaryRes?.data || null);
-        setThresholds(fitbitSummaryRes?.data?.thresholds || null);
-      } catch (err: unknown) {
-        const errObj = err as {
-          response?: { data?: { error?: string; message?: string; detail?: string } };
-        };
-        const msg = errObj?.response?.data;
 
+        const storeError = healthStore.error || patientFitbitStore.error;
+        if (storeError) {
+          setAdherenceItems([]);
+          setFitbitSummary(null);
+          setThresholds(null);
+          setError(storeError);
+          return;
+        }
+
+        setAdherenceItems(healthStore.adherenceData);
+        setFitbitSummary(patientFitbitStore.summary as FitbitSummaryResponse | null);
+        setThresholds(
+          (patientFitbitStore.summary?.thresholds ?? null) as ThresholdsResponse | null
+        );
+      } catch {
         if (!alive) return;
         setAdherenceItems([]);
         setFitbitSummary(null);
         setThresholds(null);
-        setError(String(msg?.error || msg?.message || msg?.detail || 'Request failed'));
+        setError(healthStore.error || patientFitbitStore.error || 'Request failed');
       } finally {
         if (alive) setLoading(false);
       }
@@ -189,7 +190,7 @@ export function usePatientProcess() {
     return () => {
       alive = false;
     };
-  }, [patientId, isAllowed, from, to, processFilter]);
+  }, [patientId, isAllowed, from, to, processFilter, healthStore]);
 
   const dailyMetrics = useMemo<DailyMetricsDatum[]>(() => {
     const byDay = new Map<string, Omit<DailyMetricsDatum, 'date'>>();

--- a/frontend/src/pages/Patient.tsx
+++ b/frontend/src/pages/Patient.tsx
@@ -101,7 +101,6 @@ const PatientView: React.FC = observer(() => {
         patientInterventionsStore.fetchPlan(patientId, i18n.language);
         patientQuestionnairesStore.checkInitialQuestionnaire(patientId);
         patientQuestionnairesStore.loadHealthQuestionnaire(patientId, i18n.language);
-        patientVitalsStore.checkExists(patientId);
       }
 
       setLoading(false);
@@ -152,11 +151,7 @@ const PatientView: React.FC = observer(() => {
         />
 
         <HealthCheckInSection
-          loading={
-            patientFitbitStore.connected === null ||
-            patientFitbitStore.summaryLoading ||
-            patientVitalsStore.loading
-          }
+          loading={patientFitbitStore.connected === null || patientFitbitStore.summaryLoading}
           selectedDateLabel={selectedDateLabel}
           weightKg={patientFitbitStore.summary?.today?.weight_kg}
           bpSys={patientFitbitStore.summary?.today?.bp_sys}

--- a/frontend/src/pages/Patient.tsx
+++ b/frontend/src/pages/Patient.tsx
@@ -187,7 +187,7 @@ const PatientView: React.FC = observer(() => {
           if (patientVitalsStore.error) {
             throw new Error(t('failedSave'));
           }
-          patientFitbitStore.fetchSummary(patientId, 7);
+          patientFitbitStore.fetchSummary(patientId, 7, true);
         }}
       />
 
@@ -203,7 +203,7 @@ const PatientView: React.FC = observer(() => {
           if (patientVitalsStore.error) {
             throw new Error(t('failedSave'));
           }
-          patientFitbitStore.fetchSummary(patientId, 7);
+          patientFitbitStore.fetchSummary(patientId, 7, true);
         }}
       />
 

--- a/frontend/src/pages/PatientPlan.tsx
+++ b/frontend/src/pages/PatientPlan.tsx
@@ -105,7 +105,7 @@ const PatientPlan: React.FC = observer(() => {
       </div>
 
       <div
-        className="flex flex-col gap-2 mt-6 lg:grid lg:grid-cols-2 lg:items-start"
+        className="flex flex-col gap-2 mt-6 lg:grid lg:grid-cols-3 lg:items-start"
         role="region"
         aria-label={t('Weekly interventions')}
       >

--- a/frontend/src/pages/PatientPlan.tsx
+++ b/frontend/src/pages/PatientPlan.tsx
@@ -13,6 +13,8 @@ import { observer } from 'mobx-react-lite';
 import { patientQuestionnairesStore } from '@/stores/patientQuestionnairesStore';
 import FeedbackPopup from '@/components/PatientPage/FeedbackPopup';
 import { getDateFnsLocale } from '@/utils/dateLocale';
+import ArrowLeftIcon from '@/assets/icons/arrow-left-fill.svg?react';
+import ArrowRightIcon from '@/assets/icons/arrow-right-fill.svg?react';
 
 type DayFilter = 'all' | 0 | 1 | 2 | 3 | 4 | 5 | 6;
 
@@ -41,6 +43,14 @@ const PatientPlan: React.FC = observer(() => {
     { value: 5 as const, label: t('Sat') },
     { value: 6 as const, label: t('Sun') },
   ];
+
+  const goToPreviousWeek = () => {
+    patientUiStore.setSelectedDate(addDays(patientUiStore.selectedDate, -7));
+  };
+
+  const goToNextWeek = () => {
+    patientUiStore.setSelectedDate(addDays(patientUiStore.selectedDate, 7));
+  };
 
   // Safe questions array for feedback questionnaire
   const safeInterventionQuestions = Array.isArray(patientQuestionnairesStore.feedbackQuestions)
@@ -77,10 +87,15 @@ const PatientPlan: React.FC = observer(() => {
   return (
     <Layout aria-label={t('Week range and current month')}>
       <div className="flex flex-col lg:flex-row gap-8 justify-between items-start">
-        <PageHeader
-          title={`${format(start, 'dd.MM.')} - ${format(end, 'dd.MM.')}`}
-          subtitle={format(patientUiStore.selectedDate, 'MMMM yyyy', { locale })}
-        />
+        <div className="flex gap-2">
+          <ArrowLeftIcon className="mt-2 h-4 w-4 hover:cursor-pointer" onClick={goToPreviousWeek} />
+          <PageHeader
+            title={`${format(start, 'dd.MM.')} - ${format(end, 'dd.MM.')}`}
+            subtitle={format(patientUiStore.selectedDate, 'MMMM yyyy', { locale })}
+          />
+          <ArrowRightIcon className="mt-2 h-4 w-4 hover:cursor-pointer" onClick={goToNextWeek} />
+        </div>
+
         {/* Day Filter */}
         <div
           className="flex flex-nowrap gap-1 overflow-x-auto overflow-y-hidden no-scrollbar w-full lg:w-auto"

--- a/frontend/src/pages/PatientProfile.tsx
+++ b/frontend/src/pages/PatientProfile.tsx
@@ -26,7 +26,6 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
-import QuestionFill from '@/assets/icons/question-fill.svg?react';
 import LogoutFill from '@/assets/icons/logout-fill.svg?react';
 import Mail from '@/assets/icons/contact/mail.svg?react';
 import Phone from '@/assets/icons/contact/phone.svg?react';

--- a/frontend/src/pages/PatientProfile.tsx
+++ b/frontend/src/pages/PatientProfile.tsx
@@ -247,7 +247,7 @@ const PatientProfile: React.FC = observer(() => {
           ))}
         </div>
 
-        <div className="flex flex-col gap-1 mt-16">
+        <div className="flex flex-col gap-1 mt-16 text-sm text-zinc-500">
           <Link to="/terms">{t('Terms & Conditions')}</Link>
           <Link to="/privacypolicy">{t('Privacy Policy')}</Link>
           <div>

--- a/frontend/src/pages/PatientProfile.tsx
+++ b/frontend/src/pages/PatientProfile.tsx
@@ -65,6 +65,24 @@ const PatientProfile: React.FC = observer(() => {
     nl: 'Nederlands',
   };
 
+  const partnerLogos = [
+    {
+      src: '/artorg_unibern_logo.gif',
+      alt: 'ARTORG Center for Biomedical Engineering Research',
+      className: 'w-[80px]',
+    },
+    {
+      src: '/insel_logo.svg',
+      alt: 'Inselspital - Universitatsspital Bern',
+      className: 'w-[160px]',
+    },
+    {
+      src: '/brz_logo.png',
+      alt: 'Berner Reha Zentrum',
+      className: 'w-[160px]',
+    },
+  ];
+
   const lang = currentLanguage.slice(0, 2);
 
   const handleLanguageChange = (l: string) => {
@@ -210,17 +228,9 @@ const PatientProfile: React.FC = observer(() => {
           </Section>
 
           <div className="flex flex-col items-center gap-6 mt-4 mb-12 lg:hidden">
-            <img
-              src="/artorg_unibern_logo.gif"
-              alt="ARTORG Center for Biomedical Engineering Research"
-              className="w-[80px]"
-            />
-            <img
-              src="/insel_logo.svg"
-              alt="Inselspital - Universitätsspital Bern"
-              className="w-[160px]"
-            />
-            <img src="/brz_logo.png" alt="Berner Reha Zentrum" className="w-[160px]" />
+            {partnerLogos.map((logo) => (
+              <img key={logo.src} src={logo.src} alt={logo.alt} className={logo.className} />
+            ))}
           </div>
 
           <Section>
@@ -229,6 +239,12 @@ const PatientProfile: React.FC = observer(() => {
               <LogoutFill />
             </Button>
           </Section>
+        </div>
+
+        <div className="hidden lg:flex lg:items-end lg:justify-start lg:gap-6 lg:mt-16">
+          {partnerLogos.map((logo) => (
+            <img key={logo.src} src={logo.src} alt={logo.alt} className={logo.className} />
+          ))}
         </div>
 
         <div className="flex flex-col gap-1 mt-16">

--- a/frontend/src/pages/PatientProfile.tsx
+++ b/frontend/src/pages/PatientProfile.tsx
@@ -5,7 +5,6 @@ import Section from '@/components/Section';
 import { useTranslation } from 'react-i18next';
 import { Switch } from '@/components/ui/switch';
 import { Button } from '@/components/ui/button';
-import HelpCenter from '@/components/help/HelpCenter';
 import { Badge } from '@/components/ui/badge';
 import { Skeleton } from '@/components/ui/skeleton';
 import FitbitConnectButton from '@/components/PatientPage/FitbitStatus';
@@ -46,7 +45,6 @@ const PatientProfile: React.FC = observer(() => {
     localStorage.getItem('i18nextLng')?.slice(0, 2) || i18n.language?.slice(0, 2) || 'en';
 
   const [currentLanguage, setCurrentLanguage] = useState(getInitialLang);
-  const [helpOpen, setHelpOpen] = useState(false);
 
   const languages = ['de', 'fr', 'en', 'it', 'pt', 'nl'] as const;
 
@@ -181,16 +179,7 @@ const PatientProfile: React.FC = observer(() => {
           </Section>
 
           <Section>
-            <div className="flex justify-between w-full">
-              <div className="p-2 pl-4 font-medium text-lg text-zinc-500">{t('Contact')}</div>
-              <Badge
-                onClick={() => setHelpOpen(true)}
-                className="font-medium text-zinc-500 rounded-full py-[6px] px-3 border-none bg-zinc-50 shadow-none"
-              >
-                {t('Help')}
-                <QuestionFill className="w-4 h-4 ml-1" />
-              </Badge>
-            </div>
+            <div className="p-2 pl-4 font-medium text-lg text-zinc-500">{t('Contact')}</div>
 
             <div className="border border-accent p-4 rounded-3xl flex flex-col items-start gap-2">
               <div className="font-bold text-lg leading-6 text-zinc-800">
@@ -251,8 +240,6 @@ const PatientProfile: React.FC = observer(() => {
           </div>
         </div>
       </Layout>
-
-      <HelpCenter open={helpOpen} onClose={() => setHelpOpen(false)} />
     </>
   );
 });

--- a/frontend/src/services/patientDataService.ts
+++ b/frontend/src/services/patientDataService.ts
@@ -1,0 +1,29 @@
+import { patientFitbitStore } from '@/stores/patientFitbitStore';
+import { patientInterventionsStore } from '@/stores/patientInterventionsStore';
+import { patientInterventionsLibraryStore } from '@/stores/interventionsLibraryStore';
+import { healthPageStore } from '@/stores/healthPageStore';
+import { getDateWindow } from '@/hooks/usePatientProcess';
+
+let initializedFor: string | null = null;
+
+export function initPatientData(patientId: string, lang: string): void {
+  if (!patientId || initializedFor === patientId) return;
+  initializedFor = patientId;
+
+  const language = (lang || 'en').slice(0, 2);
+  const { from: wFrom, to: wTo } = getDateWindow('week');
+  const { from: mFrom, to: mTo } = getDateWindow('month');
+
+  patientFitbitStore.fetchStatus(patientId);
+  patientFitbitStore.fetchSummary(patientId, 7);
+  patientFitbitStore.fetchSummary(patientId, 30);
+  patientInterventionsStore.fetchPlan(patientId, lang);
+  patientInterventionsLibraryStore.fetchAll({ mode: 'patient', lang: language });
+  healthPageStore.fetchCombinedHistoryForPatient(patientId, wFrom, wTo);
+  healthPageStore.fetchCombinedHistoryForPatient(patientId, mFrom, mTo);
+}
+
+/** Call on logout so the next login re-triggers a fresh fetch. */
+export function resetPatientDataInit(): void {
+  initializedFor = null;
+}

--- a/frontend/src/stores/authStore.ts
+++ b/frontend/src/stores/authStore.ts
@@ -369,7 +369,10 @@ class AuthStore {
     // preserve language and notification settings
     const lang = localStorage.getItem('i18nextLng');
     const notificationsEnabled = localStorage.getItem('notifications-enabled');
+
+    sessionStorage.clear();
     localStorage.clear();
+
     if (lang) localStorage.setItem('i18nextLng', lang);
     if (notificationsEnabled) localStorage.setItem('notifications-enabled', notificationsEnabled);
   }

--- a/frontend/src/stores/healthPageStore.ts
+++ b/frontend/src/stores/healthPageStore.ts
@@ -1,6 +1,7 @@
 // src/stores/healthPageStore.ts
 import { makeAutoObservable, runInAction } from 'mobx';
-import apiClient from '../api/client';
+import apiClient from '@/api/client';
+import { SessionCache } from '@/utils/sessionCache';
 import type {
   FitbitEntry,
   QuestionnaireEntry,
@@ -170,11 +171,11 @@ export class HealthPageStore {
   loading = false;
   error = '';
 
+  private static cache = new SessionCache('healthPageStore');
+
   constructor() {
     makeAutoObservable(this, {}, { autoBind: true });
   }
-
-  private static STORAGE_KEY = 'healthPageStore';
 
   private static saveToSessionStorage(
     cacheKey: string,
@@ -184,52 +185,15 @@ export class HealthPageStore {
       adherenceData: AdherenceEntry[];
     }
   ) {
-    try {
-      const raw = sessionStorage.getItem(HealthPageStore.STORAGE_KEY);
-      let store: Record<string, unknown> = {};
-      try {
-        const parsed = JSON.parse(raw ?? '{}');
-        // migrate old single-entry format
-        if (parsed?.cacheKey) store = {};
-        else if (parsed && typeof parsed === 'object') store = parsed;
-      } catch {
-        /* ignore */
-      }
-      store[cacheKey] = data;
-      // keep at most 4 entries
-      const keys = Object.keys(store);
-      if (keys.length > 4) keys.slice(0, keys.length - 4).forEach((k) => delete store[k]);
-      sessionStorage.setItem(HealthPageStore.STORAGE_KEY, JSON.stringify(store));
-    } catch {
-      // storage quota — ignore
-    }
+    HealthPageStore.cache.set(cacheKey, data);
   }
 
   static loadFromSessionStorage(cacheKey: string) {
-    try {
-      const raw = sessionStorage.getItem(HealthPageStore.STORAGE_KEY);
-      if (!raw) return null;
-      const store = JSON.parse(raw);
-      // new map format
-      if (store?.[cacheKey]) {
-        return store[cacheKey] as {
-          fitbitData: FitbitEntry[];
-          questionnaireData: QuestionnaireEntry[];
-          adherenceData: AdherenceEntry[];
-        };
-      }
-      // old flat format
-      if (store?.cacheKey === cacheKey) {
-        return store as {
-          fitbitData: FitbitEntry[];
-          questionnaireData: QuestionnaireEntry[];
-          adherenceData: AdherenceEntry[];
-        };
-      }
-      return null;
-    } catch {
-      return null;
-    }
+    return HealthPageStore.cache.get<{
+      fitbitData: FitbitEntry[];
+      questionnaireData: QuestionnaireEntry[];
+      adherenceData: AdherenceEntry[];
+    }>(cacheKey);
   }
 
   // ───────────────────────────

--- a/frontend/src/stores/healthPageStore.ts
+++ b/frontend/src/stores/healthPageStore.ts
@@ -320,41 +320,53 @@ export class HealthPageStore {
       return;
     }
 
+    // fetch thresholds in parallel (don't block if it fails)
+    void this.fetchThresholds(userId, t);
+
+    await this.fetchCombinedHistoryForPatient(
+      userId,
+      from.toISOString().slice(0, 10),
+      to.toISOString().slice(0, 10),
+      t
+    );
+  }
+
+  // ───────────────────────────
+  // Fetch combined history by explicit patient ID (patient self-view)
+  // ───────────────────────────
+  async fetchCombinedHistoryForPatient(
+    patientId: string,
+    from: string,
+    to: string,
+    t: (k: string) => string = (k) => k
+  ) {
+    if (!patientId) return;
+
     this.loading = true;
     this.error = '';
 
     try {
-      // fetch thresholds in parallel (don’t block if it fails)
-      void this.fetchThresholds(userId, t);
-
-      const params = {
-        from: from.toISOString().slice(0, 10),
-        to: to.toISOString().slice(0, 10),
-      };
-
       const res = await apiClient.get<CombinedHealthResponseRaw>(
-        `/patients/health-combined-history/${userId}/`,
-        { params }
+        `/patients/health-combined-history/${patientId}/`,
+        { params: { from, to } }
       );
 
       const raw = res.data;
-
       const fitbitRaw = isRecord(raw) ? raw.fitbit : undefined;
       const questionnaireRaw = isRecord(raw) ? raw.questionnaire : undefined;
       const adherenceRaw = isRecord(raw) ? raw.adherence : undefined;
 
-      const normalizedFitbit = normalizeFitbitList(fitbitRaw);
-      const normalizedQuestionnaire = normalizeQuestionnaireList(questionnaireRaw);
-      const normalizedAdherence = normalizeAdherenceList(adherenceRaw);
-
       runInAction(() => {
-        this.fitbitData = normalizedFitbit;
-        this.questionnaireData = normalizedQuestionnaire;
-        this.adherenceData = normalizedAdherence;
+        this.fitbitData = normalizeFitbitList(fitbitRaw);
+        this.questionnaireData = normalizeQuestionnaireList(questionnaireRaw);
+        this.adherenceData = normalizeAdherenceList(adherenceRaw);
         this._rebuildVisibleQuestionsFromData();
       });
     } catch (err: unknown) {
       runInAction(() => {
+        this.fitbitData = [];
+        this.questionnaireData = [];
+        this.adherenceData = [];
         this.error = extractApiErrorMessage(err, t('Failed to load health data.'));
       });
     } finally {

--- a/frontend/src/stores/healthPageStore.ts
+++ b/frontend/src/stores/healthPageStore.ts
@@ -174,6 +174,64 @@ export class HealthPageStore {
     makeAutoObservable(this, {}, { autoBind: true });
   }
 
+  private static STORAGE_KEY = 'healthPageStore';
+
+  private static saveToSessionStorage(
+    cacheKey: string,
+    data: {
+      fitbitData: FitbitEntry[];
+      questionnaireData: QuestionnaireEntry[];
+      adherenceData: AdherenceEntry[];
+    }
+  ) {
+    try {
+      const raw = sessionStorage.getItem(HealthPageStore.STORAGE_KEY);
+      let store: Record<string, unknown> = {};
+      try {
+        const parsed = JSON.parse(raw ?? '{}');
+        // migrate old single-entry format
+        if (parsed?.cacheKey) store = {};
+        else if (parsed && typeof parsed === 'object') store = parsed;
+      } catch {
+        /* ignore */
+      }
+      store[cacheKey] = data;
+      // keep at most 4 entries
+      const keys = Object.keys(store);
+      if (keys.length > 4) keys.slice(0, keys.length - 4).forEach((k) => delete store[k]);
+      sessionStorage.setItem(HealthPageStore.STORAGE_KEY, JSON.stringify(store));
+    } catch {
+      // storage quota — ignore
+    }
+  }
+
+  static loadFromSessionStorage(cacheKey: string) {
+    try {
+      const raw = sessionStorage.getItem(HealthPageStore.STORAGE_KEY);
+      if (!raw) return null;
+      const store = JSON.parse(raw);
+      // new map format
+      if (store?.[cacheKey]) {
+        return store[cacheKey] as {
+          fitbitData: FitbitEntry[];
+          questionnaireData: QuestionnaireEntry[];
+          adherenceData: AdherenceEntry[];
+        };
+      }
+      // old flat format
+      if (store?.cacheKey === cacheKey) {
+        return store as {
+          fitbitData: FitbitEntry[];
+          questionnaireData: QuestionnaireEntry[];
+          adherenceData: AdherenceEntry[];
+        };
+      }
+      return null;
+    } catch {
+      return null;
+    }
+  }
+
   // ───────────────────────────
   // Derived ranges (data window)
   // ───────────────────────────
@@ -342,7 +400,18 @@ export class HealthPageStore {
   ) {
     if (!patientId) return;
 
-    this.loading = true;
+    const cacheKey = `${patientId}_${from}_${to}`;
+    const cached = HealthPageStore.loadFromSessionStorage(cacheKey);
+    if (cached) {
+      runInAction(() => {
+        this.fitbitData = cached.fitbitData;
+        this.questionnaireData = cached.questionnaireData;
+        this.adherenceData = cached.adherenceData;
+        this._rebuildVisibleQuestionsFromData();
+      });
+    }
+
+    if (!cached) this.loading = true;
     this.error = '';
 
     try {
@@ -362,6 +431,12 @@ export class HealthPageStore {
         this.adherenceData = normalizeAdherenceList(adherenceRaw);
         this._rebuildVisibleQuestionsFromData();
       });
+
+      HealthPageStore.saveToSessionStorage(cacheKey, {
+        fitbitData: this.fitbitData,
+        questionnaireData: this.questionnaireData,
+        adherenceData: this.adherenceData,
+      });
     } catch (err: unknown) {
       runInAction(() => {
         this.fitbitData = [];
@@ -377,4 +452,5 @@ export class HealthPageStore {
   }
 }
 
+export const healthPageStore = new HealthPageStore();
 export default HealthPageStore;

--- a/frontend/src/stores/interventionsLibraryStore.ts
+++ b/frontend/src/stores/interventionsLibraryStore.ts
@@ -1,7 +1,8 @@
 // src/stores/interventionsLibraryStore.ts
 import { makeAutoObservable, reaction, runInAction } from 'mobx';
-import apiClient from '../api/client';
-import type { InterventionTypeTh } from '../types';
+import apiClient from '@/api/client';
+import { SessionCache } from '@/utils/sessionCache';
+import type { InterventionTypeTh } from '@/types';
 
 export type LibraryMode = 'patient' | 'therapist';
 
@@ -133,10 +134,10 @@ export class InterventionsLibraryStore {
   lastMode: LibraryMode | null = null;
   lastFetch: FetchOptions | null = null;
 
-  private storageKey: string;
+  private cache: SessionCache;
 
   constructor(storageKey: string) {
-    this.storageKey = storageKey;
+    this.cache = new SessionCache(storageKey);
     makeAutoObservable(this, {}, { autoBind: true });
     this.loadFromSessionStorage();
 
@@ -149,18 +150,13 @@ export class InterventionsLibraryStore {
   }
 
   saveToSessionStorage() {
-    sessionStorage.setItem(this.storageKey, JSON.stringify({ items: this.items }));
+    this.cache.set('items', this.items);
   }
 
   loadFromSessionStorage() {
-    const dataStr = sessionStorage.getItem(this.storageKey);
-    if (dataStr) {
-      try {
-        const data = JSON.parse(dataStr);
-        this.items = data.items ?? [];
-      } catch {
-        sessionStorage.removeItem(this.storageKey);
-      }
+    const items = this.cache.get<InterventionTypeTh[]>('items');
+    if (items) {
+      this.items = items;
     }
   }
 

--- a/frontend/src/stores/interventionsLibraryStore.ts
+++ b/frontend/src/stores/interventionsLibraryStore.ts
@@ -1,5 +1,5 @@
 // src/stores/interventionsLibraryStore.ts
-import { makeAutoObservable, runInAction } from 'mobx';
+import { makeAutoObservable, reaction, runInAction } from 'mobx';
 import apiClient from '../api/client';
 import type { InterventionTypeTh } from '../types';
 
@@ -133,8 +133,35 @@ export class InterventionsLibraryStore {
   lastMode: LibraryMode | null = null;
   lastFetch: FetchOptions | null = null;
 
-  constructor() {
+  private storageKey: string;
+
+  constructor(storageKey: string) {
+    this.storageKey = storageKey;
     makeAutoObservable(this, {}, { autoBind: true });
+    this.loadFromSessionStorage();
+
+    reaction(
+      () => this.items,
+      () => {
+        this.saveToSessionStorage();
+      }
+    );
+  }
+
+  saveToSessionStorage() {
+    sessionStorage.setItem(this.storageKey, JSON.stringify({ items: this.items }));
+  }
+
+  loadFromSessionStorage() {
+    const dataStr = sessionStorage.getItem(this.storageKey);
+    if (dataStr) {
+      try {
+        const data = JSON.parse(dataStr);
+        this.items = data.items ?? [];
+      } catch {
+        sessionStorage.removeItem(this.storageKey);
+      }
+    }
   }
 
   get count() {
@@ -171,7 +198,7 @@ export class InterventionsLibraryStore {
     const { mode, patientId, includePrivate, lang } = opts;
     if (this.loading) return;
 
-    this.loading = true;
+    if (!this.items.length) this.loading = true;
     this.error = '';
     this.lastMode = mode;
     this.lastFetch = opts;
@@ -226,5 +253,9 @@ export class InterventionsLibraryStore {
   }
 }
 
-export const patientInterventionsLibraryStore = new InterventionsLibraryStore();
-export const therapistInterventionsLibraryStore = new InterventionsLibraryStore();
+export const patientInterventionsLibraryStore = new InterventionsLibraryStore(
+  'patientInterventionsLibraryStore'
+);
+export const therapistInterventionsLibraryStore = new InterventionsLibraryStore(
+  'therapistInterventionsLibraryStore'
+);

--- a/frontend/src/stores/patientFitbitStore.ts
+++ b/frontend/src/stores/patientFitbitStore.ts
@@ -1,5 +1,6 @@
 import { makeAutoObservable, reaction, runInAction } from 'mobx';
-import apiClient from '../api/client';
+import apiClient from '@/api/client';
+import { SessionCache } from '@/utils/sessionCache';
 
 export type Thresholds = {
   steps_goal: number;
@@ -76,7 +77,7 @@ export const mergeThresholds = (api?: Partial<Thresholds>): Thresholds => ({
 });
 
 class PatientFitbitStore {
-  private static STORAGE_KEY = 'patientFitbitStore';
+  private static cache = new SessionCache('patientFitbitStore');
 
   connected: boolean | null = null;
   statusLoading = false;
@@ -97,52 +98,20 @@ class PatientFitbitStore {
   }
 
   private saveConnectedToStorage() {
-    try {
-      const raw = sessionStorage.getItem(PatientFitbitStore.STORAGE_KEY);
-      const store: Record<string, unknown> = raw
-        ? (JSON.parse(raw) as Record<string, unknown>)
-        : {};
-      store['connected'] = this.connected;
-      sessionStorage.setItem(PatientFitbitStore.STORAGE_KEY, JSON.stringify(store));
-    } catch {
-      // storage quota — ignore
-    }
+    PatientFitbitStore.cache.set('connected', this.connected);
   }
 
   private loadConnectedFromStorage() {
-    try {
-      const raw = sessionStorage.getItem(PatientFitbitStore.STORAGE_KEY);
-      if (raw) {
-        const data = JSON.parse(raw) as Record<string, unknown>;
-        this.connected = typeof data['connected'] === 'boolean' ? data['connected'] : null;
-      }
-    } catch {
-      // ignore
-    }
+    const val = PatientFitbitStore.cache.get<boolean>('connected');
+    if (typeof val === 'boolean') this.connected = val;
   }
 
   private static saveSummaryToStorage(cacheKey: string, data: FitbitSummary) {
-    try {
-      const raw = sessionStorage.getItem(PatientFitbitStore.STORAGE_KEY);
-      const store: Record<string, unknown> = raw
-        ? (JSON.parse(raw) as Record<string, unknown>)
-        : {};
-      store[cacheKey] = data;
-      sessionStorage.setItem(PatientFitbitStore.STORAGE_KEY, JSON.stringify(store));
-    } catch {
-      // storage quota — ignore
-    }
+    PatientFitbitStore.cache.set(cacheKey, data);
   }
 
   private static loadSummaryFromStorage(cacheKey: string): FitbitSummary | null {
-    try {
-      const raw = sessionStorage.getItem(PatientFitbitStore.STORAGE_KEY);
-      if (!raw) return null;
-      const store = JSON.parse(raw) as Record<string, unknown>;
-      return (store[cacheKey] as FitbitSummary) ?? null;
-    } catch {
-      return null;
-    }
+    return PatientFitbitStore.cache.get<FitbitSummary>(cacheKey);
   }
 
   clearError() {

--- a/frontend/src/stores/patientFitbitStore.ts
+++ b/frontend/src/stores/patientFitbitStore.ts
@@ -1,4 +1,4 @@
-import { makeAutoObservable, runInAction } from 'mobx';
+import { makeAutoObservable, reaction, runInAction } from 'mobx';
 import apiClient from '../api/client';
 
 export type Thresholds = {
@@ -76,6 +76,8 @@ export const mergeThresholds = (api?: Partial<Thresholds>): Thresholds => ({
 });
 
 class PatientFitbitStore {
+  private static STORAGE_KEY = 'patientFitbitStore';
+
   connected: boolean | null = null;
   statusLoading = false;
 
@@ -86,6 +88,61 @@ class PatientFitbitStore {
 
   constructor() {
     makeAutoObservable(this);
+    this.loadConnectedFromStorage();
+
+    reaction(
+      () => this.connected,
+      () => this.saveConnectedToStorage()
+    );
+  }
+
+  private saveConnectedToStorage() {
+    try {
+      const raw = sessionStorage.getItem(PatientFitbitStore.STORAGE_KEY);
+      const store: Record<string, unknown> = raw
+        ? (JSON.parse(raw) as Record<string, unknown>)
+        : {};
+      store['connected'] = this.connected;
+      sessionStorage.setItem(PatientFitbitStore.STORAGE_KEY, JSON.stringify(store));
+    } catch {
+      // storage quota — ignore
+    }
+  }
+
+  private loadConnectedFromStorage() {
+    try {
+      const raw = sessionStorage.getItem(PatientFitbitStore.STORAGE_KEY);
+      if (raw) {
+        const data = JSON.parse(raw) as Record<string, unknown>;
+        this.connected = typeof data['connected'] === 'boolean' ? data['connected'] : null;
+      }
+    } catch {
+      // ignore
+    }
+  }
+
+  private static saveSummaryToStorage(cacheKey: string, data: FitbitSummary) {
+    try {
+      const raw = sessionStorage.getItem(PatientFitbitStore.STORAGE_KEY);
+      const store: Record<string, unknown> = raw
+        ? (JSON.parse(raw) as Record<string, unknown>)
+        : {};
+      store[cacheKey] = data;
+      sessionStorage.setItem(PatientFitbitStore.STORAGE_KEY, JSON.stringify(store));
+    } catch {
+      // storage quota — ignore
+    }
+  }
+
+  private static loadSummaryFromStorage(cacheKey: string): FitbitSummary | null {
+    try {
+      const raw = sessionStorage.getItem(PatientFitbitStore.STORAGE_KEY);
+      if (!raw) return null;
+      const store = JSON.parse(raw) as Record<string, unknown>;
+      return (store[cacheKey] as FitbitSummary) ?? null;
+    } catch {
+      return null;
+    }
   }
 
   clearError() {
@@ -93,7 +150,7 @@ class PatientFitbitStore {
   }
 
   async fetchStatus(patientId: string) {
-    this.statusLoading = true;
+    if (this.connected === null) this.statusLoading = true;
     this.error = '';
     try {
       const { data } = await apiClient.get(`/fitbit/status/${patientId}/`);
@@ -111,18 +168,28 @@ class PatientFitbitStore {
     }
   }
 
-  async fetchSummary(patientId: string, days = 7) {
-    this.summaryLoading = true;
+  async fetchSummary(patientId: string, days = 7, force = false) {
+    const cacheKey = `${patientId}_${days}`;
+    const cached = PatientFitbitStore.loadSummaryFromStorage(cacheKey);
+    if (cached && !force) {
+      runInAction(() => {
+        this.summary = cached;
+      });
+    }
+    if (!cached || force) this.summaryLoading = true;
     this.error = '';
     try {
-      const { data } = await apiClient.get(`/fitbit/summary/${patientId}/?days=${days}`);
+      const { data } = await apiClient.get(`/fitbit/summary/${patientId}/`, { params: { days } });
       runInAction(() => {
         this.summary = data;
       });
+      PatientFitbitStore.saveSummaryToStorage(cacheKey, data as FitbitSummary);
     } catch {
       runInAction(() => {
-        this.summary = null;
-        this.error = 'error_f';
+        if (!cached) {
+          this.summary = null;
+          this.error = 'error_f';
+        }
       });
     } finally {
       runInAction(() => {
@@ -139,7 +206,7 @@ class PatientFitbitStore {
   async submitManualSteps(patientId: string, date: string, steps: number) {
     this.error = '';
     await apiClient.post(`/fitbit/manual_steps/${patientId}/`, { date, steps });
-    await this.fetchSummary(patientId, 7);
+    await this.fetchSummary(patientId, 7, true);
   }
 }
 

--- a/frontend/src/stores/patientInterventionsStore.ts
+++ b/frontend/src/stores/patientInterventionsStore.ts
@@ -1,4 +1,4 @@
-import { makeAutoObservable, runInAction } from 'mobx';
+import { makeAutoObservable, reaction, runInAction } from 'mobx';
 import apiClient from '../api/client';
 import { translateText } from '../utils/translate';
 import { format } from 'date-fns';
@@ -68,6 +68,30 @@ class PatientInterventionsStore {
 
   constructor() {
     makeAutoObservable(this, {}, { autoBind: true });
+    this.loadFromSessionStorage();
+
+    reaction(
+      () => this.items,
+      () => {
+        this.saveToSessionStorage();
+      }
+    );
+  }
+
+  saveToSessionStorage() {
+    sessionStorage.setItem('patientInterventionsStore', JSON.stringify({ items: this.items }));
+  }
+
+  loadFromSessionStorage() {
+    const dataStr = sessionStorage.getItem('patientInterventionsStore');
+    if (dataStr) {
+      try {
+        const data = JSON.parse(dataStr);
+        this.items = data.items ?? [];
+      } catch {
+        sessionStorage.removeItem('patientInterventionsStore');
+      }
+    }
   }
 
   clearError() {
@@ -82,7 +106,7 @@ class PatientInterventionsStore {
   }
 
   async fetchPlan(patientId: string, uiLang: string) {
-    this.loading = true;
+    if (!this.items.length) this.loading = true;
     this.clearError();
 
     try {

--- a/frontend/src/stores/patientInterventionsStore.ts
+++ b/frontend/src/stores/patientInterventionsStore.ts
@@ -1,6 +1,7 @@
 import { makeAutoObservable, reaction, runInAction } from 'mobx';
-import apiClient from '../api/client';
-import { translateText } from '../utils/translate';
+import apiClient from '@/api/client';
+import { SessionCache } from '@/utils/sessionCache';
+import { translateText } from '@/utils/translate';
 import { format } from 'date-fns';
 
 export type InterventionMeta = {
@@ -40,7 +41,7 @@ export type PatientRec = {
   preview_img?: string;
   media?: any[];
 
-  // ✅ NEW: full intervention object (from backend)
+  // full intervention object (from backend)
   intervention?: InterventionMeta;
 
   // translations
@@ -60,38 +61,37 @@ const upsertCompletionDate = (dates: string[] | undefined, dateKey: string) => {
 };
 
 class PatientInterventionsStore {
+  private static cache = new SessionCache('patientInterventionsStore');
+
   items: PatientRec[] = [];
   loading = false;
 
   error: string | null = null;
   errorDetails: string | null = null;
 
+  private currentPatientId: string | null = null;
+
   constructor() {
-    makeAutoObservable(this, {}, { autoBind: true });
-    this.loadFromSessionStorage();
+    makeAutoObservable<PatientInterventionsStore, 'currentPatientId'>(
+      this,
+      { currentPatientId: false },
+      { autoBind: true }
+    );
 
     reaction(
       () => this.items,
       () => {
-        this.saveToSessionStorage();
+        if (this.currentPatientId) this.saveToSessionStorage(this.currentPatientId);
       }
     );
   }
 
-  saveToSessionStorage() {
-    sessionStorage.setItem('patientInterventionsStore', JSON.stringify({ items: this.items }));
+  private saveToSessionStorage(patientId: string) {
+    PatientInterventionsStore.cache.set(patientId, this.items);
   }
 
-  loadFromSessionStorage() {
-    const dataStr = sessionStorage.getItem('patientInterventionsStore');
-    if (dataStr) {
-      try {
-        const data = JSON.parse(dataStr);
-        this.items = data.items ?? [];
-      } catch {
-        sessionStorage.removeItem('patientInterventionsStore');
-      }
-    }
+  private loadFromSessionStorage(patientId: string): PatientRec[] | null {
+    return PatientInterventionsStore.cache.get<PatientRec[]>(patientId);
   }
 
   clearError() {
@@ -99,13 +99,19 @@ class PatientInterventionsStore {
     this.errorDetails = null;
   }
 
-  // ✅ completion_dates are now day-keys: ["2026-02-25", ...]
   isCompletedOn(rec: PatientRec, date: Date) {
     const dateStr = format(date, 'yyyy-MM-dd');
     return asArray<string>(rec.completion_dates).some((d) => String(d).startsWith(dateStr));
   }
 
   async fetchPlan(patientId: string, uiLang: string) {
+    this.currentPatientId = patientId;
+    const cached = this.loadFromSessionStorage(patientId);
+    if (cached) {
+      runInAction(() => {
+        this.items = cached;
+      });
+    }
     if (!this.items.length) this.loading = true;
     this.clearError();
 

--- a/frontend/src/utils/sessionCache.ts
+++ b/frontend/src/utils/sessionCache.ts
@@ -1,0 +1,54 @@
+export class SessionCache {
+  constructor(private readonly storageKey: string) {}
+
+  get<T = unknown>(cacheKey: string): T | null {
+    try {
+      const raw = sessionStorage.getItem(this.storageKey);
+      if (!raw) return null;
+      const store = JSON.parse(raw) as Record<string, unknown>;
+      return (store[cacheKey] as T) ?? null;
+    } catch {
+      return null;
+    }
+  }
+
+  set(cacheKey: string, data: unknown): void {
+    try {
+      const raw = sessionStorage.getItem(this.storageKey);
+      let store: Record<string, unknown> = {};
+      try {
+        const parsed = JSON.parse(raw ?? '{}');
+        if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+          store = parsed as Record<string, unknown>;
+        }
+      } catch {
+        /* corrupted — start fresh */
+      }
+
+      store[cacheKey] = data;
+      sessionStorage.setItem(this.storageKey, JSON.stringify(store));
+    } catch {
+      /* storage quota — ignore */
+    }
+  }
+
+  remove(cacheKey: string): void {
+    try {
+      const raw = sessionStorage.getItem(this.storageKey);
+      if (!raw) return;
+      const store = JSON.parse(raw) as Record<string, unknown>;
+      delete store[cacheKey];
+      sessionStorage.setItem(this.storageKey, JSON.stringify(store));
+    } catch {
+      /* ignore */
+    }
+  }
+
+  clear(): void {
+    try {
+      sessionStorage.removeItem(this.storageKey);
+    } catch {
+      /* ignore */
+    }
+  }
+}


### PR DESCRIPTION
## Description
This PR improves the patient experience by preloading key patient data once per session, adding lightweight session caching support. It also includes small UI refinements (for example in Patient Plan/Profile/Process) to make screens more consistent and responsive.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Related Issue
[Preload and patient cache data](https://www.notion.so/Preload-and-patient-cache-data-33661846b450809db715c6ad1642dd13?source=copy_link)

## Changes Made
- Added a patient data flow that initializes important patient data after login.
- Added a shared patient data service and session cache utility.
- Updated patient-related stores and hooks to use the new preload flow.
- Applied small UI adjustments in patient pages/components (layout, spacing, card presentation).
- Added/updated frontend tests for bootstrap, data service behavior, root layout, patient profile/view, and auth store integration.
 
## Testing
### How to test
1. Run frontend tests: npm test
2. Log in as a patient and navigate through Patient pages.
3. Verify data is preloaded on first load and not repeatedly re-fetched during the same session.
4. Log out and log in again, then verify preload runs again.

### Test Cases
- Bootstrap triggers initialization only for authenticated patient users with valid ID.
- Initialization is skipped for invalid/empty patient IDs.
- Initialization runs once per patient ID and re-runs after reset/logout.
- Language handling for preload requests works with locale variants (for example de).
- Existing patient page and root layout tests remain green after integration.

## Checklist
- [x] Code follows style guidelines
- [x] Tests added/updated
- [x] Documentation updated (if applicable)
- [x] No new warnings generated
