### PR TITLE
Feat/Bug - Feedback and Reviews [WIP]

### DIFF
--- a/backend/core/views/patient_views.py
+++ b/backend/core/views/patient_views.py
@@ -1326,6 +1326,17 @@ def get_feedback_questions(request, questionaire_type, patient_id, intervention_
                     raw_type = str(getattr(assignment.interventionId, "content_type", "") or "")
                     intervention_type = raw_type.strip().lower() or None
 
+        # Fallback: if assignment wasn't found or content_type is empty,
+        # look up the Intervention document directly (handles library-browse path
+        # where the intervention may not be in any rehabilitation plan yet).
+        if not intervention_type and intervention_id:
+            try:
+                fallback_iv = Intervention.objects.get(pk=ObjectId(intervention_id))
+                raw_type = str(getattr(fallback_iv, "content_type", "") or "")
+                intervention_type = raw_type.strip().lower() or None
+            except Exception:
+                pass
+
         # 1) Core questions (apply to all interventions).
         #    We accept two ways to mark "core":
         #       - No applicable_types field
@@ -1358,8 +1369,8 @@ def get_feedback_questions(request, questionaire_type, patient_id, intervention_
                     seen.add(q.questionKey)
             type_q = merged
 
-        # 3) Build final list
-        result = _serialize_questions(core_q) + _serialize_questions(type_q)
+        # 3) Build final list — type-specific (stars = Frage 1) first, then core (Frage 2 + open)
+        result = _serialize_questions(type_q) + _serialize_questions(core_q)
 
         # 4) Optional: require video feedback per assignment flag
         if assignment and getattr(assignment, "require_video_feedback", False):

--- a/backend/core/views/recomendation_views.py
+++ b/backend/core/views/recomendation_views.py
@@ -32,6 +32,7 @@ import utils.interventions  # for _save_file and other helpers
 from core.models import (
     DefaultInterventions,
     DiagnosisAssignmentSettings,
+    FeedbackQuestion,
     Intervention,
     InterventionAssignment,
     InterventionMedia,
@@ -1017,6 +1018,8 @@ def list_all_interventions(request, patient_id=None):
                     for pt in (getattr(item, "patient_types", None) or [])
                 ],
                 "is_private": bool(getattr(item, "is_private", False)),
+                "avg_rating": None,
+                "rating_count": 0,
             }
 
         if q_external_id:
@@ -1048,7 +1051,43 @@ def list_all_interventions(request, patient_id=None):
             chosen, langs = _pick_variant(docs, preferred_lang, fallback_order=["en", "de"])
             public_serialized.append(serialize(chosen, langs))
 
-        return JsonResponse(private_serialized + public_serialized, safe=False, status=200)
+        all_serialized = private_serialized + public_serialized
+
+        # Annotate each intervention with its average star rating from patient feedback.
+        star_q_ids = [
+            q.id
+            for q in FeedbackQuestion.objects(questionKey__startswith="rating_stars_").only("id")
+        ]
+        if star_q_ids:
+            valid_ids = [ObjectId(s["_id"]) for s in all_serialized if ObjectId.is_valid(s["_id"])]
+            if valid_ids:
+                logs_col = PatientInterventionLogs._get_collection()
+                pipeline = [
+                    {"$match": {"interventionId": {"$in": valid_ids}}},
+                    {"$unwind": "$feedback"},
+                    {"$match": {"feedback.questionId": {"$in": star_q_ids}}},
+                    {
+                        "$project": {
+                            "interventionId": 1,
+                            "rating": {"$toInt": {"$arrayElemAt": ["$feedback.answerKey.key", 0]}},
+                        }
+                    },
+                    {
+                        "$group": {
+                            "_id": "$interventionId",
+                            "avg_rating": {"$avg": "$rating"},
+                            "rating_count": {"$sum": 1},
+                        }
+                    },
+                ]
+                rating_map = {str(r["_id"]): r for r in logs_col.aggregate(pipeline)}
+                for item in all_serialized:
+                    rd = rating_map.get(item["_id"], {})
+                    avg = rd.get("avg_rating")
+                    item["avg_rating"] = round(avg, 1) if avg is not None else None
+                    item["rating_count"] = rd.get("rating_count", 0)
+
+        return JsonResponse(all_serialized, safe=False, status=200)
 
     except Exception as e:
         logger.exception("[list_all_interventions] Unexpected error")

--- a/backend/core/views/recomendation_views.py
+++ b/backend/core/views/recomendation_views.py
@@ -1054,10 +1054,7 @@ def list_all_interventions(request, patient_id=None):
         all_serialized = private_serialized + public_serialized
 
         # Annotate each intervention with its average star rating from patient feedback.
-        star_q_ids = [
-            q.id
-            for q in FeedbackQuestion.objects(questionKey__startswith="rating_stars_").only("id")
-        ]
+        star_q_ids = [q.id for q in FeedbackQuestion.objects(questionKey__startswith="rating_stars_").only("id")]
         if star_q_ids:
             valid_ids = [ObjectId(s["_id"]) for s in all_serialized if ObjectId.is_valid(s["_id"])]
             if valid_ids:

--- a/backend/tests/patient_views/TESTING.md
+++ b/backend/tests/patient_views/TESTING.md
@@ -12,6 +12,7 @@ It also includes [`test_helpers.py`](test_helpers.py) for pure helper logic in
 | Endpoint | HTTP verb(s) | View function | Tests |
 |---|---|---|---|
 | `/api/patients/feedback/questionaire/` | POST | `submit_patient_feedback` | 6 |
+
 | `/api/interventions/complete/` | POST | `mark_intervention_completed` | 9 |
 | `/api/interventions/uncomplete/` | POST | `unmark_intervention_completed` | 6 |
 | `/api/interventions/remove-from-patient/` | POST | `remove_intervention_from_patient` | 4 |
@@ -19,7 +20,7 @@ It also includes [`test_helpers.py`](test_helpers.py) for pure helper logic in
 | `/api/interventions/modify-patient/` | POST | `modify_intervention_from_date` | 13 |
 | `/api/patients/rehabilitation-plan/patient/<id>/` | GET | `get_patient_plan` | 16 |
 | `/api/patients/rehabilitation-plan/therapist/<id>/` | GET | `get_patient_plan_for_therapist` | 4 |
-| `/api/patients/get-questions/<type>/<id>/` | GET | `get_feedback_questions` | 7 |
+| `/api/patients/get-questions/<type>/<id>/` | GET | `get_feedback_questions` | 12 |
 | `/api/users/<id>/initial-questionaire/` | GET, POST | `initial_patient_questionaire` | 7 |
 | `/api/patients/vitals/manual/<id>/` | POST | `add_manual_vitals` | 6 |
 | `/api/patients/vitals/exists/<id>/` | GET | `vitals_exists_for_day` | 6 |
@@ -247,6 +248,13 @@ Returns a structured plan with adherence metadata for the therapist dashboard.  
 
 Returns the list of feedback questions for the given questionnaire type ('Intervention', 'Healthstatus').  Accepts an optional `intervention_id` path segment or query parameter.
 
+The three-question feedback structure for interventions is:
+1. **Frage 1** — 5-star rating (`rating_stars_education` or `rating_stars_exercise` depending on `content_type`)
+2. **Frage 2** — Difficulty scale (`difficulty_scale`, applicable to all)
+3. **Open feedback** — Free text / audio (`open_feedback`, applicable to all)
+
+Type-specific questions (stars) are returned before core/All questions (difficulty, open feedback).
+
 ### Tests (`test_get_endpoints.py`)
 
 | Test | Scenario | Expected |
@@ -258,6 +266,11 @@ Returns the list of feedback questions for the given questionnaire type ('Interv
 | `test_fetch_feedback_questions_patient_not_found` | Unknown patient | 404, 'Patient not found' |
 | `test_fetch_feedback_questions_post_method_not_allowed` | POST | 405 |
 | `test_fetch_feedback_questions_invalid_patient_id` | Non-ObjectId `patient_id` | 400, 'Invalid patient id' |
+| `test_star_rating_returned_when_intervention_in_plan` | Video intervention in rehab plan | `rating_stars_education` present |
+| `test_star_rating_returned_without_rehab_plan` | Exercise intervention NOT in any plan (library-browse path) | `rating_stars_exercise` present via fallback lookup |
+| `test_star_rating_is_first_question` | Video intervention with both star + difficulty seeded | star rating index < difficulty index |
+| `test_correct_star_question_selected_for_exercise` | Exercise `content_type` | `rating_stars_exercise` included, `rating_stars_education` excluded |
+| `test_star_rating_absent_when_no_intervention_id` | No `interventionId` query param | no `rating_stars_*` keys; `difficulty_scale` still present |
 
 ---
 

--- a/backend/tests/patient_views/test_get_endpoints.py
+++ b/backend/tests/patient_views/test_get_endpoints.py
@@ -385,3 +385,218 @@ def test_fetch_feedback_questions_invalid_patient_id(mongo_mock):
         HTTP_AUTHORIZATION="Bearer test",
     )
     assert resp.status_code == 400
+
+
+# ===========================================================================
+# Star rating (Frage 1) — get_feedback_questions
+# ===========================================================================
+
+
+def _make_star_questions():
+    """Seed the two canonical star-rating questions and the core 'All' questions."""
+    from core.models import AnswerOption
+
+    star_education = FeedbackQuestion(
+        questionSubject="Intervention",
+        questionKey="rating_stars_education",
+        answer_type="select",
+        applicable_types=["Education", "Instruction", "Text", "PDF", "Video", "Audio", "Website", "Apps"],
+        translations=[
+            Translation(language="en", text="How did you like the content?"),
+            Translation(language="de", text="Wie fandest du den Inhalt?"),
+        ],
+        possibleAnswers=[
+            AnswerOption(key=str(i), translations=[Translation(language="en", text=f"{i}/5")])
+            for i in range(1, 6)
+        ],
+    )
+    star_education.save()
+
+    star_exercise = FeedbackQuestion(
+        questionSubject="Intervention",
+        questionKey="rating_stars_exercise",
+        answer_type="select",
+        applicable_types=["Exercise", "Exercises", "Physiotherapy", "Training", "Movement"],
+        translations=[
+            Translation(language="en", text="How did you like the exercise?"),
+            Translation(language="de", text="Wie fandest du die Übung?"),
+        ],
+        possibleAnswers=[
+            AnswerOption(key=str(i), translations=[Translation(language="en", text=f"{i}/5")])
+            for i in range(1, 6)
+        ],
+    )
+    star_exercise.save()
+
+    difficulty = FeedbackQuestion(
+        questionSubject="Intervention",
+        questionKey="difficulty_scale",
+        answer_type="select",
+        applicable_types=["All"],
+        translations=[Translation(language="en", text="The content was…")],
+        possibleAnswers=[
+            AnswerOption(key="too_difficult", translations=[Translation(language="en", text="Too difficult")]),
+            AnswerOption(key="just_right", translations=[Translation(language="en", text="Just right")]),
+            AnswerOption(key="too_easy", translations=[Translation(language="en", text="Too easy")]),
+        ],
+    )
+    difficulty.save()
+
+    open_fb = FeedbackQuestion(
+        questionSubject="Intervention",
+        questionKey="open_feedback",
+        answer_type="text",
+        applicable_types=["All"],
+        translations=[Translation(language="en", text="Any additional feedback?")],
+        possibleAnswers=[],
+    )
+    open_fb.save()
+
+    return star_education, star_exercise, difficulty, open_fb
+
+
+def test_star_rating_returned_when_intervention_in_plan(mongo_mock):
+    """
+    GET /api/patients/get-questions/Intervention/<patient_id>/?interventionId=<iv_id>
+    returns the star-rating question when the intervention IS in the patient's
+    rehabilitation plan.
+
+    This is the standard Reha-Table path: a patient opens feedback immediately
+    after completing an assigned session.
+    """
+    _make_star_questions()
+    patient, _, intervention, _ = setup_basic_plan()  # intervention.content_type = "Video"
+
+    resp = client.get(
+        f"/api/patients/get-questions/Intervention/{patient.userId.id}/",
+        data={"interventionId": str(intervention.id)},
+        HTTP_AUTHORIZATION="Bearer test",
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    keys = [q["questionKey"] for q in (body if isinstance(body, list) else body.get("questions", []))]
+    assert "rating_stars_education" in keys, f"Star rating missing from {keys}"
+
+
+def test_star_rating_returned_without_rehab_plan(mongo_mock):
+    """
+    GET /api/patients/get-questions/Intervention/<patient_id>/?interventionId=<iv_id>
+    returns the star-rating question even when the intervention is NOT in any
+    rehabilitation plan (library-browse path).
+
+    Previously, ``intervention_type`` resolved to ``None`` because the plan
+    lookup found no assignment, causing only the 'All' questions to be returned.
+    The fix adds a fallback direct Intervention document lookup.
+    """
+    _make_star_questions()
+    patient, _, _, _ = setup_basic_plan(with_plan=False)
+
+    # Create a standalone exercise intervention — not in any plan.
+    exercise_iv = Intervention(
+        title="Squats",
+        description="Lower body",
+        content_type="Exercise",
+        external_id="EXT-SQ-001",
+        language="de",
+    )
+    exercise_iv.save()
+
+    resp = client.get(
+        f"/api/patients/get-questions/Intervention/{patient.userId.id}/",
+        data={"interventionId": str(exercise_iv.id)},
+        HTTP_AUTHORIZATION="Bearer test",
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    keys = [q["questionKey"] for q in (body if isinstance(body, list) else body.get("questions", []))]
+    assert "rating_stars_exercise" in keys, (
+        f"Star rating missing from {keys}. "
+        "Fallback Intervention lookup may not be working."
+    )
+
+
+def test_star_rating_is_first_question(mongo_mock):
+    """
+    The star-rating question (Frage 1) must appear *before* the difficulty-scale
+    question (Frage 2) in the response list.
+
+    The backend returns type-specific questions (star) first, then core/All
+    questions (difficulty, open feedback), matching the agreed UI order:
+    Frage 1 → Frage 2 → open feedback.
+    """
+    _make_star_questions()
+    patient, _, intervention, _ = setup_basic_plan()  # content_type = "Video"
+
+    resp = client.get(
+        f"/api/patients/get-questions/Intervention/{patient.userId.id}/",
+        data={"interventionId": str(intervention.id)},
+        HTTP_AUTHORIZATION="Bearer test",
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    questions = body if isinstance(body, list) else body.get("questions", [])
+    keys = [q["questionKey"] for q in questions]
+
+    assert "rating_stars_education" in keys, f"Star rating not present: {keys}"
+    assert "difficulty_scale" in keys, f"Difficulty scale not present: {keys}"
+    assert keys.index("rating_stars_education") < keys.index("difficulty_scale"), (
+        f"Expected star rating before difficulty; got order: {keys}"
+    )
+
+
+def test_correct_star_question_selected_for_exercise(mongo_mock):
+    """
+    An intervention with content_type='Exercise' must return
+    ``rating_stars_exercise``, not ``rating_stars_education``.
+
+    Each content category has its own star-rating question with an
+    aim-appropriate label ("Wie fandest du die Übung?" vs
+    "Wie fandest du den Inhalt?").
+    """
+    _make_star_questions()
+    patient, _, _, _ = setup_basic_plan(with_plan=False)
+
+    exercise_iv = Intervention(
+        title="Lunges",
+        description="Leg exercise",
+        content_type="Exercise",
+        external_id="EXT-LG-001",
+        language="en",
+    )
+    exercise_iv.save()
+
+    resp = client.get(
+        f"/api/patients/get-questions/Intervention/{patient.userId.id}/",
+        data={"interventionId": str(exercise_iv.id)},
+        HTTP_AUTHORIZATION="Bearer test",
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    keys = [q["questionKey"] for q in (body if isinstance(body, list) else body.get("questions", []))]
+
+    assert "rating_stars_exercise" in keys, f"Exercise star rating missing: {keys}"
+    assert "rating_stars_education" not in keys, f"Wrong star rating included: {keys}"
+
+
+def test_star_rating_absent_when_no_intervention_id(mongo_mock):
+    """
+    GET without an interventionId query param returns only the generic 'All'
+    questions (difficulty_scale, open_feedback) — no star rating.
+
+    Without a content_type the backend cannot select the correct star variant,
+    so it deliberately omits both ``rating_stars_*`` questions.
+    """
+    _make_star_questions()
+    patient, _, _, _ = setup_basic_plan()
+
+    resp = client.get(
+        f"/api/patients/get-questions/Intervention/{patient.userId.id}/",
+        HTTP_AUTHORIZATION="Bearer test",
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    keys = [q["questionKey"] for q in (body if isinstance(body, list) else body.get("questions", []))]
+
+    assert "rating_stars_education" not in keys
+    assert "rating_stars_exercise" not in keys
+    assert "difficulty_scale" in keys, f"Core questions missing: {keys}"

--- a/backend/tests/patient_views/test_get_endpoints.py
+++ b/backend/tests/patient_views/test_get_endpoints.py
@@ -406,8 +406,7 @@ def _make_star_questions():
             Translation(language="de", text="Wie fandest du den Inhalt?"),
         ],
         possibleAnswers=[
-            AnswerOption(key=str(i), translations=[Translation(language="en", text=f"{i}/5")])
-            for i in range(1, 6)
+            AnswerOption(key=str(i), translations=[Translation(language="en", text=f"{i}/5")]) for i in range(1, 6)
         ],
     )
     star_education.save()
@@ -422,8 +421,7 @@ def _make_star_questions():
             Translation(language="de", text="Wie fandest du die Übung?"),
         ],
         possibleAnswers=[
-            AnswerOption(key=str(i), translations=[Translation(language="en", text=f"{i}/5")])
-            for i in range(1, 6)
+            AnswerOption(key=str(i), translations=[Translation(language="en", text=f"{i}/5")]) for i in range(1, 6)
         ],
     )
     star_exercise.save()
@@ -510,8 +508,7 @@ def test_star_rating_returned_without_rehab_plan(mongo_mock):
     body = resp.json()
     keys = [q["questionKey"] for q in (body if isinstance(body, list) else body.get("questions", []))]
     assert "rating_stars_exercise" in keys, (
-        f"Star rating missing from {keys}. "
-        "Fallback Intervention lookup may not be working."
+        f"Star rating missing from {keys}. " "Fallback Intervention lookup may not be working."
     )
 
 
@@ -539,9 +536,9 @@ def test_star_rating_is_first_question(mongo_mock):
 
     assert "rating_stars_education" in keys, f"Star rating not present: {keys}"
     assert "difficulty_scale" in keys, f"Difficulty scale not present: {keys}"
-    assert keys.index("rating_stars_education") < keys.index("difficulty_scale"), (
-        f"Expected star rating before difficulty; got order: {keys}"
-    )
+    assert keys.index("rating_stars_education") < keys.index(
+        "difficulty_scale"
+    ), f"Expected star rating before difficulty; got order: {keys}"
 
 
 def test_correct_star_question_selected_for_exercise(mongo_mock):

--- a/backend/tests/recomendation_views/TESTING.md
+++ b/backend/tests/recomendation_views/TESTING.md
@@ -1,25 +1,40 @@
-# Recommendation Views (Extra) — Test Documentation
+# Recommendation Views — Test Documentation
 
-Tests in [`test_recomendation_views_extra.py`](test_recomendation_views_extra.py) add
-focused branch coverage for `core/views/recomendation_views.py`.
+## Files
 
-## Coverage focus
-- `apply_template_to_patient` validation branches:
-  - invalid JSON body
-  - invalid `startTime` format
-- `template_plan_preview` generic-exception branch (`horizon` parse failure)
-- `get_intervention_by_external_id`:
-  - method not allowed
-  - not found
-  - successful language variant selection
-- `add_new_intervention` validation branches:
-  - invalid taxonomy JSON
-  - invalid patientTypes JSON
-  - private intervention without/with invalid patient id
-  - media validation for invalid kind/type and missing file reference
-- `list_intervention_diagnoses`:
-  - `all` flag propagation
-  - per-diagnosis active mapping
+| File | Focus |
+|---|---|
+| [`test_recomendation_views_extra.py`](test_recomendation_views_extra.py) | Validation branches for template apply/preview, intervention creation, diagnosis listing |
+| [`test_list_all_interventions_ratings.py`](test_list_all_interventions_ratings.py) | `avg_rating` / `rating_count` aggregation on `GET /api/interventions/all/` |
+
+---
+
+## `list_all_interventions` — avg_rating aggregation
+
+`GET /api/interventions/all/` and `GET /api/interventions/all/<patient_id>/`
+
+After all interventions are serialized, the endpoint runs a single MongoDB aggregation pipeline over `PatientInterventionLogs` to compute the average star rating per intervention. Only feedback entries whose `questionId` references a `FeedbackQuestion` with `questionKey` starting with `rating_stars_` are included; difficulty-scale and open-feedback entries are excluded.
+
+The results are merged back into the serialized items as:
+- `avg_rating` — `float | null` — rounded to 1 decimal place; `null` when no ratings exist
+- `rating_count` — `int` — number of individual star ratings submitted
+
+### Tests (`test_list_all_interventions_ratings.py`)
+
+| Test | Scenario | Expected |
+|---|---|---|
+| `test_list_all_interventions_avg_rating_none_when_no_feedback` | No logs at all | `avg_rating: null`, `rating_count: 0` |
+| `test_list_all_interventions_avg_rating_single_rating` | One patient gives 4 stars | `avg_rating: 4.0`, `rating_count: 1` |
+| `test_list_all_interventions_avg_rating_multiple_patients` | Patient A: 5 stars, Patient B: 3 stars | `avg_rating: 4.0`, `rating_count: 2` |
+| `test_list_all_interventions_non_rating_feedback_excluded_from_average` | Only `difficulty_scale` answer submitted | `avg_rating: null`, `rating_count: 0` |
+| `test_list_all_interventions_independent_avg_per_intervention` | Two interventions, only one rated | Rated: `avg_rating: 5.0`; Unrated: `avg_rating: null` |
+| `test_list_all_interventions_avg_rating_rounded_to_one_decimal` | Three ratings: 1, 2, 4 (mean = 2.333…) | `avg_rating: 2.3`, `rating_count: 3` |
+
+---
+
+## `apply_template_to_patient`, `get_intervention_by_external_id`, `add_new_intervention`, `list_intervention_diagnoses`
+
+See [`test_recomendation_views_extra.py`](test_recomendation_views_extra.py) for validation-branch coverage.
 
 ## Running
 ```bash

--- a/backend/tests/recomendation_views/test_list_all_interventions_ratings.py
+++ b/backend/tests/recomendation_views/test_list_all_interventions_ratings.py
@@ -135,8 +135,7 @@ def _make_star_question(question_key="rating_stars_education"):
         applicable_types=["All"],  # simplified: "All" so aggregation finds it regardless of type
         translations=[Translation(language="en", text="Rate it")],
         possibleAnswers=[
-            AnswerOption(key=str(i), translations=[Translation(language="en", text=f"{i}/5")])
-            for i in range(1, 6)
+            AnswerOption(key=str(i), translations=[Translation(language="en", text=f"{i}/5")]) for i in range(1, 6)
         ],
     )
     q.save()
@@ -260,9 +259,7 @@ def test_list_all_interventions_non_rating_feedback_excluded_from_average(mongo_
         answer_type="select",
         applicable_types=["All"],
         translations=[Translation(language="en", text="Difficulty?")],
-        possibleAnswers=[
-            AnswerOption(key="too_easy", translations=[Translation(language="en", text="Too easy")])
-        ],
+        possibleAnswers=[AnswerOption(key="too_easy", translations=[Translation(language="en", text="Too easy")])],
     )
     difficulty_q.save()
 
@@ -301,9 +298,7 @@ def test_list_all_interventions_non_rating_feedback_excluded_from_average(mongo_
     rated = next((x for x in resp.json() if x["_id"] == str(iv.id)), None)
     assert rated is not None
     # No star ratings submitted → should still be null
-    assert rated["avg_rating"] is None, (
-        f"Non-star feedback leaked into avg_rating: {rated['avg_rating']}"
-    )
+    assert rated["avg_rating"] is None, f"Non-star feedback leaked into avg_rating: {rated['avg_rating']}"
     assert rated["rating_count"] == 0
 
 

--- a/backend/tests/recomendation_views/test_list_all_interventions_ratings.py
+++ b/backend/tests/recomendation_views/test_list_all_interventions_ratings.py
@@ -1,0 +1,353 @@
+"""
+list_all_interventions — avg_rating / rating_count tests
+=========================================================
+
+Endpoints covered
+-----------------
+``GET /api/interventions/all/``                  → ``list_all_interventions``
+``GET /api/interventions/all/<patient_id>/``     → ``list_all_interventions``
+
+Coverage goals
+--------------
+Star-rating aggregation
+  * ``avg_rating`` and ``rating_count`` are ``None`` / 0 when no logs exist.
+  * ``avg_rating`` is computed correctly when one patient has submitted a rating.
+  * Ratings from multiple patients are averaged together.
+  * Only ``rating_stars_*`` questions are included in the aggregation;
+    unrelated feedback (difficulty_scale, open_feedback) does not skew the
+    average.
+  * Private interventions are included in the aggregation lookup.
+  * Missing / malformed answer keys do not crash the endpoint.
+
+Test setup
+----------
+The ``mongo_mock`` autouse fixture provides a fresh in-memory MongoDB for
+every test.  Helper functions build the minimal object graph required for
+each scenario.
+"""
+
+from datetime import datetime, timedelta
+
+import mongomock
+import pytest
+from bson import ObjectId
+from django.test import Client
+
+from core.models import (
+    AnswerOption,
+    FeedbackQuestion,
+    Intervention,
+    Patient,
+    PatientInterventionLogs,
+    RehabilitationPlan,
+    Therapist,
+    Translation,
+    User,
+)
+
+client = Client()
+
+
+# ---------------------------------------------------------------------------
+# Fixtures and helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True, scope="function")
+def mongo_mock():
+    """Isolated in-memory MongoDB for every test."""
+    from mongoengine import connect, disconnect
+    from mongoengine.connection import _connections
+
+    alias = "default"
+    if alias in _connections:
+        disconnect(alias)
+
+    conn = connect(
+        "mongoenginetest",
+        alias=alias,
+        host="mongodb://localhost",
+        mongo_client_class=mongomock.MongoClient,
+    )
+    yield conn
+    disconnect(alias)
+
+
+def _make_intervention(content_type="Video", external_id=None, is_private=False):
+    """Create and save a public or private Intervention document."""
+    iv = Intervention(
+        external_id=external_id or str(ObjectId()),
+        language="en",
+        title="Test Intervention",
+        description="Desc",
+        content_type=content_type,
+        is_private=is_private,
+    )
+    iv.save()
+    return iv
+
+
+def _make_patient():
+    """Create a minimal User + Therapist + Patient chain."""
+    therapist_user = User(
+        username=f"th-{ObjectId()}",
+        createdAt=datetime.now(),
+        isActive=True,
+    )
+    therapist_user.save()
+    therapist = Therapist(userId=therapist_user, default_recommendations=[])
+    therapist.save()
+
+    patient_user = User(
+        username=f"p-{ObjectId()}",
+        createdAt=datetime.now(),
+        isActive=True,
+    )
+    patient_user.save()
+    patient = Patient(
+        userId=patient_user,
+        patient_code=f"PAT-{ObjectId()}",
+        name="Patient",
+        first_name="Test",
+        access_word="pass",
+        age="30",
+        therapist=therapist,
+        sex="Male",
+        diagnosis=["Stroke"],
+        function=["Cardiology"],
+        level_of_education="High School",
+        professional_status="Employed Full-Time",
+        marital_status="Single",
+        lifestyle=[],
+        personal_goals=[],
+        reha_end_date=datetime.now() + timedelta(days=30),
+    )
+    patient.save()
+    return patient
+
+
+def _make_star_question(question_key="rating_stars_education"):
+    """Seed one star-rating FeedbackQuestion with keys '1'–'5'."""
+    q = FeedbackQuestion(
+        questionSubject="Intervention",
+        questionKey=question_key,
+        answer_type="select",
+        applicable_types=["All"],  # simplified: "All" so aggregation finds it regardless of type
+        translations=[Translation(language="en", text="Rate it")],
+        possibleAnswers=[
+            AnswerOption(key=str(i), translations=[Translation(language="en", text=f"{i}/5")])
+            for i in range(1, 6)
+        ],
+    )
+    q.save()
+    return q
+
+
+def _submit_star_rating(patient, intervention, star_question, star_value: int):
+    """
+    Write a PatientInterventionLogs entry containing a star-rating FeedbackEntry.
+    ``star_value`` must be 1–5.
+    """
+    from core.models import FeedbackEntry
+
+    plan = RehabilitationPlan.objects(patientId=patient).first()
+    if plan is None:
+        plan = RehabilitationPlan(
+            patientId=patient,
+            therapistId=patient.therapist,
+            startDate=datetime.now(),
+            endDate=datetime.now() + timedelta(days=30),
+            status="active",
+            interventions=[],
+        )
+        plan.save()
+
+    entry = FeedbackEntry(
+        questionId=star_question,
+        answerKey=[AnswerOption(key=str(star_value), translations=[])],
+        comment="",
+    )
+    log = PatientInterventionLogs(
+        userId=patient,
+        interventionId=intervention,
+        rehabilitationPlanId=plan,
+        date=datetime.now(),
+        status=["completed"],
+        feedback=[entry],
+    )
+    log.save()
+    return log
+
+
+# ===========================================================================
+# avg_rating / rating_count on GET /api/interventions/all/
+# ===========================================================================
+
+
+def test_list_all_interventions_avg_rating_none_when_no_feedback(mongo_mock):
+    """
+    Interventions with no feedback logs must have ``avg_rating: null`` and
+    ``rating_count: 0`` in the response.
+
+    This is the baseline state for a newly uploaded intervention.
+    """
+    _make_intervention()
+
+    resp = client.get("/api/interventions/all/", HTTP_AUTHORIZATION="Bearer test")
+    assert resp.status_code == 200
+
+    data = resp.json()
+    assert len(data) >= 1
+    item = data[0]
+    assert item["avg_rating"] is None, f"Expected None, got {item['avg_rating']}"
+    assert item["rating_count"] == 0, f"Expected 0, got {item['rating_count']}"
+
+
+def test_list_all_interventions_avg_rating_single_rating(mongo_mock):
+    """
+    After one patient gives a 4-star rating, the intervention's
+    ``avg_rating`` must be 4.0 and ``rating_count`` must be 1.
+    """
+    iv = _make_intervention()
+    star_q = _make_star_question()
+    patient = _make_patient()
+    _submit_star_rating(patient, iv, star_q, star_value=4)
+
+    resp = client.get("/api/interventions/all/", HTTP_AUTHORIZATION="Bearer test")
+    assert resp.status_code == 200
+
+    rated = next((x for x in resp.json() if x["_id"] == str(iv.id)), None)
+    assert rated is not None, "Intervention not found in response"
+    assert rated["avg_rating"] == 4.0, f"Expected 4.0, got {rated['avg_rating']}"
+    assert rated["rating_count"] == 1, f"Expected 1, got {rated['rating_count']}"
+
+
+def test_list_all_interventions_avg_rating_multiple_patients(mongo_mock):
+    """
+    Ratings from multiple patients are averaged correctly.
+
+    Patient A rates 5 stars, Patient B rates 3 stars → average 4.0.
+    """
+    iv = _make_intervention()
+    star_q = _make_star_question()
+    patient_a = _make_patient()
+    patient_b = _make_patient()
+    _submit_star_rating(patient_a, iv, star_q, star_value=5)
+    _submit_star_rating(patient_b, iv, star_q, star_value=3)
+
+    resp = client.get("/api/interventions/all/", HTTP_AUTHORIZATION="Bearer test")
+    assert resp.status_code == 200
+
+    rated = next((x for x in resp.json() if x["_id"] == str(iv.id)), None)
+    assert rated is not None
+    assert rated["avg_rating"] == 4.0, f"Expected 4.0, got {rated['avg_rating']}"
+    assert rated["rating_count"] == 2, f"Expected 2, got {rated['rating_count']}"
+
+
+def test_list_all_interventions_non_rating_feedback_excluded_from_average(mongo_mock):
+    """
+    Non-star feedback (difficulty_scale, open_feedback) must not affect
+    ``avg_rating``.  Only ``rating_stars_*`` question keys feed the aggregation.
+    """
+    from core.models import FeedbackEntry
+
+    iv = _make_intervention()
+
+    # Seed a non-star question
+    difficulty_q = FeedbackQuestion(
+        questionSubject="Intervention",
+        questionKey="difficulty_scale",
+        answer_type="select",
+        applicable_types=["All"],
+        translations=[Translation(language="en", text="Difficulty?")],
+        possibleAnswers=[
+            AnswerOption(key="too_easy", translations=[Translation(language="en", text="Too easy")])
+        ],
+    )
+    difficulty_q.save()
+
+    # Also seed a star question so the aggregation has something to look for
+    star_q = _make_star_question()
+
+    patient = _make_patient()
+    plan = RehabilitationPlan(
+        patientId=patient,
+        therapistId=patient.therapist,
+        startDate=datetime.now(),
+        endDate=datetime.now() + timedelta(days=30),
+        status="active",
+        interventions=[],
+    )
+    plan.save()
+
+    # Log with difficulty answer only — no star rating
+    difficulty_entry = FeedbackEntry(
+        questionId=difficulty_q,
+        answerKey=[AnswerOption(key="too_easy", translations=[])],
+        comment="",
+    )
+    PatientInterventionLogs(
+        userId=patient,
+        interventionId=iv,
+        rehabilitationPlanId=plan,
+        date=datetime.now(),
+        status=["completed"],
+        feedback=[difficulty_entry],
+    ).save()
+
+    resp = client.get("/api/interventions/all/", HTTP_AUTHORIZATION="Bearer test")
+    assert resp.status_code == 200
+
+    rated = next((x for x in resp.json() if x["_id"] == str(iv.id)), None)
+    assert rated is not None
+    # No star ratings submitted → should still be null
+    assert rated["avg_rating"] is None, (
+        f"Non-star feedback leaked into avg_rating: {rated['avg_rating']}"
+    )
+    assert rated["rating_count"] == 0
+
+
+def test_list_all_interventions_independent_avg_per_intervention(mongo_mock):
+    """
+    Ratings for one intervention must not affect the avg_rating of another.
+
+    Two interventions: only one is rated.  The unrated one keeps avg_rating=null.
+    """
+    iv_rated = _make_intervention(external_id="EXT-RATED")
+    iv_unrated = _make_intervention(external_id="EXT-UNRATED")
+
+    star_q = _make_star_question()
+    patient = _make_patient()
+    _submit_star_rating(patient, iv_rated, star_q, star_value=5)
+
+    resp = client.get("/api/interventions/all/", HTTP_AUTHORIZATION="Bearer test")
+    assert resp.status_code == 200
+    data = resp.json()
+
+    rated = next((x for x in data if x["_id"] == str(iv_rated.id)), None)
+    unrated = next((x for x in data if x["_id"] == str(iv_unrated.id)), None)
+
+    assert rated is not None and unrated is not None
+    assert rated["avg_rating"] == 5.0
+    assert unrated["avg_rating"] is None
+    assert unrated["rating_count"] == 0
+
+
+def test_list_all_interventions_avg_rating_rounded_to_one_decimal(mongo_mock):
+    """
+    avg_rating is rounded to one decimal place in the response.
+
+    Three ratings of 1, 2, 3 → raw mean = 2.0 (exact).
+    Three ratings of 1, 2, 4 → raw mean = 2.333… → reported as 2.3.
+    """
+    iv = _make_intervention()
+    star_q = _make_star_question()
+    for star_value in (1, 2, 4):
+        _submit_star_rating(_make_patient(), iv, star_q, star_value=star_value)
+
+    resp = client.get("/api/interventions/all/", HTTP_AUTHORIZATION="Bearer test")
+    rated = next((x for x in resp.json() if x["_id"] == str(iv.id)), None)
+    assert rated is not None
+    # 7 / 3 = 2.333... rounded to 1 dp = 2.3
+    assert rated["avg_rating"] == 2.3, f"Expected 2.3, got {rated['avg_rating']}"
+    assert rated["rating_count"] == 3

--- a/docs/09-API_DOCUMENTATION.md
+++ b/docs/09-API_DOCUMENTATION.md
@@ -878,7 +878,50 @@ JWT required. Note: legacy spelling (`questionaire`).
 
 JWT required.
 
-**Response 200:** Questionnaire with questions for the given type/patient context.
+**Query parameters:**
+
+| Parameter        | Type   | Required | Notes |
+|------------------|--------|----------|-------|
+| `interventionId` | string | no       | ObjectId of the intervention being rated. Must be provided for the star-rating question to be included. |
+
+**Path parameter `questionaire_type`:** `"Intervention"` or `"Healthstatus"`.
+
+**Response 200** (`{ "questions": [...] }`):
+
+Each question object:
+
+```json
+{
+  "questionKey": "rating_stars_education",
+  "answerType": "select",
+  "translations": [
+    { "language": "en", "text": "How did you like the content?" },
+    { "language": "de", "text": "Wie fandest du den Inhalt?" }
+  ],
+  "possibleAnswers": [
+    { "key": "1", "translations": [{ "language": "en", "text": "★☆☆☆☆ (1/5)" }] },
+    { "key": "2", "translations": [{ "language": "en", "text": "★★☆☆☆ (2/5)" }] },
+    { "key": "3", "translations": [{ "language": "en", "text": "★★★☆☆ (3/5)" }] },
+    { "key": "4", "translations": [{ "language": "en", "text": "★★★★☆ (4/5)" }] },
+    { "key": "5", "translations": [{ "language": "en", "text": "★★★★★ (5/5)" }] }
+  ]
+}
+```
+
+**Intervention feedback question order (Frage 1 → 2 → Open):**
+
+| Position | `questionKey` | `answerType` | Condition |
+|----------|--------------|--------------|-----------|
+| 1 | `rating_stars_education` | `select` | `content_type` ∈ `Education`, `Instruction`, `Text`, `PDF`, `Video`, `Audio`, `Website`, `Apps` |
+| 1 | `rating_stars_exercise` | `select` | `content_type` ∈ `Exercise`, `Exercises`, `Physiotherapy`, `Training`, `Movement` |
+| 2 | `difficulty_scale` | `select` | always included |
+| 3 | `open_feedback` | `text` | always included |
+
+The star-rating question is resolved from the intervention's `content_type`. The lookup first checks the patient's rehabilitation plan assignment; if the intervention is not assigned (library-browse path), the `Intervention` document is looked up directly. When no `interventionId` is supplied, only the `difficulty_scale` and `open_feedback` questions are returned.
+
+The seed command `python manage.py seed_feedback_questions` must be run at least once to populate the `FeedbackQuestions` collection.
+
+**Errors:** 400 invalid patient id · 400 invalid type · 404 patient not found · 405
 
 ---
 
@@ -921,7 +964,38 @@ JWT required.
 
 JWT required. When `patient_id` is provided, filters interventions relevant to the patient's specialities/diagnosis.
 
+**Query parameters:**
+
+| Parameter     | Type   | Required | Notes |
+|---------------|--------|----------|-------|
+| `lang`        | string | no       | ISO language code (e.g. `de`). Selects the best language variant of each public intervention. |
+| `external_id` | string | no       | Returns only the single intervention group matching this external id. |
+
 **Response 200:** Array of intervention summary objects.
+
+```json
+[
+  {
+    "_id": "507f1f77bcf86cd799439011",
+    "external_id": "EXT-001",
+    "language": "de",
+    "available_languages": ["de", "en"],
+    "title": "Kniebeugen",
+    "description": "...",
+    "content_type": "Exercise",
+    "aims": ["exercise"],
+    "tags": ["strength", "lower body"],
+    "duration": 15,
+    "preview_img": "https://...",
+    "media": [],
+    "is_private": false,
+    "avg_rating": 4.3,
+    "rating_count": 12
+  }
+]
+```
+
+**`avg_rating` / `rating_count`** — aggregated from all `PatientInterventionLogs` feedback entries whose question key starts with `rating_stars_`. `avg_rating` is rounded to one decimal place and is `null` when no ratings have been submitted. `rating_count` is the total number of individual star ratings across all patients.
 
 ---
 

--- a/docs/09-API_OPENAPI.yaml
+++ b/docs/09-API_OPENAPI.yaml
@@ -483,23 +483,54 @@ paths:
   /api/patients/get-questions/{questionaire_type}/{patient_id}/:
     get:
       tags: [Patients]
-      summary: Get feedback questions (without intervention)
+      summary: Get feedback questions
+      description: >
+        Returns the ordered list of feedback questions for the given type.
+        For `questionaire_type=Intervention`, supply `?interventionId=<id>` to
+        receive the star-rating question (Frage 1) appropriate for that
+        intervention's `content_type`. Without `interventionId` only the
+        core questions (difficulty_scale, open_feedback) are returned.
+        Questions are returned in UI order: star rating first, difficulty
+        second, open feedback last.
       parameters:
         - $ref: '#/components/parameters/questionaire_type'
         - $ref: '#/components/parameters/patient_id'
+        - in: query
+          name: interventionId
+          schema: { type: string }
+          description: >
+            ObjectId of the intervention being rated. Required for the
+            star-rating question (Frage 1) to be included. The backend first
+            checks the patient's rehabilitation plan; if not found, it looks up
+            the Intervention document directly (library-browse path).
       responses:
-        '200': { $ref: '#/components/responses/OK' }
+        '200':
+          description: Ordered list of feedback questions
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/FeedbackQuestionsResponse' }
+        '400': { $ref: '#/components/responses/BadRequest' }
+        '404': { $ref: '#/components/responses/NotFound' }
 
   /api/patients/get-questions/{questionaire_type}/{patient_id}/{intervention_id}/:
     get:
       tags: [Patients]
-      summary: Get feedback questions (with intervention)
+      summary: Get feedback questions (intervention id in path)
+      description: >
+        Same as the query-parameter variant but accepts the intervention id as
+        a path segment. Both forms are supported for backwards compatibility.
       parameters:
         - $ref: '#/components/parameters/questionaire_type'
         - $ref: '#/components/parameters/patient_id'
         - $ref: '#/components/parameters/intervention_id'
       responses:
-        '200': { $ref: '#/components/responses/OK' }
+        '200':
+          description: Ordered list of feedback questions
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/FeedbackQuestionsResponse' }
+        '400': { $ref: '#/components/responses/BadRequest' }
+        '404': { $ref: '#/components/responses/NotFound' }
 
   /api/users/{patient_id}/initial-questionaire/:
     post:
@@ -627,27 +658,50 @@ paths:
     get:
       tags: [Interventions]
       summary: List interventions
+      description: >
+        Returns all public interventions grouped by `external_id` (best language
+        variant selected). Each item includes `avg_rating` (average star rating
+        across all patients, rounded to 1 dp; `null` when unrated) and
+        `rating_count` (total individual star ratings submitted).
       parameters:
         - in: query
           name: lang
           schema: { type: string }
+          description: ISO language code for variant selection (e.g. `de`).
         - in: query
           name: external_id
           schema: { type: string }
+          description: Return only the single group matching this external id.
       responses:
-        '200': { $ref: '#/components/responses/OK' }
+        '200':
+          description: Array of intervention summary objects
+          content:
+            application/json:
+              schema:
+                type: array
+                items: { $ref: '#/components/schemas/InterventionSummary' }
 
   /api/interventions/all/{patient_id}/:
     get:
       tags: [Interventions]
       summary: List interventions including patient-private entries
+      description: >
+        Same as `/api/interventions/all/` but also includes private interventions
+        created for this specific patient. `avg_rating` and `rating_count` are
+        included for all items.
       parameters:
         - $ref: '#/components/parameters/patient_id'
         - in: query
           name: lang
           schema: { type: string }
       responses:
-        '200': { $ref: '#/components/responses/OK' }
+        '200':
+          description: Array of intervention summary objects
+          content:
+            application/json:
+              schema:
+                type: array
+                items: { $ref: '#/components/schemas/InterventionSummary' }
 
   /api/interventions/add/:
     post:
@@ -1141,6 +1195,103 @@ components:
       required: true
       schema: { type: string }
   schemas:
+    FeedbackPossibleAnswer:
+      type: object
+      properties:
+        key: { type: string, example: "3" }
+        translations:
+          type: array
+          items:
+            type: object
+            properties:
+              language: { type: string, example: "de" }
+              text: { type: string, example: "★★★☆☆ (3/5)" }
+
+    FeedbackQuestion:
+      type: object
+      description: >
+        A single feedback question. `answerType` controls the UI widget:
+        `select` with a `questionKey` starting with `rating_stars_` renders as
+        a 5-star picker; `select` for other keys renders as a radio/dropdown;
+        `text` renders as a free-text + audio field.
+      properties:
+        questionKey:
+          type: string
+          example: rating_stars_education
+          enum:
+            - rating_stars_education
+            - rating_stars_exercise
+            - difficulty_scale
+            - open_feedback
+        answerType:
+          type: string
+          enum: [select, text, multi-select, video]
+        translations:
+          type: array
+          items:
+            type: object
+            properties:
+              language: { type: string, example: "de" }
+              text: { type: string, example: "Wie fandest du den Inhalt?" }
+        possibleAnswers:
+          type: array
+          items: { $ref: '#/components/schemas/FeedbackPossibleAnswer' }
+
+    FeedbackQuestionsResponse:
+      type: object
+      description: >
+        Ordered list of feedback questions for the requested type. For
+        `questionaire_type=Intervention` the order is always:
+        1. Star rating (Frage 1) — `rating_stars_education` or `rating_stars_exercise`
+        2. Difficulty scale (Frage 2) — `difficulty_scale`
+        3. Open feedback — `open_feedback`
+      properties:
+        questions:
+          type: array
+          items: { $ref: '#/components/schemas/FeedbackQuestion' }
+
+    InterventionSummary:
+      type: object
+      description: Intervention object as returned by GET /api/interventions/all/.
+      properties:
+        _id: { type: string, example: "507f1f77bcf86cd799439011" }
+        external_id: { type: string, example: "EXT-001" }
+        language: { type: string, example: "de" }
+        available_languages:
+          type: array
+          items: { type: string }
+          example: ["de", "en"]
+        title: { type: string }
+        description: { type: string }
+        content_type:
+          type: string
+          example: Exercise
+          enum: [Exercise, Video, Audio, Text, PDF, Website, Apps, Instruction, Education]
+        aims:
+          type: array
+          items: { type: string }
+        tags:
+          type: array
+          items: { type: string }
+        duration: { type: integer, example: 15, description: "Minutes" }
+        preview_img: { type: string, format: uri }
+        media:
+          type: array
+          items: { type: object }
+        is_private: { type: boolean }
+        avg_rating:
+          type: number
+          format: float
+          nullable: true
+          example: 4.3
+          description: >
+            Average star rating (1–5) across all patients, rounded to 1 decimal
+            place. `null` when no ratings have been submitted yet.
+        rating_count:
+          type: integer
+          example: 12
+          description: Total number of individual star ratings submitted.
+
     SuccessBooleanMessageResponse:
       type: object
       properties:

--- a/frontend/src/__tests__/components/PatientLibrary/PatientLibraryInterventionCard.test.tsx
+++ b/frontend/src/__tests__/components/PatientLibrary/PatientLibraryInterventionCard.test.tsx
@@ -51,4 +51,73 @@ describe('PatientLibraryInterventionCard', () => {
     expect(screen.getByText('Breathing')).toBeInTheDocument();
     expect(screen.getByText('-')).toBeInTheDocument();
   });
+
+  // -------------------------------------------------------------------------
+  // Star rating badge (avg_rating)
+  // -------------------------------------------------------------------------
+
+  it('shows star badge with filled/empty stars and numeric average when avg_rating is provided', () => {
+    // avg_rating = 4.3 → Math.round(4.3) = 4 → ★★★★☆
+    render(
+      <PatientLibraryInterventionCard
+        item={{ duration: 20, content_type: 'Exercise', avg_rating: 4.3, rating_count: 12 }}
+        displayTitle="Squats"
+        Icon={MockMainIcon}
+        contentTypeIcon={MockContentTypeIcon}
+        containerClassName="w-full"
+        onClick={() => {}}
+      />
+    );
+
+    // Numeric average is shown
+    expect(screen.getByText('4.3')).toBeInTheDocument();
+    // Correct filled/empty star pattern
+    expect(screen.getByText('★★★★☆')).toBeInTheDocument();
+  });
+
+  it('shows 5 filled stars when avg_rating is 5', () => {
+    render(
+      <PatientLibraryInterventionCard
+        item={{ duration: 10, content_type: 'Video', avg_rating: 5.0, rating_count: 3 }}
+        displayTitle="Yoga"
+        Icon={MockMainIcon}
+        contentTypeIcon={null}
+        containerClassName="w-full"
+        onClick={() => {}}
+      />
+    );
+
+    expect(screen.getByText('★★★★★')).toBeInTheDocument();
+    expect(screen.getByText('5.0')).toBeInTheDocument();
+  });
+
+  it('hides star badge when avg_rating is null', () => {
+    render(
+      <PatientLibraryInterventionCard
+        item={{ duration: 20, content_type: 'Exercise', avg_rating: null }}
+        displayTitle="No-Rating Exercise"
+        Icon={MockMainIcon}
+        contentTypeIcon={null}
+        containerClassName="w-full"
+        onClick={() => {}}
+      />
+    );
+
+    expect(screen.queryByText(/★/)).not.toBeInTheDocument();
+  });
+
+  it('hides star badge when avg_rating is undefined (field absent)', () => {
+    render(
+      <PatientLibraryInterventionCard
+        item={{ duration: 15, content_type: 'Audio' }}
+        displayTitle="Podcast"
+        Icon={MockMainIcon}
+        contentTypeIcon={null}
+        containerClassName="w-full"
+        onClick={() => {}}
+      />
+    );
+
+    expect(screen.queryByText(/★/)).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/components/PatientLibrary/PatientLibraryInterventionCard.tsx
+++ b/frontend/src/components/PatientLibrary/PatientLibraryInterventionCard.tsx
@@ -6,6 +6,8 @@ import { Badge } from '@/components/ui/badge';
 type PatientLibraryInterventionCardItem = {
   duration?: string | number;
   content_type?: string;
+  avg_rating?: number | null;
+  rating_count?: number;
 };
 
 type PatientLibraryInterventionCardProps = {
@@ -47,6 +49,15 @@ const PatientLibraryInterventionCard: React.FC<PatientLibraryInterventionCardPro
             {ContentTypeIcon && <ContentTypeIcon className="w-4 h-4" />}
             <div className="text-[#00956C] font-medium">{t(item.content_type) || '-'}</div>
           </Badge>
+          {item.avg_rating != null && (
+            <Badge className="flex gap-1 bg-white py-2 px-3 rounded-xl border border-accent shadow-none font-medium text-lg text-zinc-500">
+              <span className="text-[#EFA73B]">
+                {'★'.repeat(Math.round(item.avg_rating))}
+                {'☆'.repeat(5 - Math.round(item.avg_rating))}
+              </span>
+              <span className="text-[#00956C] font-medium">{item.avg_rating.toFixed(1)}</span>
+            </Badge>
+          )}
         </div>
       </div>
     </div>

--- a/frontend/src/stores/interventionsLibraryStore.ts
+++ b/frontend/src/stores/interventionsLibraryStore.ts
@@ -123,6 +123,10 @@ const normalizeIntervention = (raw: unknown): UnknownRec => {
   n.where = Array.isArray(n.where) ? n.where : [];
   n.setting = Array.isArray(n.setting) ? n.setting : [];
 
+  // star rating aggregation from backend
+  n.avg_rating = typeof (n as any).avg_rating === 'number' ? (n as any).avg_rating : null;
+  n.rating_count = typeof (n as any).rating_count === 'number' ? (n as any).rating_count : 0;
+
   return n;
 };
 

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -18,6 +18,8 @@ export interface InterventionTypeTh {
   }>;
   media_url?: string;
   link?: string;
+  avg_rating?: number | null;
+  rating_count?: number;
 }
 // src/types/AdminEntry.ts
 export interface AdminEntry {


### PR DESCRIPTION
## Summary

- **Fix star rating (Frage 1) missing from intervention feedback** — the 5-star rating question was seeded in the DB but never returned by the API because the backend resolved the intervention's `content_type` exclusively via the patient's rehabilitation plan assignment. When an intervention wasn't in any plan (library-browse path), `intervention_type` was `None` and only the "All" questions (difficulty scale, open feedback) were returned. Fixed by adding a fallback direct `Intervention` document lookup.
- **Fix question ordering** — questions are now returned stars-first (Frage 1), then difficulty scale (Frage 2), then open feedback, matching the agreed feedback structure.
- **Show average star rating in patient library cards** — the library endpoint now runs a single MongoDB aggregation over `PatientInterventionLogs` to compute `avg_rating` and `rating_count` per intervention and includes them in the response. Cards display a star badge (e.g. `★★★★☆ 4.2`) only when ratings exist.

## Changed files

| File | Change |
|------|--------|
| `backend/core/views/patient_views.py` | Fallback Intervention lookup + flip result order to `type_q + core_q` |
| `backend/core/views/recomendation_views.py` | Add `FeedbackQuestion` import; add `avg_rating`/`rating_count` fields; post-serialize aggregation pipeline |
| `frontend/src/stores/interventionsLibraryStore.ts` | Pass `avg_rating` / `rating_count` through `normalizeIntervention` |
| `frontend/src/types/index.ts` | Add `avg_rating?: number \| null` and `rating_count?: number` to `InterventionTypeTh` |
| `frontend/src/components/PatientLibrary/PatientLibraryInterventionCard.tsx` | Extend type + render star badge when `avg_rating` is set |
| `backend/tests/patient_views/test_get_endpoints.py` | +5 tests for star rating question selection, ordering, and fallback lookup |
| `backend/tests/recomendation_views/test_list_all_interventions_ratings.py` | New file — 6 tests for `avg_rating`/`rating_count` aggregation |
| `frontend/src/__tests__/components/PatientLibrary/PatientLibraryInterventionCard.test.tsx` | +4 tests for star badge rendering |
| `backend/tests/patient_views/TESTING.md` | Document 3-question feedback structure and new test cases |
| `backend/tests/recomendation_views/TESTING.md` | New `avg_rating` aggregation section with test table |
| `docs/09-API_DOCUMENTATION.md` | Expanded `get-questions` and `interventions/all` endpoint specs |
| `docs/09-API_OPENAPI.yaml` | New schemas: `FeedbackQuestion`, `FeedbackQuestionsResponse`, `InterventionSummary` with `avg_rating`/`rating_count` |

## Test plan

- [ ] Run `docker exec django python manage.py seed_feedback_questions` and confirm 4 questions upserted
- [ ] `docker exec django pytest tests/patient_views/test_get_endpoints.py tests/recomendation_views/test_list_all_interventions_ratings.py -v` — all 25 pass
- [ ] `cd frontend && npx jest PatientLibraryInterventionCard --no-coverage` — all 6 pass
- [ ] As a patient, open a feedback sheet for an intervention **in your Reha-Table** → star rating appears as the first question
- [ ] As a patient, open a feedback sheet for an intervention **from the library** (not yet in your plan) → star rating still appears first
- [ ] Submit a star rating and reload the library → the rated intervention's card shows the star badge with the average and count
- [ ] Interventions with no ratings yet show no star badge (only duration + content-type badges)
