### PR TITLE
Display and filter ratings

### DIFF
--- a/frontend/src/__tests__/components/PatientLibrary/PatientLibraryDesktopFilters.test.tsx
+++ b/frontend/src/__tests__/components/PatientLibrary/PatientLibraryDesktopFilters.test.tsx
@@ -26,9 +26,9 @@ jest.mock('@/components/ui/input-group', () => ({
 }));
 
 jest.mock('@/components/ui/slider', () => ({
-  Slider: ({ onValueChange }: any) => (
-    <button type="button" onClick={() => onValueChange([1, 3])}>
-      duration-slider
+  Slider: ({ onValueChange, 'data-testid': testId }: any) => (
+    <button type="button" data-testid={testId} onClick={() => onValueChange([1, 3])}>
+      slider
     </button>
   ),
 }));
@@ -49,6 +49,7 @@ describe('PatientLibraryDesktopFilters', () => {
     const setAimsFilter = jest.fn();
     const setContentTypeFilter = jest.fn();
     const setDurationFilterIndices = jest.fn();
+    const setRatingFilterIndices = jest.fn();
 
     render(
       <PatientLibraryDesktopFilters
@@ -63,12 +64,16 @@ describe('PatientLibraryDesktopFilters', () => {
         durationFilterIndices={[0, 4]}
         setDurationFilterIndices={setDurationFilterIndices}
         durationLabels={['5min', '20min', '35min', '50min', '1h+']}
+        ratingFilterIndices={[0, 4]}
+        setRatingFilterIndices={setRatingFilterIndices}
+        ratingLabels={['1', '2', '3', '4', '5']}
       />
     );
 
     expect(screen.getByText('Type')).toBeInTheDocument();
     expect(screen.getByText('Medium')).toBeInTheDocument();
     expect(screen.getByText('Duration')).toBeInTheDocument();
+    expect(screen.getByText('Rating')).toBeInTheDocument();
 
     fireEvent.change(screen.getByPlaceholderText('Search'), { target: { value: 'balance' } });
     expect(onSearchTermChange).toHaveBeenCalledWith('balance');
@@ -86,7 +91,11 @@ describe('PatientLibraryDesktopFilters', () => {
     expect(contentUpdater([])).toEqual(['video']);
     expect(contentUpdater(['video'])).toEqual([]);
 
-    fireEvent.click(screen.getByRole('button', { name: 'duration-slider' }));
+    const sliderButtons = screen.getAllByRole('button', { name: 'slider' });
+    fireEvent.click(sliderButtons[0]);
     expect(setDurationFilterIndices).toHaveBeenCalledWith([1, 3]);
+
+    fireEvent.click(sliderButtons[1]);
+    expect(setRatingFilterIndices).toHaveBeenCalledWith([1, 3]);
   });
 });

--- a/frontend/src/__tests__/components/PatientLibrary/PatientLibraryFilterSheet.test.tsx
+++ b/frontend/src/__tests__/components/PatientLibrary/PatientLibraryFilterSheet.test.tsx
@@ -18,7 +18,7 @@ jest.mock('@/components/ui/sheet', () => ({
 }));
 
 jest.mock('@/components/ui/slider', () => ({
-  Slider: () => <div data-testid="duration-slider" />,
+  Slider: ({ 'data-testid': testId }: any) => <div data-testid={testId ?? 'slider'} />,
 }));
 
 jest.mock('@/components/ui/switch', () => ({
@@ -49,6 +49,9 @@ describe('PatientLibraryFilterSheet', () => {
         durationFilterIndices={[0, 4]}
         setDurationFilterIndices={jest.fn()}
         durationLabels={['5min', '20min', '35min', '50min', '1h+']}
+        ratingFilterIndices={[0, 4]}
+        setRatingFilterIndices={jest.fn()}
+        ratingLabels={['1', '2', '3', '4', '5']}
         onResetFilters={onResetFilters}
       />
     );
@@ -57,6 +60,7 @@ describe('PatientLibraryFilterSheet', () => {
     expect(screen.getByText('Type')).toBeInTheDocument();
     expect(screen.getByText('Medium')).toBeInTheDocument();
     expect(screen.getByText('Duration')).toBeInTheDocument();
+    expect(screen.getByText('Rating')).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('button', { name: 'Reset filters' }));
     expect(onResetFilters).toHaveBeenCalledTimes(1);

--- a/frontend/src/__tests__/components/PatientLibrary/PatientLibraryInterventionCard.test.tsx
+++ b/frontend/src/__tests__/components/PatientLibrary/PatientLibraryInterventionCard.test.tsx
@@ -56,8 +56,7 @@ describe('PatientLibraryInterventionCard', () => {
   // Star rating badge (avg_rating)
   // -------------------------------------------------------------------------
 
-  it('shows star badge with filled/empty stars and numeric average when avg_rating is provided', () => {
-    // avg_rating = 4.3 → Math.round(4.3) = 4 → ★★★★☆
+  it('shows numeric average when avg_rating is provided', () => {
     render(
       <PatientLibraryInterventionCard
         item={{ duration: 20, content_type: 'Exercise', avg_rating: 4.3, rating_count: 12 }}
@@ -69,13 +68,10 @@ describe('PatientLibraryInterventionCard', () => {
       />
     );
 
-    // Numeric average is shown
     expect(screen.getByText('4.3')).toBeInTheDocument();
-    // Correct filled/empty star pattern
-    expect(screen.getByText('★★★★☆')).toBeInTheDocument();
   });
 
-  it('shows 5 filled stars when avg_rating is 5', () => {
+  it('shows formatted average when avg_rating is 5', () => {
     render(
       <PatientLibraryInterventionCard
         item={{ duration: 10, content_type: 'Video', avg_rating: 5.0, rating_count: 3 }}
@@ -87,11 +83,10 @@ describe('PatientLibraryInterventionCard', () => {
       />
     );
 
-    expect(screen.getByText('★★★★★')).toBeInTheDocument();
     expect(screen.getByText('5.0')).toBeInTheDocument();
   });
 
-  it('hides star badge when avg_rating is null', () => {
+  it('hides rating badge when avg_rating is null', () => {
     render(
       <PatientLibraryInterventionCard
         item={{ duration: 20, content_type: 'Exercise', avg_rating: null }}
@@ -103,10 +98,13 @@ describe('PatientLibraryInterventionCard', () => {
       />
     );
 
-    expect(screen.queryByText(/★/)).not.toBeInTheDocument();
+    // avg_rating badge not rendered
+    expect(screen.queryByText('null')).not.toBeInTheDocument();
+    // only the duration and content_type badges are present
+    expect(screen.getAllByText(/-|Exercise/).length).toBeGreaterThanOrEqual(1);
   });
 
-  it('hides star badge when avg_rating is undefined (field absent)', () => {
+  it('hides rating badge when avg_rating is undefined (field absent)', () => {
     render(
       <PatientLibraryInterventionCard
         item={{ duration: 15, content_type: 'Audio' }}
@@ -118,6 +116,7 @@ describe('PatientLibraryInterventionCard', () => {
       />
     );
 
-    expect(screen.queryByText(/★/)).not.toBeInTheDocument();
+    expect(screen.queryByText('undefined')).not.toBeInTheDocument();
+    expect(screen.getByText('15min')).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/PatientLibrary/PatientLibraryDesktopFilters.tsx
+++ b/frontend/src/components/PatientLibrary/PatientLibraryDesktopFilters.tsx
@@ -152,7 +152,7 @@ const PatientLibraryDesktopFilters: React.FC<PatientLibraryDesktopFiltersProps> 
             </FilterSection>
 
             <FilterSection title={t('Duration')}>
-              <div className="flex flex-col gap-4">
+              <div className="flex flex-col gap-3">
                 <Slider
                   value={durationFilterIndices}
                   min={0}
@@ -168,7 +168,7 @@ const PatientLibraryDesktopFilters: React.FC<PatientLibraryDesktopFiltersProps> 
               </div>
             </FilterSection>
             <FilterSection title={t('Rating')}>
-              <div className="flex flex-col gap-4">
+              <div className="flex flex-col gap-3">
                 <Slider
                   value={ratingFilterIndices}
                   min={0}

--- a/frontend/src/components/PatientLibrary/PatientLibraryDesktopFilters.tsx
+++ b/frontend/src/components/PatientLibrary/PatientLibraryDesktopFilters.tsx
@@ -26,6 +26,9 @@ type PatientLibraryDesktopFiltersProps = {
   durationFilterIndices: [number, number];
   setDurationFilterIndices: React.Dispatch<React.SetStateAction<[number, number]>>;
   durationLabels: string[];
+  ratingFilterIndices: [number, number];
+  setRatingFilterIndices: React.Dispatch<React.SetStateAction<[number, number]>>;
+  ratingLabels: string[];
 };
 
 type FilterSectionProps = {
@@ -72,6 +75,9 @@ const PatientLibraryDesktopFilters: React.FC<PatientLibraryDesktopFiltersProps> 
   durationFilterIndices,
   setDurationFilterIndices,
   durationLabels,
+  ratingFilterIndices,
+  setRatingFilterIndices,
+  ratingLabels,
 }) => {
   const { t } = useTranslation();
 
@@ -156,6 +162,22 @@ const PatientLibraryDesktopFilters: React.FC<PatientLibraryDesktopFiltersProps> 
                 />
                 <div className="flex justify-between font-medium text-sm text-zinc-400 px-0.5">
                   {durationLabels.map((label, i) => (
+                    <span key={i}>{label}</span>
+                  ))}
+                </div>
+              </div>
+            </FilterSection>
+            <FilterSection title={t('Rating')}>
+              <div className="flex flex-col gap-4">
+                <Slider
+                  value={ratingFilterIndices}
+                  min={0}
+                  max={4}
+                  step={1}
+                  onValueChange={(value) => setRatingFilterIndices([value[0], value[1]])}
+                />
+                <div className="flex justify-between font-medium text-sm text-zinc-400 px-0.5">
+                  {ratingLabels.map((label, i) => (
                     <span key={i}>{label}</span>
                   ))}
                 </div>

--- a/frontend/src/components/PatientLibrary/PatientLibraryFilterSheet.tsx
+++ b/frontend/src/components/PatientLibrary/PatientLibraryFilterSheet.tsx
@@ -109,7 +109,7 @@ const PatientLibraryFilterSheet: React.FC<PatientLibraryFilterSheetProps> = ({
             </div>
           </div>
 
-          <div className="flex flex-col gap-4">
+          <div className="flex flex-col gap-3">
             <div className="font-medium text-lg text-zinc-600">{t('Duration')}</div>
             <Slider
               value={durationFilterIndices}
@@ -125,7 +125,7 @@ const PatientLibraryFilterSheet: React.FC<PatientLibraryFilterSheetProps> = ({
             </div>
           </div>
 
-          <div className="flex flex-col gap-4">
+          <div className="flex flex-col gap-3">
             <div className="font-medium text-lg text-zinc-600">{t('Rating')}</div>
             <Slider
               value={ratingFilterIndices}

--- a/frontend/src/components/PatientLibrary/PatientLibraryFilterSheet.tsx
+++ b/frontend/src/components/PatientLibrary/PatientLibraryFilterSheet.tsx
@@ -24,6 +24,9 @@ type PatientLibraryFilterSheetProps = {
   durationFilterIndices: [number, number];
   setDurationFilterIndices: React.Dispatch<React.SetStateAction<[number, number]>>;
   durationLabels: string[];
+  ratingFilterIndices: [number, number];
+  setRatingFilterIndices: React.Dispatch<React.SetStateAction<[number, number]>>;
+  ratingLabels: string[];
   onResetFilters: () => void;
 };
 
@@ -39,6 +42,9 @@ const PatientLibraryFilterSheet: React.FC<PatientLibraryFilterSheetProps> = ({
   durationFilterIndices,
   setDurationFilterIndices,
   durationLabels,
+  ratingFilterIndices,
+  setRatingFilterIndices,
+  ratingLabels,
   onResetFilters,
 }) => {
   const { t } = useTranslation();
@@ -114,6 +120,22 @@ const PatientLibraryFilterSheet: React.FC<PatientLibraryFilterSheetProps> = ({
             />
             <div className="flex justify-between font-medium text-sm text-zinc-400 px-0.5">
               {durationLabels.map((label, i) => (
+                <span key={i}>{label}</span>
+              ))}
+            </div>
+          </div>
+
+          <div className="flex flex-col gap-4">
+            <div className="font-medium text-lg text-zinc-600">{t('Rating')}</div>
+            <Slider
+              value={ratingFilterIndices}
+              min={0}
+              max={4}
+              step={1}
+              onValueChange={(value) => setRatingFilterIndices([value[0], value[1]])}
+            />
+            <div className="flex justify-between font-medium text-sm text-zinc-400 px-0.5">
+              {ratingLabels.map((label, i) => (
                 <span key={i}>{label}</span>
               ))}
             </div>

--- a/frontend/src/components/PatientLibrary/PatientLibraryInterventionCard.tsx
+++ b/frontend/src/components/PatientLibrary/PatientLibraryInterventionCard.tsx
@@ -40,18 +40,18 @@ const PatientLibraryInterventionCard: React.FC<PatientLibraryInterventionCardPro
       <div className="flex-1 flex flex-col gap-2 justify-between">
         <div className="font-bold text-lg leading-6 text-zinc-800">{displayTitle || '-'}</div>
         <div className="flex gap-1">
-          <Badge className="flex gap-1 bg-white py-2 px-3 rounded-xl border border-accent shadow-none font-medium text-lg text-zinc-500">
+          <Badge className="flex gap-1 bg-white p-2 rounded-xl border border-accent shadow-none font-medium text-zinc-500">
             <ClockIcon className="w-4 h-4" />
             <div className="text-[#00956C] font-medium">
               {isNaN(Number(item.duration)) ? '-' : `${item.duration}min`}
             </div>
           </Badge>
-          <Badge className="flex gap-1 bg-white py-2 px-3 rounded-xl border border-accent shadow-none font-medium text-lg text-zinc-500">
+          <Badge className="flex gap-1 bg-white p-2 rounded-xl border border-accent shadow-none font-medium text-zinc-500">
             {ContentTypeIcon && <ContentTypeIcon className="w-4 h-4" />}
             <div className="text-[#00956C] font-medium">{t(item.content_type) || '-'}</div>
           </Badge>
           {item.avg_rating != null && (
-            <Badge className="flex gap-1 bg-white py-2 px-3 rounded-xl border border-accent shadow-none font-medium text-lg text-zinc-500">
+            <Badge className="flex gap-1 bg-white p-2 rounded-xl border border-accent shadow-none font-medium text-zinc-500">
               <StarsIcon className="w-4 h-4" />
               <div className="text-[#00956C] font-medium">{item.avg_rating.toFixed(1)}</div>
             </Badge>

--- a/frontend/src/components/PatientLibrary/PatientLibraryInterventionCard.tsx
+++ b/frontend/src/components/PatientLibrary/PatientLibraryInterventionCard.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import ClockIcon from '@/assets/icons/interventions/clock.svg?react';
+import StarsIcon from '@/assets/icons/interventions/stars.svg?react';
 import { Badge } from '@/components/ui/badge';
 
 type PatientLibraryInterventionCardItem = {
@@ -51,11 +52,8 @@ const PatientLibraryInterventionCard: React.FC<PatientLibraryInterventionCardPro
           </Badge>
           {item.avg_rating != null && (
             <Badge className="flex gap-1 bg-white py-2 px-3 rounded-xl border border-accent shadow-none font-medium text-lg text-zinc-500">
-              <span className="text-[#EFA73B]">
-                {'★'.repeat(Math.round(item.avg_rating))}
-                {'☆'.repeat(5 - Math.round(item.avg_rating))}
-              </span>
-              <span className="text-[#00956C] font-medium">{item.avg_rating.toFixed(1)}</span>
+              <StarsIcon className="w-4 h-4" />
+              <div className="text-[#00956C] font-medium">{item.avg_rating.toFixed(1)}</div>
             </Badge>
           )}
         </div>

--- a/frontend/src/pages/PatientInterventionsLibrary.tsx
+++ b/frontend/src/pages/PatientInterventionsLibrary.tsx
@@ -45,6 +45,7 @@ type InterventionCardItem = {
   title?: string;
   duration?: string | number;
   content_type?: string;
+  avg_rating?: number | null;
   aims?: string[];
   intervention_title?: string;
   intervention_id?: string;
@@ -83,6 +84,9 @@ const escapeRegExp = (value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\
 
 const durationBuckets = [5, 20, 35, 50, 60];
 const durationLabels = ['5min', '20min', '35min', '50min', '1h+'];
+
+const ratingBuckets = [1, 2, 3, 4, 5];
+const ratingLabels = ['1', '2', '3', '4', '5'];
 
 const buildUniqueOptions = <T,>(
   sourceItems: T[],
@@ -166,12 +170,14 @@ const PatientInterventionsLibrary: React.FC = observer(() => {
   const [contentTypeFilter, setContentTypeFilter] = useState<string[]>([]);
   const [aimsFilter, setAimsFilter] = useState<string[]>([]);
   const [durationFilterIndices, setDurationFilterIndices] = useState<[number, number]>([0, 4]);
+  const [ratingFilterIndices, setRatingFilterIndices] = useState<[number, number]>([0, 4]);
 
   const resetAllFilters = useCallback(() => {
     setSearchTerm('');
     setContentTypeFilter([]);
     setAimsFilter([]);
     setDurationFilterIndices([0, 4]);
+    setRatingFilterIndices([0, 4]);
   }, []);
 
   useEffect(() => {
@@ -293,7 +299,16 @@ const PatientInterventionsLibrary: React.FC = observer(() => {
       return duration >= minBucket && duration <= maxBucketValue;
     });
 
-    return withDuration;
+    const withRating = withDuration.filter((it: any) => {
+      const rating = Number(it?.avg_rating);
+      if (isNaN(rating) || it?.avg_rating == null) return true;
+
+      const minRating = ratingBuckets[ratingFilterIndices[0]];
+      const maxRating = ratingBuckets[ratingFilterIndices[1]];
+      return rating >= minRating && rating <= maxRating;
+    });
+
+    return withRating;
   }, [
     sourceItems,
     contentTypeFilter,
@@ -302,6 +317,7 @@ const PatientInterventionsLibrary: React.FC = observer(() => {
     translatedTitles,
     durationFilterIndices,
     durationBuckets,
+    ratingFilterIndices,
   ]);
 
   const [showFilterSheet, setShowFilterSheet] = useState<boolean>(false);
@@ -457,6 +473,9 @@ const PatientInterventionsLibrary: React.FC = observer(() => {
           durationFilterIndices={durationFilterIndices}
           setDurationFilterIndices={setDurationFilterIndices}
           durationLabels={durationLabels}
+          ratingFilterIndices={ratingFilterIndices}
+          setRatingFilterIndices={setRatingFilterIndices}
+          ratingLabels={ratingLabels}
           onResetFilters={resetAllFilters}
         />
       </div>
@@ -474,6 +493,9 @@ const PatientInterventionsLibrary: React.FC = observer(() => {
           durationFilterIndices={durationFilterIndices}
           setDurationFilterIndices={setDurationFilterIndices}
           durationLabels={durationLabels}
+          ratingFilterIndices={ratingFilterIndices}
+          setRatingFilterIndices={setRatingFilterIndices}
+          ratingLabels={ratingLabels}
         />
 
         {/* Lists by type */}

--- a/frontend/src/pages/PatientInterventionsLibrary.tsx
+++ b/frontend/src/pages/PatientInterventionsLibrary.tsx
@@ -301,7 +301,8 @@ const PatientInterventionsLibrary: React.FC = observer(() => {
 
     const withRating = withDuration.filter((it: any) => {
       const rating = Number(it?.avg_rating);
-      if (isNaN(rating) || it?.avg_rating == null) return true;
+      const isFullRatingRange = ratingFilterIndices[0] === 0 && ratingFilterIndices[1] === 4;
+      if (isNaN(rating) || it?.avg_rating == null) return isFullRatingRange;
 
       const minRating = ratingBuckets[ratingFilterIndices[0]];
       const maxRating = ratingBuckets[ratingFilterIndices[1]];


### PR DESCRIPTION
## Description
Updates rating display and adds rating-based filtering to the Patient Interventions Library (desktop filters and mobile filter sheet), plus updates tests to cover the new behavior.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Related Issue
[Display ratings and add filter in library](https://www.notion.so/Display-ratings-and-add-filter-in-library-34261846b45080faa781e020875e5dd2?source=copy_link)

## Changes Made
- Show numeric intervention rating on cards (instead of stars).
- Add rating filter options in Patient Library filters.
- Update Patient Library tests for desktop filters, filter sheet, and intervention cards.
 
## Testing
### How to test
- Run frontend tests.
- Open Patient Interventions Library and validate rating display/filtering on desktop and mobile filter UI.

### Test Cases
- No rating filter selected: all interventions are shown.
- One or multiple rating filters selected: only matching interventions are shown.
- Intervention card shows numeric rating value correctly.
- Desktop and mobile filter UIs both apply rating filters consistently.
- Existing Patient Library tests pass after updates.

## Checklist
- [x] Code follows style guidelines
- [x] Tests added/updated
- [x] Documentation updated (if applicable)
- [x] No new warnings generated
