### PR TITLE
Bug template creation [WIP]

### DIFF
--- a/backend/core/views/template_views.py
+++ b/backend/core/views/template_views.py
@@ -456,7 +456,11 @@ def template_intervention_assign(request, template_id):
     )
 
     if existing is not None:
-        existing.diagnosis_assignments[diagnosis_key] = [schedule]
+        # MongoEngine does not detect in-place mutations of nested dicts inside
+        # EmbeddedDocument fields — reassign the whole dict to force dirty-tracking.
+        da = dict(existing.diagnosis_assignments or {})
+        da[diagnosis_key] = [schedule]
+        existing.diagnosis_assignments = da
     else:
         entry = DefaultInterventions(
             recommendation=intervention,
@@ -502,7 +506,11 @@ def template_intervention_remove(request, template_id, intervention_id):
         # Remove just that diagnosis block from the matching entry.
         for rec in tmpl.recommendations:
             if _rec_intervention_id(rec) == intervention_id:
-                rec.diagnosis_assignments.pop(diagnosis_key, None)
+                # Reassign dict to force MongoEngine dirty-tracking (in-place
+                # mutations like .pop() are silently ignored by change detection).
+                da = dict(rec.diagnosis_assignments or {})
+                da.pop(diagnosis_key, None)
+                rec.diagnosis_assignments = da
                 # Drop the whole entry if no blocks remain.
                 if not rec.diagnosis_assignments:
                     tmpl.recommendations.remove(rec)

--- a/backend/tests/template_views/TESTING.md
+++ b/backend/tests/template_views/TESTING.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-`test_template_views.py` contains **63 tests** covering the three phases of the
+`test_template_views.py` contains **77 tests** covering the three phases of the
 named-template system introduced in `backend/core/views/template_views.py`.
 
 Run from inside the Django container:
@@ -140,6 +140,25 @@ patch `_get_therapist` and forward all kwargs to Django's test client.
 - Other's private template → 404 ✓
 - Creates `RehabilitationPlan` when none exists ✓
 - GET returns 405 ✓
+
+### MongoEngine dirty-tracking regression (3 tests)
+
+These tests catch a class of silent data-loss bugs where in-place mutations of
+nested dicts inside `EmbeddedDocument` `ListField`s are not detected by
+MongoEngine's change-tracking and are therefore silently discarded by `.save()`.
+
+> **Root cause** (`template_views.py`): code like
+> `existing.diagnosis_assignments[key] = value` or
+> `rec.diagnosis_assignments.pop(key)` mutates the dict in-place. MongoEngine
+> never sees the change and writes the old (or empty) dict to MongoDB.
+> The fix is to always reassign the whole dict:
+> `existing.diagnosis_assignments = {**existing.diagnosis_assignments, key: value}`.
+
+| Test | Scenario | Asserts |
+|---|---|---|
+| `test_assign_then_apply_produces_sessions` | Fresh assign then apply | `applied==1`, `sessions_created > 0` |
+| `test_update_existing_assignment_persisted_on_apply` | Second assign (update path) with new `end_day`, then apply | Serialised response shows new `end_day`; apply creates > 1 session |
+| `test_remove_diagnosis_block_persisted` | Assign two diagnosis blocks, remove one via `?diagnosis=` | Removed block absent; other block present after re-fetch |
 
 ### Phase 3 — Calendar preview (11 tests)
 

--- a/backend/tests/template_views/test_template_views.py
+++ b/backend/tests/template_views/test_template_views.py
@@ -1582,3 +1582,136 @@ def test_apply_template_diagnosis_no_matching_patients(mongo_mock):
     assert data["applied"] == 0
     assert data["patients_affected"] == 0
     assert "message" in data
+
+
+# ===========================================================================
+# MongoEngine dirty-tracking regression tests
+# These tests guard against silent data loss caused by in-place mutation of
+# nested dicts inside EmbeddedDocument ListFields (MongoEngine does not detect
+# such mutations, so .save() would silently drop the change).
+# ===========================================================================
+
+
+def test_assign_then_apply_produces_sessions(mongo_mock):
+    """
+    Regression: assigning an intervention and immediately applying the template
+    must produce > 0 sessions.
+
+    Previously, when the intervention was NEWLY added (i.e. existing=None path),
+    this worked.  This test pins that behaviour so any regression in the creation
+    path is caught quickly.
+    """
+    _, therapist = _make_therapist()
+    _, patient = _make_patient(therapist)
+    tmpl = _make_template(therapist)  # empty template
+    intervention = _make_intervention()
+
+    # Assign the intervention to the template
+    assign_resp = _post_json(
+        ASSIGN_URL.format(id=tmpl.id),
+        {"interventionId": str(intervention.id), "end_day": 10},
+        therapist,
+    )
+    assert assign_resp.status_code == 200
+
+    tomorrow = (datetime.now() + timedelta(days=1)).strftime("%Y-%m-%d")
+    apply_resp = _post_json(
+        APPLY_URL.format(id=tmpl.id),
+        {"patientIds": [str(patient.id)], "effectiveFrom": tomorrow},
+        therapist,
+    )
+
+    assert apply_resp.status_code == 200, apply_resp.content.decode()
+    body = apply_resp.json()
+    assert body["applied"] == 1, "apply must report 1 intervention applied"
+    assert body["sessions_created"] > 0, "apply must create at least one session"
+
+
+def test_update_existing_assignment_persisted_on_apply(mongo_mock):
+    """
+    Regression (MongoEngine dirty-tracking bug): updating an existing
+    diagnosis block via a second POST to the assign endpoint and then applying
+    the template must use the UPDATED schedule, not the original one.
+
+    The bug: ``existing.diagnosis_assignments[key] = new_value`` mutates the
+    dict in-place, which MongoEngine's change-tracker ignores — the old value
+    is written to DB and apply produces 0 sessions (or uses wrong end_day).
+    The fix is to reassign the whole dict: ``existing.diagnosis_assignments = da``.
+    """
+    _, therapist = _make_therapist()
+    _, patient = _make_patient(therapist)
+    tmpl = _make_template(therapist)
+    intervention = _make_intervention()
+    url = ASSIGN_URL.format(id=tmpl.id)
+
+    # First assign: end_day=1 (very short — would create exactly 1 session)
+    _post_json(url, {"interventionId": str(intervention.id), "end_day": 1}, therapist)
+
+    # Second assign (UPDATE path — triggers the buggy branch): end_day=14
+    update_resp = _post_json(
+        url, {"interventionId": str(intervention.id), "end_day": 14}, therapist
+    )
+    assert update_resp.status_code == 200
+
+    # The serialised template returned by the assign endpoint must already
+    # reflect end_day=14 (checks in-memory correctness).
+    recs = update_resp.json()["template"]["recommendations"]
+    assert len(recs) == 1
+    assert recs[0]["diagnosis_assignments"]["_all"][0]["end_day"] == 14
+
+    # Apply the template — the DB-persisted schedule must also use end_day=14,
+    # so sessions_created must be > 1 (14-day window).
+    tomorrow = (datetime.now() + timedelta(days=1)).strftime("%Y-%m-%d")
+    apply_resp = _post_json(
+        APPLY_URL.format(id=tmpl.id),
+        {"patientIds": [str(patient.id)], "effectiveFrom": tomorrow},
+        therapist,
+    )
+    assert apply_resp.status_code == 200, apply_resp.content.decode()
+    body = apply_resp.json()
+    assert body["applied"] == 1, "apply must find the intervention"
+    assert body["sessions_created"] > 1, (
+        "updated end_day=14 must produce more than 1 session; "
+        "if sessions_created == 0 the dirty-tracking bug is back"
+    )
+
+
+def test_remove_diagnosis_block_persisted(mongo_mock):
+    """
+    Regression: removing a single diagnosis block via DELETE ?diagnosis=<key>
+    must persist after the delete.
+
+    The bug: ``rec.diagnosis_assignments.pop(key, None)`` mutates the dict
+    in-place, so MongoEngine ignores it and the entry reappears after reload.
+    The fix is to reassign the whole dict.
+    """
+    _, therapist = _make_therapist()
+    tmpl = _make_template(therapist)
+    intervention = _make_intervention()
+    assign_url = ASSIGN_URL.format(id=tmpl.id)
+
+    # Assign the same intervention under two different diagnosis keys
+    _post_json(assign_url, {"interventionId": str(intervention.id), "end_day": 5, "diagnosis": "Stroke"}, therapist)
+    _post_json(assign_url, {"interventionId": str(intervention.id), "end_day": 5, "diagnosis": "MS"}, therapist)
+
+    # Verify both blocks exist
+    detail_before = _get(f"/api/templates/{tmpl.id}/", therapist).json()
+    recs_before = detail_before["template"]["recommendations"]
+    assert len(recs_before) == 1
+    da_before = recs_before[0]["diagnosis_assignments"]
+    assert "Stroke" in da_before and "MS" in da_before
+
+    # Remove just the "MS" block
+    remove_resp = _delete(
+        f"/api/templates/{tmpl.id}/interventions/{intervention.id}/?diagnosis=MS",
+        therapist,
+    )
+    assert remove_resp.status_code == 200
+
+    # Re-fetch and confirm "MS" is gone but "Stroke" remains
+    detail_after = _get(f"/api/templates/{tmpl.id}/", therapist).json()
+    recs_after = detail_after["template"]["recommendations"]
+    assert len(recs_after) == 1, "intervention entry should still exist (Stroke block remains)"
+    da_after = recs_after[0]["diagnosis_assignments"]
+    assert "MS" not in da_after, "MS block must be removed from DB (dirty-tracking bug regression)"
+    assert "Stroke" in da_after, "Stroke block must be untouched"

--- a/backend/tests/template_views/test_template_views.py
+++ b/backend/tests/template_views/test_template_views.py
@@ -1648,9 +1648,7 @@ def test_update_existing_assignment_persisted_on_apply(mongo_mock):
     _post_json(url, {"interventionId": str(intervention.id), "end_day": 1}, therapist)
 
     # Second assign (UPDATE path — triggers the buggy branch): end_day=14
-    update_resp = _post_json(
-        url, {"interventionId": str(intervention.id), "end_day": 14}, therapist
-    )
+    update_resp = _post_json(url, {"interventionId": str(intervention.id), "end_day": 14}, therapist)
     assert update_resp.status_code == 200
 
     # The serialised template returned by the assign endpoint must already

--- a/frontend/e2e/template-assign-apply.spec.ts
+++ b/frontend/e2e/template-assign-apply.spec.ts
@@ -1,0 +1,500 @@
+/**
+ * E2E tests — Template assign & apply (MongoEngine dirty-tracking regression)
+ *
+ * These tests exercise the full stack through real HTTP calls to the backend,
+ * covering the bug where in-place dict mutations on MongoEngine EmbeddedDocument
+ * fields were silently discarded by .save(), causing "0 interventions, 0 sessions"
+ * when a template was applied after its schedule was updated.
+ *
+ * Two layers of coverage:
+ *   1. API-level  — uses Playwright's `request` fixture, no browser needed.
+ *   2. UI-level   — full browser flow through the Therapist Interventions page.
+ *
+ * Required environment variables (all tests skip gracefully when absent):
+ *   E2E_THERAPIST_LOGIN    — therapist username / email
+ *   E2E_THERAPIST_PASSWORD — therapist password
+ *   E2E_PATIENT_ID         — ObjectId of an existing patient to apply the template to
+ *
+ * The API base URL is read from:
+ *   VITE_API_URL  (default: http://127.0.0.1:8001/api)
+ */
+
+import { expect, test, type APIRequestContext } from '@playwright/test';
+
+// ---------------------------------------------------------------------------
+// Config helpers
+// ---------------------------------------------------------------------------
+
+const API_BASE = process.env.VITE_API_URL || 'http://127.0.0.1:8001/api';
+
+function creds() {
+  return {
+    login: process.env.E2E_THERAPIST_LOGIN,
+    password: process.env.E2E_THERAPIST_PASSWORD,
+    patientId: process.env.E2E_PATIENT_ID,
+  };
+}
+
+function skipUnlessSeeded(t: typeof test) {
+  const { login, password } = creds();
+  t.skip(
+    !login || !password,
+    'Missing E2E_THERAPIST_LOGIN / E2E_THERAPIST_PASSWORD — skipping seeded E2E tests'
+  );
+}
+
+function skipUnlessPatient(t: typeof test) {
+  const { login, password, patientId } = creds();
+  t.skip(
+    !login || !password || !patientId,
+    'Missing E2E_THERAPIST_LOGIN / E2E_THERAPIST_PASSWORD / E2E_PATIENT_ID — skipping apply tests'
+  );
+}
+
+// ---------------------------------------------------------------------------
+// API helpers
+// ---------------------------------------------------------------------------
+
+/** Obtain a JWT access token for the therapist. */
+async function getToken(request: APIRequestContext): Promise<string> {
+  const { login, password } = creds();
+  const res = await request.post(`${API_BASE}/auth/login/`, {
+    data: { username: login, password },
+  });
+  expect(res.ok(), `Login failed: ${await res.text()}`).toBeTruthy();
+  const body = await res.json();
+  return body.access_token as string;
+}
+
+/** Create a minimal template and return its id. */
+async function createTemplate(request: APIRequestContext, token: string): Promise<string> {
+  const res = await request.post(`${API_BASE}/templates/`, {
+    headers: { Authorization: `Bearer ${token}` },
+    data: { name: `E2E Regression ${Date.now()}` },
+  });
+  expect(res.ok(), `Create template failed: ${await res.text()}`).toBeTruthy();
+  const body = await res.json();
+  return body.template._id as string;
+}
+
+/** Return the _id of the first intervention returned by /interventions/all/. */
+async function getFirstInterventionId(
+  request: APIRequestContext,
+  token: string
+): Promise<string | null> {
+  const res = await request.get(`${API_BASE}/interventions/all/`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!res.ok()) return null;
+  const body = await res.json();
+  const list = Array.isArray(body) ? body : (body.data ?? body.results ?? []);
+  if (!list.length) return null;
+  return (list[0]._id ?? list[0].id) as string;
+}
+
+/** Assign an intervention to a template with a given end_day. */
+async function assignIntervention(
+  request: APIRequestContext,
+  token: string,
+  templateId: string,
+  interventionId: string,
+  endDay: number
+) {
+  const res = await request.post(`${API_BASE}/templates/${templateId}/interventions/`, {
+    headers: { Authorization: `Bearer ${token}` },
+    data: { interventionId, end_day: endDay },
+  });
+  expect(res.ok(), `Assign failed: ${await res.text()}`).toBeTruthy();
+  return res.json();
+}
+
+/** Apply a template to a patient and return the response body. */
+async function applyTemplate(
+  request: APIRequestContext,
+  token: string,
+  templateId: string,
+  patientId: string,
+  effectiveFrom: string
+) {
+  const res = await request.post(`${API_BASE}/templates/${templateId}/apply/`, {
+    headers: { Authorization: `Bearer ${token}` },
+    data: { patientIds: [patientId], effectiveFrom },
+  });
+  expect(res.ok(), `Apply failed: ${await res.text()}`).toBeTruthy();
+  return res.json();
+}
+
+/** Delete a template (cleanup). */
+async function deleteTemplate(
+  request: APIRequestContext,
+  token: string,
+  templateId: string
+) {
+  await request.delete(`${API_BASE}/templates/${templateId}/`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+}
+
+/** Tomorrow as YYYY-MM-DD string. */
+function tomorrow(): string {
+  const d = new Date();
+  d.setDate(d.getDate() + 1);
+  return d.toISOString().slice(0, 10);
+}
+
+// ---------------------------------------------------------------------------
+// UI helper
+// ---------------------------------------------------------------------------
+
+/** Log in via the home page modal and wait for the therapist redirect. */
+async function loginAsTherapist(page: Parameters<Parameters<typeof test>[1]>[0]) {
+  const { login, password } = creds();
+  await page.goto('/');
+  await page.getByRole('button', { name: /login/i }).first().click();
+  const modal = page.locator('.modal.show');
+  await expect(modal).toBeVisible();
+  await modal.locator('#email').fill(login as string);
+  await modal.locator('#password').fill(password as string);
+  const loginDone = page.waitForResponse(
+    (res) => res.url().includes('/auth/login/') && res.request().method() === 'POST'
+  );
+  await modal.getByRole('button', { name: /login/i }).click();
+  await loginDone;
+  await expect(page).toHaveURL(/\/therapist/);
+}
+
+// ===========================================================================
+// API-level E2E tests
+// ===========================================================================
+
+test.describe('Template assign/apply — API level', () => {
+  // ---- Assign then apply produces sessions ----------------------------------
+
+  test('fresh assign then apply returns applied=1 and sessions_created > 0', async ({
+    request,
+  }) => {
+    skipUnlessPatient(test);
+
+    const { patientId } = creds();
+    const token = await getToken(request);
+
+    const interventionId = await getFirstInterventionId(request, token);
+    test.skip(!interventionId, 'No interventions available in the DB — skipping');
+
+    const templateId = await createTemplate(request, token);
+
+    try {
+      // Assign with end_day=7
+      await assignIntervention(request, token, templateId, interventionId as string, 7);
+
+      // Apply
+      const body = await applyTemplate(request, token, templateId, patientId as string, tomorrow());
+
+      expect(body.success).toBe(true);
+      expect(body.applied).toBe(1);
+      expect(body.sessions_created).toBeGreaterThan(0);
+    } finally {
+      await deleteTemplate(request, token, templateId);
+    }
+  });
+
+  // ---- Update existing schedule then apply (the dirty-tracking regression) --
+
+  test('update existing schedule (second assign) then apply uses the NEW end_day', async ({
+    request,
+  }) => {
+    skipUnlessPatient(test);
+
+    const { patientId } = creds();
+    const token = await getToken(request);
+
+    const interventionId = await getFirstInterventionId(request, token);
+    test.skip(!interventionId, 'No interventions available in the DB — skipping');
+
+    const templateId = await createTemplate(request, token);
+
+    try {
+      // First assign: end_day=1 (short)
+      await assignIntervention(request, token, templateId, interventionId as string, 1);
+
+      // Second assign (UPDATE path — triggers the formerly-buggy branch): end_day=14
+      const updateBody = await assignIntervention(
+        request,
+        token,
+        templateId,
+        interventionId as string,
+        14
+      );
+
+      // The serialised response must already show end_day=14
+      const rec = updateBody.template.recommendations[0];
+      expect(rec.diagnosis_assignments._all[0].end_day).toBe(14);
+
+      // Apply — DB-persisted schedule must also use end_day=14
+      const applyBody = await applyTemplate(
+        request,
+        token,
+        templateId,
+        patientId as string,
+        tomorrow()
+      );
+
+      expect(applyBody.success).toBe(true);
+      expect(applyBody.applied).toBe(1);
+      // A 14-day window starting tomorrow must produce more than 1 session
+      expect(applyBody.sessions_created).toBeGreaterThan(1);
+    } finally {
+      await deleteTemplate(request, token, templateId);
+    }
+  });
+
+  // ---- Remove a diagnosis block, confirm it is gone from DB ----------------
+
+  test('removing a diagnosis block via DELETE ?diagnosis= persists after reload', async ({
+    request,
+  }) => {
+    skipUnlessSeeded(test);
+
+    const token = await getToken(request);
+    const interventionId = await getFirstInterventionId(request, token);
+    test.skip(!interventionId, 'No interventions available in the DB — skipping');
+
+    const templateId = await createTemplate(request, token);
+
+    try {
+      // Assign same intervention under two diagnosis keys
+      await assignIntervention(request, token, templateId, interventionId as string, 5);
+
+      const res2 = await request.post(`${API_BASE}/templates/${templateId}/interventions/`, {
+        headers: { Authorization: `Bearer ${token}` },
+        data: { interventionId, end_day: 5, diagnosis: 'MS' },
+      });
+      expect(res2.ok()).toBeTruthy();
+
+      // Confirm both keys exist
+      const detail1 = await request.get(`${API_BASE}/templates/${templateId}/`, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      const da1 = (await detail1.json()).template.recommendations[0].diagnosis_assignments;
+      expect('MS' in da1).toBeTruthy();
+      expect('_all' in da1).toBeTruthy();
+
+      // Remove the MS block
+      const removeRes = await request.delete(
+        `${API_BASE}/templates/${templateId}/interventions/${interventionId}/?diagnosis=MS`,
+        { headers: { Authorization: `Bearer ${token}` } }
+      );
+      expect(removeRes.ok(), `Remove failed: ${await removeRes.text()}`).toBeTruthy();
+
+      // Re-fetch and verify MS is gone but _all remains
+      const detail2 = await request.get(`${API_BASE}/templates/${templateId}/`, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      const da2 = (await detail2.json()).template.recommendations[0].diagnosis_assignments;
+      expect('MS' in da2).toBeFalsy();
+      expect('_all' in da2).toBeTruthy();
+    } finally {
+      await deleteTemplate(request, token, templateId);
+    }
+  });
+
+  // ---- Apply an empty template returns applied=0 (sanity) ------------------
+
+  test('applying an empty template returns applied=0 and sessions_created=0', async ({
+    request,
+  }) => {
+    skipUnlessPatient(test);
+
+    const { patientId } = creds();
+    const token = await getToken(request);
+    const templateId = await createTemplate(request, token);
+
+    try {
+      const body = await applyTemplate(request, token, templateId, patientId as string, tomorrow());
+
+      expect(body.success).toBe(true);
+      expect(body.applied).toBe(0);
+      expect(body.sessions_created ?? 0).toBe(0);
+    } finally {
+      await deleteTemplate(request, token, templateId);
+    }
+  });
+});
+
+// ===========================================================================
+// UI-level E2E tests
+// ===========================================================================
+
+test.describe('Template assign/apply — UI level', () => {
+  test.beforeEach(async ({ page }) => {
+    skipUnlessSeeded(test);
+    await loginAsTherapist(page);
+  });
+
+  /** Open /interventions and click the Templates tab. */
+  async function openTemplatesTab(page: Parameters<Parameters<typeof test>[1]>[0]) {
+    await page.goto('/interventions');
+    const tab = page.getByRole('tab', { name: /templates/i });
+    await expect(tab).toBeVisible();
+    await tab.click();
+  }
+
+  // ---- Create a template via the UI, then apply it, and verify the result --
+
+  test('create template → add intervention → apply → result shows sessions_created > 0', async ({
+    page,
+    request,
+  }) => {
+    skipUnlessPatient(test);
+
+    const { patientId } = creds();
+
+    // Get a real token for direct API calls (cleanup + apply)
+    const token = await getToken(request);
+    const interventionId = await getFirstInterventionId(request, token);
+    test.skip(!interventionId, 'No interventions available in the DB — skipping');
+
+    await openTemplatesTab(page);
+
+    // 1. Create a template via the UI
+    await page.getByRole('button', { name: /\+ new/i }).click();
+    const modal = page.locator('.modal.show');
+    await expect(modal).toBeVisible();
+
+    const uniqueName = `E2E Apply Test ${Date.now()}`;
+    await modal.getByLabel(/template name/i).fill(uniqueName);
+
+    const createRes = page.waitForResponse(
+      (res) => res.url().includes('/api/templates/') && res.request().method() === 'POST'
+    );
+    await modal.getByRole('button', { name: /create/i }).click();
+    const createResp = await createRes;
+    const createBody = await createResp.json();
+    const templateId: string = createBody.template._id;
+
+    await expect(modal).not.toBeVisible({ timeout: 5000 });
+
+    // 2. Assign intervention via direct API call (the UI assign flow would
+    //    require navigating to the intervention card, which is a separate test).
+    await assignIntervention(request, token, templateId, interventionId as string, 7);
+
+    // 3. Select the template in the UI and click Apply
+    await page.reload();
+    await openTemplatesTab(page);
+    await page.getByRole('option', { name: uniqueName }).waitFor({ timeout: 5000 });
+    await page.getByRole('combobox').first().selectOption({ label: uniqueName });
+
+    const applyModal = page.locator('.modal.show');
+    await page.getByRole('button', { name: /^apply$/i }).click();
+    await expect(applyModal).toBeVisible();
+
+    // 4. Intercept the apply response before clicking confirm in the modal
+    const applyResponse = page.waitForResponse(
+      (res) =>
+        res.url().includes(`/api/templates/${templateId}/apply/`) && res.request().method() === 'POST'
+    );
+
+    // Fill in the effective-from date if the modal has a date picker
+    const datePicker = applyModal.locator('input[type="date"]');
+    if (await datePicker.isVisible()) {
+      await datePicker.fill(tomorrow());
+    }
+
+    // Select the patient if there is a patient selector
+    const patientSelect = applyModal.getByRole('combobox');
+    if (await patientSelect.isVisible()) {
+      const options = await patientSelect.locator('option').all();
+      if (options.length > 1) {
+        await patientSelect.selectOption({ index: 1 });
+      }
+    }
+
+    // Confirm apply
+    await applyModal.getByRole('button', { name: /apply/i }).last().click();
+    const applyResp = await applyResponse;
+    const applyBody = await applyResp.json();
+
+    expect(applyBody.success).toBe(true);
+    expect(applyBody.applied).toBeGreaterThanOrEqual(1);
+    expect(applyBody.sessions_created).toBeGreaterThan(0);
+
+    // Cleanup
+    await deleteTemplate(request, token, templateId);
+  });
+
+  // ---- The apply result dialog shows a non-zero session count --------------
+
+  test('apply dialog reports sessions_created when template has interventions', async ({
+    page,
+    request,
+  }) => {
+    skipUnlessPatient(test);
+
+    const { patientId } = creds();
+    const token = await getToken(request);
+    const interventionId = await getFirstInterventionId(request, token);
+    test.skip(!interventionId, 'No interventions available in the DB — skipping');
+
+    // Create template + assign via API (fast path)
+    const templateId = await createTemplate(request, token);
+    await assignIntervention(request, token, templateId, interventionId as string, 7);
+
+    try {
+      await openTemplatesTab(page);
+
+      // Wait for the new template to appear in the selector
+      const selector = page.getByRole('combobox').first();
+      await page.waitForFunction(
+        (id) =>
+          [...document.querySelectorAll('option')].some((o) => o.getAttribute('value') === id),
+        templateId,
+        { timeout: 8000 }
+      );
+      await selector.selectOption(templateId);
+
+      const applyResponse = page.waitForResponse(
+        (res) =>
+          res.url().includes(`/api/templates/${templateId}/apply/`) &&
+          res.request().method() === 'POST'
+      );
+
+      await page.getByRole('button', { name: /^apply$/i }).click();
+      const applyModal = page.locator('.modal.show');
+      await expect(applyModal).toBeVisible();
+
+      const datePicker = applyModal.locator('input[type="date"]');
+      if (await datePicker.isVisible()) {
+        await datePicker.fill(tomorrow());
+      }
+
+      // Use the patientId directly if the form accepts it, otherwise pick first option
+      const patientSelect = applyModal.getByRole('combobox');
+      if (await patientSelect.isVisible()) {
+        const hasPatient = await patientSelect
+          .locator(`option[value="${patientId}"]`)
+          .isVisible()
+          .catch(() => false);
+        if (hasPatient) {
+          await patientSelect.selectOption(patientId as string);
+        } else {
+          const options = await patientSelect.locator('option').all();
+          if (options.length > 1) await patientSelect.selectOption({ index: 1 });
+        }
+      }
+
+      await applyModal.getByRole('button', { name: /apply/i }).last().click();
+      const resp = await applyResponse;
+      const body = await resp.json();
+
+      // The bug caused sessions_created=0 — assert it is positive
+      expect(body.sessions_created).toBeGreaterThan(0);
+
+      // The UI should show the result (success banner / count)
+      await expect(
+        page.getByText(/session/i).or(page.getByText(/applied/i)).first()
+      ).toBeVisible({ timeout: 5000 });
+    } finally {
+      await deleteTemplate(request, token, templateId);
+    }
+  });
+});

--- a/frontend/e2e/template-assign-apply.spec.ts
+++ b/frontend/e2e/template-assign-apply.spec.ts
@@ -125,11 +125,7 @@ async function applyTemplate(
 }
 
 /** Delete a template (cleanup). */
-async function deleteTemplate(
-  request: APIRequestContext,
-  token: string,
-  templateId: string
-) {
+async function deleteTemplate(request: APIRequestContext, token: string, templateId: string) {
   await request.delete(`${API_BASE}/templates/${templateId}/`, {
     headers: { Authorization: `Bearer ${token}` },
   });
@@ -391,7 +387,8 @@ test.describe('Template assign/apply — UI level', () => {
     // 4. Intercept the apply response before clicking confirm in the modal
     const applyResponse = page.waitForResponse(
       (res) =>
-        res.url().includes(`/api/templates/${templateId}/apply/`) && res.request().method() === 'POST'
+        res.url().includes(`/api/templates/${templateId}/apply/`) &&
+        res.request().method() === 'POST'
     );
 
     // Fill in the effective-from date if the modal has a date picker
@@ -491,7 +488,10 @@ test.describe('Template assign/apply — UI level', () => {
 
       // The UI should show the result (success banner / count)
       await expect(
-        page.getByText(/session/i).or(page.getByText(/applied/i)).first()
+        page
+          .getByText(/session/i)
+          .or(page.getByText(/applied/i))
+          .first()
       ).toBeVisible({ timeout: 5000 });
     } finally {
       await deleteTemplate(request, token, templateId);


### PR DESCRIPTION
## Bug fix: Template apply returns 0 interventions / 0 sessions

### Problem

Applying a named template after editing its schedule produced the following result dialog:

> **Template applied: 0 interventions, 0 sessions**

The template visibly contained interventions, and the UI gave no indication anything was wrong.

### Root cause

**MongoEngine does not detect in-place mutations of nested dicts inside `EmbeddedDocument` `ListField`s.**

In `backend/core/views/template_views.py`, the assign endpoint updated an existing schedule block with:

```python
existing.diagnosis_assignments[diagnosis_key] = [schedule]  # ← silent no-op
```
<p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(30, 30, 30); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">MongoEngine's dirty-tracking never saw this change, so <code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">tmpl.save()</code> wrote the old (empty) dict to MongoDB. When <code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">apply_named_template</code> ran, it read back an empty <code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">diagnosis_assignments</code>, found no keys to apply, and returned <code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">applied=0, sessions_created=0</code>.</p><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(30, 30, 30); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">The same issue existed in the <code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">DELETE ?diagnosis=</code> path via <code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">.pop()</code>.</p><h3 style="color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(30, 30, 30); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Fix</h3><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(30, 30, 30); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Reassign the entire dict so MongoEngine sees the change:</p><div class="codeBlockWrapper_-a7MRw" style="position: relative; margin: 8px 0px; color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(30, 30, 30); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><button class="copyButton_CEmTFw copyButton_-a7MRw" title="Copy code" aria-label="Copy code to clipboard" style="color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; background: none 0% 0% / auto repeat scroll padding-box border-box rgb(30, 30, 30); border-color: rgb(69, 69, 69); border-style: solid; border-width: 1px; border-image: none 100% / 1 / 0 stretch; cursor: pointer; opacity: 0; display: flex; border-radius: 4px; justify-content: center; align-items: center; padding: 4px; transition: opacity 0.15s, background 0.15s; position: absolute; top: 4px; right: 4px;"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true" data-slot="icon" class="copyIcon_CEmTFw"><path fill-rule="evenodd" d="M15.988 3.012A2.25 2.25 0 0 1 18 5.25v6.5A2.25 2.25 0 0 1 15.75 14H13.5v-3.379a3 3 0 0 0-.879-2.121l-3.12-3.121a3 3 0 0 0-1.402-.791 2.252 2.252 0 0 1 1.913-1.576A2.25 2.25 0 0 1 12.25 1h1.5a2.25 2.25 0 0 1 2.238 2.012ZM11.5 3.25a.75.75 0 0 1 .75-.75h1.5a.75.75 0 0 1 .75.75v.25h-3v-.25Z" clip-rule="evenodd"></path><path d="M3.5 6A1.5 1.5 0 0 0 2 7.5v9A1.5 1.5 0 0 0 3.5 18h7a1.5 1.5 0 0 0 1.5-1.5v-5.879a1.5 1.5 0 0 0-.44-1.06L8.44 6.439A1.5 1.5 0 0 0 7.378 6H3.5Z"></path></svg></button><pre style="overflow-x: auto; white-space: pre; box-sizing: border-box; border-radius: 4px; max-width: 100%; margin: 0px; padding: 8px;"><code class="language-python" style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 0px; border-radius: 3px; word-break: break-word; font-size: 0.9em;"># Assign (update path)
da = dict(existing.diagnosis_assignments or {})
da[diagnosis_key] = [schedule]
existing.diagnosis_assignments = da

# Delete (remove one diagnosis block)
da = dict(rec.diagnosis_assignments or {})
da.pop(diagnosis_key, None)
rec.diagnosis_assignments = da
</code></pre></div><h3 style="color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(30, 30, 30); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Files changed</h3>
File | Change
-- | --
backend/core/views/template_views.py | Fix both mutation sites
backend/tests/template_views/test_template_views.py | 3 new regression tests
backend/tests/template_views/TESTING.md | Document the new tests and root cause
frontend/e2e/template-assign-apply.spec.ts | 6 Playwright e2e tests (API + UI level)

<h3 style="color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(30, 30, 30); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">How to verify</h3><div class="codeBlockWrapper_-a7MRw" style="position: relative; margin: 8px 0px; color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(30, 30, 30); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><button class="copyButton_CEmTFw copyButton_-a7MRw" title="Copy code" aria-label="Copy code to clipboard" style="color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; background: none 0% 0% / auto repeat scroll padding-box border-box rgb(30, 30, 30); border-color: rgb(69, 69, 69); border-style: solid; border-width: 1px; border-image: none 100% / 1 / 0 stretch; cursor: pointer; opacity: 1; display: flex; border-radius: 4px; justify-content: center; align-items: center; padding: 4px; transition: opacity 0.15s, background 0.15s; position: absolute; top: 4px; right: 4px;"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true" data-slot="icon" class="copyIcon_CEmTFw"><path fill-rule="evenodd" d="M15.988 3.012A2.25 2.25 0 0 1 18 5.25v6.5A2.25 2.25 0 0 1 15.75 14H13.5v-3.379a3 3 0 0 0-.879-2.121l-3.12-3.121a3 3 0 0 0-1.402-.791 2.252 2.252 0 0 1 1.913-1.576A2.25 2.25 0 0 1 12.25 1h1.5a2.25 2.25 0 0 1 2.238 2.012ZM11.5 3.25a.75.75 0 0 1 .75-.75h1.5a.75.75 0 0 1 .75.75v.25h-3v-.25Z" clip-rule="evenodd"></path><path d="M3.5 6A1.5 1.5 0 0 0 2 7.5v9A1.5 1.5 0 0 0 3.5 18h7a1.5 1.5 0 0 0 1.5-1.5v-5.879a1.5 1.5 0 0 0-.44-1.06L8.44 6.439A1.5 1.5 0 0 0 7.378 6H3.5Z"></path></svg></button><pre style="overflow-x: auto; white-space: pre; box-sizing: border-box; border-radius: 4px; max-width: 100%; margin: 0px; padding: 8px;"><code class="language-bash" style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 0px; border-radius: 3px; word-break: break-word; font-size: 0.9em;"># Backend regression tests
docker exec django pytest tests/template_views/ -v

# E2E (requires seeded DB)
cd frontend
E2E_THERAPIST_LOGIN=... E2E_THERAPIST_PASSWORD=... E2E_PATIENT_ID=... \
  npm run test:e2e -- e2e/template-assign-apply.spec.ts</code></pre></div>
