### PR TITLE
fix(App): use react router navigation

### DIFF
--- a/frontend/src/components/Navigation.tsx
+++ b/frontend/src/components/Navigation.tsx
@@ -1,4 +1,4 @@
-import { useLocation } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { NavItem } from '@/components/NavItem';
 import authStore from '@/stores/authStore';
@@ -19,6 +19,7 @@ import UserFill from '@/assets/icons/user-fill.svg?react';
 export default function Navigation() {
   const { t } = useTranslation();
   const location = useLocation();
+  const navigate = useNavigate();
 
   const navLinks =
     authStore.userType === 'Patient'
@@ -102,9 +103,7 @@ export default function Navigation() {
           {navLinks.map((link) => (
             <NavItem
               key={link.path}
-              onClick={() => {
-                window.location.href = link.path;
-              }}
+              onClick={() => navigate(link.path)}
               iconOutline={link.iconOutline}
               iconFill={link.iconFill}
               label={link.label}
@@ -130,9 +129,7 @@ export default function Navigation() {
               .map((link) => (
                 <NavItem
                   key={link.path}
-                  onClick={() => {
-                    window.location.href = link.path;
-                  }}
+                  onClick={() => navigate(link.path)}
                   iconOutline={link.iconOutline}
                   iconFill={link.iconFill}
                   label={link.label}
@@ -142,9 +139,7 @@ export default function Navigation() {
               ))}
           </div>
           <button
-            onClick={() => {
-              window.location.href = '/patient-profile';
-            }}
+            onClick={() => navigate('/patient-profile')}
             className="bg-[#F2F2F2] border border-[#D4D4D4] p-2 aspect-square rounded-full text-[#565656] hover:text-black transition flex items-center justify-center"
             style={{ color: location.pathname === '/patient-profile' ? '#03A578' : '#565656' }}
           >

--- a/frontend/src/components/common/Header.tsx
+++ b/frontend/src/components/common/Header.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Button, Container, Dropdown, OverlayTrigger, Tooltip, Navbar, Nav } from 'react-bootstrap';
 import { useTranslation } from 'react-i18next';
-import { Link, useLocation } from 'react-router-dom';
+import { Link, useLocation, useNavigate } from 'react-router-dom';
 import { BsQuestionCircle } from 'react-icons/bs';
 import authStore from '../../stores/authStore';
 
@@ -25,6 +25,7 @@ type HeaderProps = {
 const Header: React.FC<HeaderProps> = ({ isLoggedIn, showRegisterAction, onRegister }) => {
   const { t, i18n } = useTranslation();
   const location = useLocation();
+  const navigate = useNavigate();
 
   const [helpOpen, setHelpOpen] = React.useState(false);
   const [expanded, setExpanded] = React.useState(false);
@@ -54,7 +55,7 @@ const Header: React.FC<HeaderProps> = ({ isLoggedIn, showRegisterAction, onRegis
 
   const handleLogout = async () => {
     await authStore.logout();
-    window.location.href = '/';
+    navigate('/');
   };
 
   const userType = authStore.userType?.toLowerCase();

--- a/frontend/src/pages/PatientProfile.tsx
+++ b/frontend/src/pages/PatientProfile.tsx
@@ -92,7 +92,7 @@ const PatientProfile: React.FC = observer(() => {
 
   const handleLogout = async () => {
     await authStore.logout();
-    window.location.href = '/';
+    navigate('/');
   };
 
   // Check authentication


### PR DESCRIPTION
Replaced `window.location.href` with React Router’s `useNavigate` for navigation. This avoids full page reloads, preserves React/MobX state, and ensures faster, consistent client-side routing aligned with SPA best practices.