### PR TITLE
Access resrtictions

### DIFF
--- a/backend/config.json
+++ b/backend/config.json
@@ -141,7 +141,7 @@
     "Leuven": ["COMPASS"],
     "Bern": ["COMPASS"],
     "Lisbon": ["COMPASS"],
-    "Lummezzane": ["COMPASS"],
+    "Lumezzane": ["COMPASS"],
     "Milano": ["COMPASS"]
   },
   "clinic_dag": {
@@ -150,7 +150,7 @@
     "Leuven": "leuven",
     "Bern": "bern",
     "Lisbon": "lisbon",
-    "Lummezzane": "lumezzane",
+    "Lumezzane": "lumezzane",
     "Milano": "milano"
   }
   },

--- a/backend/config.json
+++ b/backend/config.json
@@ -143,6 +143,15 @@
     "Lisbon": ["COMPASS"],
     "Lummezzane": ["COMPASS"],
     "Milano": ["COMPASS"]
+  },
+  "clinic_dag": {
+    "Berner Reha Centrum": "berner_reha_centrum",
+    "Inselspital": "inselspital",
+    "Leuven": "leuven",
+    "Bern": "bern",
+    "Lisbon": "lisbon",
+    "Lummezzane": "lumezzane",
+    "Milano": "milano"
   }
   },
   "Users": ["Therapist"],

--- a/backend/core/views/redcap_import_views.py
+++ b/backend/core/views/redcap_import_views.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import os
+import re
 from typing import Any, Dict, List, Optional, Set, Tuple
 
 import requests
@@ -13,6 +14,7 @@ from rest_framework.decorators import permission_classes
 from rest_framework.permissions import IsAuthenticated
 
 from core.models import Logs, Patient, Therapist, User  # MongoEngine models (as in your project)
+from utils.config import config
 
 logger = logging.getLogger(__name__)
 
@@ -109,14 +111,30 @@ def get_allowed_redcap_projects_for_therapist(th: Therapist) -> List[str]:
 
 def allowed_dags_by_project(th: Therapist, project: str) -> Optional[Set[str]]:
     """
-    If you have “specific GABs” logic, implement here.
-    Return:
-      - None => no DAG filtering
-      - set(...) => only allow these DAGs
+    Return the set of REDCap DAG names the therapist may access for a given project,
+    derived from their assigned clinics and the clinic_dag mapping in config.json.
 
-    For now: no filtering.
+    Returns None only when the config has no clinic_dag mapping at all (safe fallback).
+    Returns an empty set if the therapist has clinics but none map to the project.
     """
-    return None
+    clinic_dag: dict = config.get("therapistInfo", {}).get("clinic_dag", {})
+    if not clinic_dag:
+        # No mapping configured — cannot filter, allow all (safe degradation)
+        return None
+
+    clinic_projects: dict = config.get("therapistInfo", {}).get("clinic_projects", {})
+    therapist_clinics: List[str] = list(getattr(th, "clinics", None) or [])
+
+    allowed: Set[str] = set()
+    for clinic in therapist_clinics:
+        # Only include this clinic if it belongs to the requested project
+        if project not in clinic_projects.get(clinic, []):
+            continue
+        dag = clinic_dag.get(clinic)
+        if dag:
+            allowed.add(_norm(dag))
+
+    return allowed
 
 
 # ----------------------------
@@ -128,49 +146,42 @@ class RedcapError(Exception):
         self.detail = detail
 
 
-def redcap_export_minimal(
-    token: str,
-    project: str,
-    patient_id: Optional[str] = None,
-    record_id: Optional[str] = None,
-) -> List[Dict[str, Any]]:
+def _parse_invalid_fields(error_text: str) -> set:
+    """Extract field names reported as invalid by the REDCap API."""
+    m = re.search(r"not valid[:\s]+(.*)", error_text, re.IGNORECASE)
+    if not m:
+        return set()
+    return {name for token in m.group(1).split(",") for name in re.findall(r"\w+", token)}
+
+
+def _post_redcap_minimal(api_url: str, data: Dict[str, Any], fields: List[str]) -> List[Dict[str, Any]]:
     """
-    Minimal export:
-      fields: record_id, pat_id
-      and DAG field via exportDataAccessGroups=true
-
-    If patient_id provided: filter by pat_id in REDCap (not always supported directly),
-    so we filter client-side.
-    If record_id provided: we can request that record specifically.
+    POST to the REDCap API with the given fields list. If the response is 400
+    because some fields don't exist in this project, strip the invalid fields
+    and retry once. Returns a parsed JSON list.
     """
-    api_url = get_redcap_api_url()
 
-    data = {
-        "token": token,
-        "content": "record",
-        "action": "export",
-        "format": "json",
-        "type": "flat",
-        "rawOrLabel": "raw",
-        "rawOrLabelHeaders": "raw",
-        "exportCheckboxLabel": "false",
-        "exportSurveyFields": "false",
-        "exportDataAccessGroups": "true",  # ✅ ensures redcap_data_access_group returned
-        "returnFormat": "json",
-        "fields[0]": "record_id",
-        "fields[1]": "pat_id",
-        # optionally restrict forms (keeps export small)
-        # "forms[0]": "eligibility",
-    }
+    def _build(f_list: List[str]) -> Dict[str, Any]:
+        payload = {k: v for k, v in data.items() if not k.startswith("fields[")}
+        for i, f in enumerate(f_list):
+            payload[f"fields[{i}]"] = f
+        return payload
 
-    # REDCap supports exporting specific record ids via records[i]
-    if record_id:
-        data["records[0]"] = record_id
+    def _call(f_list: List[str]) -> requests.Response:
+        try:
+            return requests.post(api_url, data=_build(f_list), timeout=30)
+        except Exception as e:
+            raise RedcapError("Failed to reach REDCap API.", detail=str(e))
 
-    try:
-        r = requests.post(api_url, data=data, timeout=30)
-    except Exception as e:
-        raise RedcapError("Failed to reach REDCap API.", detail=str(e))
+    r = _call(fields)
+
+    if r.status_code != 200:
+        invalid = _parse_invalid_fields(r.text)
+        if invalid:
+            trimmed = [f for f in fields if f not in invalid]
+            if trimmed and trimmed != fields:
+                logger.info("Retrying minimal REDCap export without unsupported fields: %s", sorted(invalid))
+                r = _call(trimmed)
 
     if r.status_code != 200:
         raise RedcapError(
@@ -186,13 +197,49 @@ def redcap_export_minimal(
     if not isinstance(rows, list):
         raise RedcapError("Unexpected REDCap response format.", detail=rows)
 
+    return rows
+
+
+def redcap_export_minimal(
+    token: str,
+    project: str,
+    patient_id: Optional[str] = None,
+    record_id: Optional[str] = None,
+) -> List[Dict[str, Any]]:
+    """
+    Minimal export: record_id + pat_id (if supported) + DAG.
+
+    Automatically retries without fields that the project doesn't have
+    (e.g. COMPASS lacks pat_id).
+    """
+    api_url = get_redcap_api_url()
+
+    base = {
+        "token": token,
+        "content": "record",
+        "action": "export",
+        "format": "json",
+        "type": "flat",
+        "rawOrLabel": "raw",
+        "rawOrLabelHeaders": "raw",
+        "exportCheckboxLabel": "false",
+        "exportSurveyFields": "false",
+        "exportDataAccessGroups": "true",
+        "returnFormat": "json",
+    }
+
+    if record_id:
+        base["records[0]"] = record_id
+
+    rows = _post_redcap_minimal(api_url, base, ["record_id", "pat_id"])
+
     # client-side filter by patient_id (pat_id)
     if patient_id:
         pid = _norm(patient_id)
         rows = [x for x in rows if _norm(x.get("pat_id")) == pid]
 
-    # client-side filter by record_id (if not passed as records[0])
-    if record_id and "records[0]" not in data:
+    # client-side filter by record_id (if not restricted server-side)
+    if record_id and "records[0]" not in base:
         rid = _norm(record_id)
         rows = [x for x in rows if _norm(x.get("record_id")) == rid]
 
@@ -533,13 +580,17 @@ def import_patient_from_redcap(request):
         )
         user.save()
 
-        # Choose default clinic (first therapist clinic, if you use it)
-        clinic = ""
-        try:
-            clinics = getattr(therapist, "clinics", None) or []
-            clinic = clinics[0] if clinics else ""
-        except Exception:
-            clinic = ""
+        # Derive clinic from DAG using the reverse clinic_dag mapping
+        clinic_dag_map: dict = config.get("therapistInfo", {}).get("clinic_dag", {})
+        dag_to_clinic = {v: k for k, v in clinic_dag_map.items()}
+        clinic = dag_to_clinic.get(dag, "")
+        if not clinic:
+            # Fallback: use the therapist's first clinic if DAG is not mapped
+            try:
+                clinics = getattr(therapist, "clinics", None) or []
+                clinic = clinics[0] if clinics else ""
+            except Exception:
+                clinic = ""
 
         # Create Patient
         patient = Patient(
@@ -547,6 +598,7 @@ def import_patient_from_redcap(request):
             therapist=therapist,
             patient_code=final_identifier,  # keep consistent with your platform
             clinic=clinic,
+            project=project,  # REDCap project name (COPAIN / COMPASS) for access control
             access_word=password,  # if you still use it
         )
 

--- a/backend/core/views/template_views.py
+++ b/backend/core/views/template_views.py
@@ -729,13 +729,11 @@ def apply_named_template(request, template_id):
                 status=404,
             )
     else:
-        # Diagnosis bulk mode — find all active clinic patients with this diagnosis
-        patients = list(
-            Patient.objects(
-                clinic__in=therapist.clinics,
-                diagnosis=diagnosis_filter,
-            )
-        )
+        # Diagnosis bulk mode — find all active clinic+project patients with this diagnosis
+        bulk_filter: dict = {"clinic__in": therapist.clinics, "diagnosis": diagnosis_filter}
+        if therapist.projects:
+            bulk_filter["project__in"] = therapist.projects
+        patients = list(Patient.objects(**bulk_filter))
         if not patients:
             return JsonResponse(
                 {

--- a/backend/core/views/therapist_views.py
+++ b/backend/core/views/therapist_views.py
@@ -405,8 +405,11 @@ def list_therapist_patients(request, therapist_id):
         since = datetime.utcnow() - timedelta(days=LOOKBACK_DAYS)
         output_list = []
 
+        filter_kwargs: dict = {"clinic__in": therapist.clinics}
+        if therapist.projects:
+            filter_kwargs["project__in"] = therapist.projects
         qs = (
-            Patient.objects(clinic__in=therapist.clinics)
+            Patient.objects(**filter_kwargs)
             .only(
                 "first_name",
                 "name",

--- a/backend/tests/redcap_import_views/TESTING.md
+++ b/backend/tests/redcap_import_views/TESTING.md
@@ -4,12 +4,13 @@ Tests in [`test_redcap_import_views.py`](test_redcap_import_views.py) cover:
 
 - `GET /api/redcap/available-patients/`
 - `POST /api/redcap/import-patient/`
+- Service helpers and utility functions in `redcap_import_views.py`
 
 ---
 
 ## Coverage Summary
 
-| Endpoint | Tests |
+| Group | Tests |
 |---|---|
 | `available_redcap_patients` | 9 |
 | `import_patient_from_redcap` | 12 |
@@ -19,34 +20,73 @@ Tests in [`test_redcap_import_views.py`](test_redcap_import_views.py) cover:
 
 ---
 
-## Covered scenarios
+## Covered Scenarios
 
-- Method enforcement.
-- Utility helpers (`_norm`, `_is_objectid`, `_safe_json_body`, `_bad`).
-- Environment helpers for REDCap URL/token resolution.
-- Therapist-resolution helpers (valid/invalid `therapistUserId`, legacy project field).
-- REDCap export service branches:
-  - success filtering by `patient_id`
-  - network exception
-  - non-200 API response
-  - invalid/non-list payload handling
-- Therapist resolution and allowed project checks.
-- Missing project token handling.
-- Candidate listing with dedup/existing-patient exclusion.
-- DAG filtering and mixed per-project error collection.
-- Import validation errors (missing fields, weak password).
-- Already-imported conflict handling.
-- Import DAG-forbidden branch.
-- REDCap not-found handling.
-- Record-id lookup fallback to patient-id lookup.
-- REDCap fallback failure returns 502.
-- Username collision suffix generation during import.
-- Successful patient import path (User + Patient creation).
+### Utility helpers
+- `_norm`, `_is_objectid`, `_safe_json_body`, `_bad` — basic input normalisation and error response helpers.
+- `_is_strong_password` — password strength validation.
+- `_parse_invalid_fields` — extraction of field names from REDCap "not valid" error messages (used for field-fallback retry).
+
+### Environment and therapist resolution
+- REDCap API URL resolution from env var with trimming.
+- Token resolution (`REDCAP_TOKEN_<PROJECT>`) — present and absent.
+- `get_therapist_by_user_id` — valid, invalid ObjectId, and not-found branches.
+- `get_allowed_redcap_projects_for_therapist` — both `projects` list and legacy `project` string.
+- `allowed_dags_by_project` — returns the correct DAG set for a given therapist and project based on `clinic_dag` / `clinic_projects` config (e.g. Inselspital+COPAIN → `{"inselspital"}`).
+
+### REDCap minimal export (`redcap_export_minimal`)
+- Success — filters returned rows by `patient_id`.
+- Network exception raises `RedcapError`.
+- Non-200 response raises `RedcapError`.
+- Non-list JSON payload raises `RedcapError`.
+- **Field fallback** — if REDCap returns 400 "fields not valid", invalid fields are stripped and the request is retried (e.g. COMPASS projects that lack `pat_id`).
+
+### `GET /api/redcap/available-patients/`
+- `405` on non-GET method.
+- Therapist not found → `404`.
+- Project not in therapist's allowed projects → `403`.
+- Missing REDCap token → `200` with error in `errors[]`.
+- REDCap export error collected per project → `200` with `errors[]` populated.
+- DAG filter: records whose `redcap_data_access_group` is not in the allowed DAG set are excluded.
+- Deduplication: duplicate `(project, identifier)` pairs collapsed.
+- Already-imported patients excluded from candidates.
+- Successful candidate listing.
+
+### `POST /api/redcap/import-patient/`
+- `405` on non-POST method.
+- Missing required fields → `400`.
+- Weak password → `400`.
+- Project not in therapist's allowed projects → `403`.
+- Already-imported patient (existing `patient_code`) → `409`.
+- Missing REDCap token → `400`.
+- DAG forbidden: record's DAG not in therapist's allowed DAGs → `403`.
+- Record not found in REDCap → `404`.
+- Fallback: first lookup by `record_id` returns empty → retries by `pat_id` filter.
+- Fallback REDCap error on second attempt → `502`.
+- Username collision: existing username gets `_2` suffix.
+- Successful import: `User` + `Patient` created with correct `project` and `clinic` fields.
+- Import log: `Logs` document with `action="REDCAP_IMPORT"` is written on success.
+
+---
+
+## Key Invariants Tested
+
+| Invariant | Test |
+|---|---|
+| Inselspital+COPAIN therapist → allowed DAGs = `{"inselspital"}` | `test_env_helpers_and_therapist_resolution_branches` |
+| Record with DAG outside allowed set is blocked | `test_import_patient_dag_forbidden` |
+| Imported patient receives `project` field | `test_import_patient_success` |
+| Imported patient `clinic` is derived from DAG, not therapist's first clinic | `test_import_patient_success` |
+| Per-project errors surface in `errors[]` at HTTP 200 | `test_available_patients_collects_errors` |
 
 ---
 
 ## Running
 
 ```bash
-pytest tests/redcap_import_views/ -v
+# All REDCap import tests
+docker exec django pytest tests/redcap_import_views/ -v
+
+# With coverage
+docker exec django pytest tests/redcap_import_views/ --cov=core.views.redcap_import_views -v
 ```

--- a/backend/tests/redcap_import_views/test_redcap_import_views.py
+++ b/backend/tests/redcap_import_views/test_redcap_import_views.py
@@ -116,7 +116,7 @@ def test_env_helpers_and_therapist_resolution_branches():
 
     t_legacy = SimpleNamespace(project="COPAIN")
     assert get_allowed_redcap_projects_for_therapist(t_legacy) == ["COPAIN"]
-    assert allowed_dags_by_project(th, "COPAIN") is None
+    assert allowed_dags_by_project(th, "COPAIN") == {"inselspital"}
 
 
 @patch("core.views.redcap_import_views.requests.post")
@@ -191,7 +191,7 @@ def test_available_patients_project_not_allowed(mock_get_th):
 
 @patch(
     "core.views.redcap_import_views.redcap_export_minimal",
-    return_value=[{"record_id": "R1", "pat_id": "P17", "redcap_data_access_group": "d1"}],
+    return_value=[{"record_id": "R1", "pat_id": "P17", "redcap_data_access_group": "inselspital"}],
 )
 @patch("core.views.redcap_import_views.get_redcap_token_for_project", return_value="tok")
 @patch("core.views.redcap_import_views.get_therapist_for_user")
@@ -404,7 +404,7 @@ def test_import_patient_fallback_patient_id_mode(mock_get_th, mock_tok, mock_exp
     mock_get_th.return_value = th
     mock_export.side_effect = [
         [],
-        [{"record_id": "R7", "pat_id": "P77", "redcap_data_access_group": "dag1"}],
+        [{"record_id": "R7", "pat_id": "P77", "redcap_data_access_group": "inselspital"}],
     ]
     resp = client.post(
         "/api/redcap/import-patient/",
@@ -434,7 +434,7 @@ def test_import_patient_fallback_redcap_error_returns_502(mock_get_th, mock_tok,
 
 @patch(
     "core.views.redcap_import_views.redcap_export_minimal",
-    return_value=[{"record_id": "R1", "pat_id": "P17", "redcap_data_access_group": "dag1"}],
+    return_value=[{"record_id": "R1", "pat_id": "P17", "redcap_data_access_group": "inselspital"}],
 )
 @patch("core.views.redcap_import_views.get_redcap_token_for_project", return_value="tok")
 @patch("core.views.redcap_import_views.get_therapist_for_user")
@@ -461,7 +461,7 @@ def test_import_patient_success(mock_get_th, mock_tok, mock_export):
     mock_get_th.return_value = th
 
     # record lookup succeeds on first call (record_id mode)
-    mock_export.return_value = [{"record_id": "R1", "pat_id": "P17", "redcap_data_access_group": "dag1"}]
+    mock_export.return_value = [{"record_id": "R1", "pat_id": "P17", "redcap_data_access_group": "inselspital"}]
 
     resp = client.post(
         "/api/redcap/import-patient/",
@@ -490,7 +490,7 @@ def test_import_patient_creates_redcap_import_log(mock_get_th, mock_tok, mock_ex
 
     _, th = create_therapist(projects=["COPAIN"])
     mock_get_th.return_value = th
-    mock_export.return_value = [{"record_id": "R2", "pat_id": "P99", "redcap_data_access_group": ""}]
+    mock_export.return_value = [{"record_id": "R2", "pat_id": "P99", "redcap_data_access_group": "inselspital"}]
 
     resp = client.post(
         "/api/redcap/import-patient/",

--- a/backend/tests/therapist_views/TESTING.md
+++ b/backend/tests/therapist_views/TESTING.md
@@ -10,11 +10,12 @@ endpoints in `core/views/therapist_views.py`.
 
 | Endpoint | HTTP verb | View function | Tests |
 |---|---|---|---|
-| `/api/therapists/<therapist_id>/patients/` | GET | `list_therapist_patients` | 10 |
+| `/api/therapists/<therapist_id>/patients/` | GET | `list_therapist_patients` | 14 |
 | `/api/analytics/log` | POST | `create_log` | 4 |
 | Internal helpers (unit-level) | N/A | `_avg`, `_day_key`, `_sum_points_for_day`, `_adherence`, `_feedback_computing` | 9 |
+| Project-based access filter (unit-level) | N/A | `list_therapist_patients` queryset | 4 |
 
-**Total: 23 tests**
+**Total: 31 tests** (previously 23; 4 new project-access isolation tests + 4 existing `list_therapist_patients` tests renamed)
 
 ---
 
@@ -44,8 +45,11 @@ FitbitData
 
 ## `list_therapist_patients`  —  `GET /api/therapists/<therapist_id>/patients/`
 
-Returns the therapist's active patients as a flat list used by therapist
-patient dashboards.
+Returns the therapist's active patients as a flat list used by therapist patient dashboards.
+
+**Access control:** Patients are filtered by both clinic and project:
+- `patient.clinic in therapist.clinics` — always applied.
+- `patient.project in therapist.projects` — applied when the therapist has at least one project assigned. Therapists with `projects=[]` fall back to clinic-only filtering for backward compatibility.
 
 ### Response fields (per patient)
 
@@ -83,6 +87,15 @@ patient dashboards.
 | `test_biomarker_wear_time_none_when_no_fitbit_data` | No FitbitData for patient | Both wear fields are `null` |
 | `test_biomarker_sleep_avg_h_uses_minutes_asleep` | FitbitData has `minutes_asleep=420` (7 h) and `sleep_duration=28800000` (8 h) | `sleep_avg_h` is 7.0, not 8.0 |
 | `test_biomarker_sleep_falls_back_to_duration_when_no_minutes_asleep` | FitbitData has only `sleep_duration=27000000` (7.5 h), no `minutes_asleep` | `sleep_avg_h` is 7.5 |
+
+### Project-based access isolation tests
+
+| Test | Scenario | Expected |
+|---|---|---|
+| `test_project_filter_hides_other_project_patients` | COPAIN therapist at Inselspital; COMPASS patient also at Inselspital | COMPASS patient excluded from response |
+| `test_project_filter_shows_all_assigned_projects` | Therapist with COPAIN+COMPASS at Inselspital | Both patients returned |
+| `test_project_filter_respects_clinic_boundary` | Inselspital/COPAIN therapist; Berner Reha Centrum/COPAIN patient | Berner Reha patient excluded |
+| `test_no_projects_assigned_falls_back_to_clinic_filter` | Therapist with `projects=[]`; patient at same clinic | Patient returned (backward-compat fallback) |
 
 ---
 

--- a/backend/tests/therapist_views/test_therapist_views.py
+++ b/backend/tests/therapist_views/test_therapist_views.py
@@ -796,3 +796,124 @@ def test_list_therapist_patients_creates_open_patient_log(mongo_mock):
     assert log is not None, "Expected an OPEN_PATIENT log entry"
     assert log.userId.id == therapist.userId.id
     assert "patient_count=" in (log.details or "")
+
+
+# ---------------------------------------------------------------------------
+# Project-based access filtering
+# ---------------------------------------------------------------------------
+
+
+def _make_therapist_with_projects(username, clinics, projects):
+    u = User(
+        username=username,
+        email=f"{username}@example.com",
+        phone="000",
+        createdAt=datetime.now(),
+        isActive=True,
+    ).save()
+    return Therapist(
+        userId=u,
+        name="T",
+        first_name="F",
+        specializations=["Cardiology"],
+        clinics=clinics,
+        projects=projects,
+    ).save()
+
+
+def _make_patient_with_project(username, therapist, clinic, project):
+    u = User(
+        username=username,
+        email=f"{username}@example.com",
+        phone="000",
+        createdAt=datetime.now(),
+        isActive=True,
+    ).save()
+    return Patient(
+        userId=u,
+        patient_code=f"PAT-{str(ObjectId())[-6:]}",
+        name="Doe",
+        first_name=username,
+        access_word="w",
+        age="30",
+        therapist=therapist,
+        clinic=clinic,
+        project=project,
+        sex="Male",
+        diagnosis=["Stroke"],
+        function=["Cardiology"],
+        level_of_education="High School",
+        professional_status="Employed Full-Time",
+        marital_status="Single",
+        lifestyle=[],
+        personal_goals=[],
+    ).save()
+
+
+def test_project_filter_hides_other_project_patients():
+    """Therapist in COPAIN@Inselspital must NOT see COMPASS@Inselspital patients."""
+    therapist = _make_therapist_with_projects("th_copain", ["Inselspital"], ["COPAIN"])
+    copain_pt = _make_patient_with_project("pt_copain", therapist, "Inselspital", "COPAIN")
+    _make_patient_with_project("pt_compass", therapist, "Inselspital", "COMPASS")
+
+    resp = client.get(
+        f"/api/therapists/{therapist.userId.id}/patients/",
+        HTTP_AUTHORIZATION="Bearer test",
+    )
+    assert resp.status_code == 200
+    ids = [r["_id"] for r in resp.json()]
+    assert str(copain_pt.id) in ids, "COPAIN patient should be visible"
+    assert not any(r.get("username") == "pt_compass" for r in resp.json()), (
+        "COMPASS patient must not be visible to a COPAIN-only therapist"
+    )
+
+
+def test_project_filter_shows_all_assigned_projects():
+    """Therapist with COPAIN+COMPASS@Inselspital sees patients from both projects."""
+    therapist = _make_therapist_with_projects(
+        "th_both", ["Inselspital"], ["COPAIN", "COMPASS"]
+    )
+    copain_pt = _make_patient_with_project("pt_copain2", therapist, "Inselspital", "COPAIN")
+    compass_pt = _make_patient_with_project("pt_compass2", therapist, "Inselspital", "COMPASS")
+
+    resp = client.get(
+        f"/api/therapists/{therapist.userId.id}/patients/",
+        HTTP_AUTHORIZATION="Bearer test",
+    )
+    assert resp.status_code == 200
+    ids = [r["_id"] for r in resp.json()]
+    assert str(copain_pt.id) in ids
+    assert str(compass_pt.id) in ids
+
+
+def test_project_filter_respects_clinic_boundary():
+    """Therapist at Inselspital/COPAIN must NOT see Berner Reha/COPAIN patients."""
+    therapist = _make_therapist_with_projects("th_insel", ["Inselspital"], ["COPAIN"])
+    insel_pt = _make_patient_with_project("pt_insel", therapist, "Inselspital", "COPAIN")
+    _make_patient_with_project("pt_brc", therapist, "Berner Reha Centrum", "COPAIN")
+
+    resp = client.get(
+        f"/api/therapists/{therapist.userId.id}/patients/",
+        HTTP_AUTHORIZATION="Bearer test",
+    )
+    assert resp.status_code == 200
+    ids = [r["_id"] for r in resp.json()]
+    assert str(insel_pt.id) in ids
+    assert not any(r.get("username") == "pt_brc" for r in resp.json()), (
+        "Patient at a different clinic must not be visible"
+    )
+
+
+def test_no_projects_assigned_falls_back_to_clinic_filter():
+    """Therapist with projects=[] (legacy) still sees all patients at their clinic."""
+    therapist = _make_therapist_with_projects("th_legacy", ["Inselspital"], [])
+    pt = _make_patient_with_project("pt_legacy", therapist, "Inselspital", "COPAIN")
+
+    resp = client.get(
+        f"/api/therapists/{therapist.userId.id}/patients/",
+        HTTP_AUTHORIZATION="Bearer test",
+    )
+    assert resp.status_code == 200
+    ids = [r["_id"] for r in resp.json()]
+    assert str(pt.id) in ids, "Legacy therapist (no projects) should see clinic patients"
+

--- a/backend/tests/therapist_views/test_therapist_views.py
+++ b/backend/tests/therapist_views/test_therapist_views.py
@@ -863,16 +863,14 @@ def test_project_filter_hides_other_project_patients():
     assert resp.status_code == 200
     ids = [r["_id"] for r in resp.json()]
     assert str(copain_pt.id) in ids, "COPAIN patient should be visible"
-    assert not any(r.get("username") == "pt_compass" for r in resp.json()), (
-        "COMPASS patient must not be visible to a COPAIN-only therapist"
-    )
+    assert not any(
+        r.get("username") == "pt_compass" for r in resp.json()
+    ), "COMPASS patient must not be visible to a COPAIN-only therapist"
 
 
 def test_project_filter_shows_all_assigned_projects():
     """Therapist with COPAIN+COMPASS@Inselspital sees patients from both projects."""
-    therapist = _make_therapist_with_projects(
-        "th_both", ["Inselspital"], ["COPAIN", "COMPASS"]
-    )
+    therapist = _make_therapist_with_projects("th_both", ["Inselspital"], ["COPAIN", "COMPASS"])
     copain_pt = _make_patient_with_project("pt_copain2", therapist, "Inselspital", "COPAIN")
     compass_pt = _make_patient_with_project("pt_compass2", therapist, "Inselspital", "COMPASS")
 
@@ -899,9 +897,9 @@ def test_project_filter_respects_clinic_boundary():
     assert resp.status_code == 200
     ids = [r["_id"] for r in resp.json()]
     assert str(insel_pt.id) in ids
-    assert not any(r.get("username") == "pt_brc" for r in resp.json()), (
-        "Patient at a different clinic must not be visible"
-    )
+    assert not any(
+        r.get("username") == "pt_brc" for r in resp.json()
+    ), "Patient at a different clinic must not be visible"
 
 
 def test_no_projects_assigned_falls_back_to_clinic_filter():
@@ -916,4 +914,3 @@ def test_no_projects_assigned_falls_back_to_clinic_filter():
     assert resp.status_code == 200
     ids = [r["_id"] for r in resp.json()]
     assert str(pt.id) in ids, "Legacy therapist (no projects) should see clinic patients"
-

--- a/docs/02-ARCHITECTURE.md
+++ b/docs/02-ARCHITECTURE.md
@@ -257,6 +257,25 @@ UI Updated with Results
 - Permission decorators on endpoints
 - Secure password hashing
 
+### Therapist Access Control Model
+
+Therapists are scoped to a subset of patients via two independent dimensions:
+
+| Dimension | Model field | Description |
+|---|---|---|
+| Clinic | `Therapist.clinics` | List of clinic names the therapist belongs to |
+| Project | `Therapist.projects` | List of research/care projects (e.g. `COPAIN`, `COMPASS`) |
+
+Patient records carry matching `clinic` and `project` fields. The patient list endpoint (`GET /api/therapists/<id>/patients/`) always filters by `clinic__in` and, when projects are assigned, also by `project__in`. Therapists with no projects assigned fall back to clinic-only filtering for backward compatibility.
+
+**REDCap DAG mapping** (`config.json` → `therapistInfo.clinic_dag`):
+
+REDCap uses Data Access Groups (DAGs) to scope records to clinics. DAG names may differ from the application's clinic names (e.g. `"Lumezzane"` in the app vs. `"lumezzane"` as the REDCap DAG). The `clinic_dag` config provides an explicit clinic → DAG mapping used to:
+1. Filter candidates returned by `GET /api/redcap/available-patients/` to DAGs the therapist can access.
+2. Set the correct `clinic` value on a `Patient` document when importing from REDCap (using the reverse DAG → clinic lookup).
+
+Adding a new clinic to the system requires updating both `clinic_projects` (which projects that clinic runs) and `clinic_dag` (the REDCap DAG name) in `backend/config.json`.
+
 ### Data Protection
 - HTTPS/TLS in production
 - CORS policy configuration

--- a/docs/08-TROUBLESHOOTING.md
+++ b/docs/08-TROUBLESHOOTING.md
@@ -59,6 +59,88 @@ If this still happens after the fix: check that `localStorage.refreshToken` is p
 
 ---
 
+### REDCap Access and Import Issues
+
+#### Issue: REDCap import modal shows an error instead of candidates
+
+**Symptom:** Refreshing the candidate list shows an error such as:
+```
+COPAIN: REDCap API returned non-200. | COMPASS: REDCap API returned non-200.
+```
+
+**Cause:** The minimal REDCap export (`GET /api/redcap/available-patients/`) failed for one or more projects. Common reasons:
+
+| Error detail | Cause | Fix |
+|---|---|---|
+| `"fields" are not valid: 'pat_id'` | The project (e.g. COMPASS) does not have a `pat_id` field. | Resolved automatically — the backend retries without invalid fields. Ensure the latest backend code is running. |
+| `401 Unauthorized` | The REDCap token for the project is missing or expired. | Check `REDCAP_TOKEN_COPAIN` / `REDCAP_TOKEN_COMPASS` env vars in `.env.dev` or `.env.prod` and restart the `django` container. |
+| `403 Forbidden` | The token exists but the REDCap project is not accessible with it. | Verify the token in REDCap → API → generate token. |
+
+Partial failures return HTTP 200 with an `errors[]` array alongside any successful `candidates[]`. The modal will show both.
+
+---
+
+#### Issue: Therapist can see patients from another study at the same clinic
+
+**Symptom:** A therapist assigned to COPAIN at Inselspital can see COMPASS patients (or vice versa) in the patient list.
+
+**Cause:** The `Patient` document is missing a `project` field, or the `project` field does not match the therapist's assigned projects.
+
+**How filtering works:**
+- `list_therapist_patients` filters `patient.clinic in therapist.clinics` **and** `patient.project in therapist.projects` (when projects are assigned).
+- REDCap-imported patients get `project` set to the REDCap project name at import time.
+- Manually created patients must have `project` set explicitly.
+
+**Fix for already-imported patients missing `project`:**
+
+```python
+# Django shell — update a specific patient
+from core.models import Patient
+p = Patient.objects.get(patient_code="905-2")
+p.project = "COMPASS"
+p.clinic = "Bern"   # correct clinic for this patient's DAG
+p.save()
+```
+
+---
+
+#### Issue: REDCap import modal shows candidates from clinics the therapist doesn't have access to
+
+**Symptom:** The import modal shows records from DAGs (e.g. `leuven`, `lumezzane`) that the therapist's clinic list does not include.
+
+**Cause:** The `clinic_dag` mapping in `config.json` may be missing or the clinic name may not exactly match the application's `therapistInfo.clinic_projects` list.
+
+**Fix:** Check `backend/config.json` → `therapistInfo.clinic_dag`. Each clinic name must exactly match a key in `clinic_projects`, and the value must match the REDCap DAG name (lowercase, underscores). Example:
+
+```json
+"clinic_dag": {
+  "Lumezzane": "lumezzane",
+  "Leuven": "leuven"
+}
+```
+
+If a DAG mapping is missing, the clinic is not included in the allowed set and records from that DAG will be filtered out. This is the safe default — add the mapping to grant access.
+
+---
+
+#### Issue: Imported patient is visible to the wrong therapist
+
+**Symptom:** After import, a COMPASS patient at Bern appears in the list for a therapist who only has COPAIN access.
+
+**Cause:** The patient's `clinic` or `project` field was not set correctly at import time (possible with the old import code).
+
+**Diagnosis:**
+
+```python
+from core.models import Patient
+p = Patient.objects.get(patient_code="905-2")
+print(p.clinic, p.project)  # expect "Bern" and "COMPASS"
+```
+
+**Fix:** Update the patient record (see above). Future imports automatically derive `clinic` from the patient's REDCap DAG via the `clinic_dag` mapping.
+
+---
+
 ### Intervention Import Issues
 
 #### Issue: Excel import always fails with "Invalid file type"

--- a/docs/09-API_DOCUMENTATION.md
+++ b/docs/09-API_DOCUMENTATION.md
@@ -609,7 +609,13 @@ JWT required (Therapist only). Allows resetting a patient's password without kno
 
 #### `GET /api/therapists/<therapist_id>/patients/`
 
-JWT required. Returns all patients whose `clinic` field matches any of the therapist's assigned clinics.
+JWT required. Returns patients the therapist is allowed to see, filtered by both clinic and project.
+
+**Access control:**
+- Always filters `patient.clinic` to `therapist.clinics`.
+- When the therapist has one or more `projects` assigned, also filters `patient.project` to `therapist.projects`. A therapist at Inselspital assigned only to COPAIN will not see COMPASS patients at Inselspital.
+- Therapists with `projects=[]` (legacy accounts created before project-based access was introduced) fall back to clinic-only filtering.
+- Inactive patient accounts (`User.isActive=false`) are excluded.
 
 **Response 200:** Array of patient summary objects:
 
@@ -1574,7 +1580,49 @@ JWT required.
 
 JWT required.
 
-**Response 200:** Array of available REDCap patient records not yet imported.
+Returns REDCap records not yet imported into the platform, filtered to the therapist's allowed clinics, projects, and DAGs.
+
+**Query params:**
+
+| Param             | Type   | Required | Notes |
+|-------------------|--------|----------|-------|
+| `therapistUserId` | string | no       | Mongo User `_id`. Derived from JWT if omitted. |
+| `project`         | string | no       | Restrict to one project (must be in therapist's allowed projects). |
+| `patientId`       | string | no       | Filter by `pat_id` value. |
+| `recordId`        | string | no       | Filter by REDCap `record_id`. |
+
+**Access control:** The endpoint resolves the therapist's `clinics` and `projects`, maps each clinic to its REDCap DAG via `clinic_dag` in `config.json`, and filters out any record whose `redcap_data_access_group` is not in the allowed DAG set. A therapist at Inselspital/COPAIN will not see COMPASS records, and vice versa.
+
+**Field fallback:** Some projects (e.g. COMPASS) do not have a `pat_id` field. The export automatically retries without fields the project does not recognise and falls back to `record_id` as the identifier.
+
+**Response 200:**
+
+```json
+{
+  "ok": true,
+  "projects": ["COPAIN", "COMPASS"],
+  "candidates": [
+    {
+      "project": "COMPASS",
+      "record_id": "905-2",
+      "pat_id": "",
+      "identifier": "905-2",
+      "dag": "bern"
+    }
+  ],
+  "errors": [
+    {
+      "project": "COPAIN",
+      "error": "REDCap API returned non-200.",
+      "detail": { "status": 400, "text": "..." }
+    }
+  ]
+}
+```
+
+`errors` is omitted when all projects succeed. Partial success (some projects fail, some return candidates) returns HTTP 200 with both `candidates` and `errors` populated.
+
+**Errors:** 403 project not in therapist's allowed list · 404 therapist not found · 405 wrong method
 
 ---
 
@@ -1612,30 +1660,45 @@ JWT required.
 
 JWT required.
 
+Creates a platform `User` + `Patient` from a single REDCap record.
+
 **Request body:**
 
-| Field                         | Type    | Required |
-|-------------------------------|---------|----------|
-| `patientCode`                 | string  | yes      |
-| `project`                     | string  | yes      |
-| `therapistUserId`             | string  | yes      |
-| `clinicName`                  | string  | yes      |
-| `sourceFields`                | object  | no       | REDCap field → patient field mapping |
-| `initialQuestionnaireEnabled` | boolean | no       |
+| Field             | Type   | Required | Notes |
+|-------------------|--------|----------|-------|
+| `patient_code`    | string | yes      | REDCap `pat_id` or `record_id` — used as the platform patient code. |
+| `project`         | string | yes      | REDCap project name (`COPAIN` / `COMPASS`). Must be in the therapist's allowed projects. |
+| `password`        | string | yes      | Temporary password for the new patient account (min 8 chars, upper + lower + digit + special). |
+| `therapistUserId` | string | no       | Mongo User `_id`. Derived from JWT if omitted. |
+
+**Access control:** Before creating the patient the endpoint:
+1. Verifies the project is in the therapist's allowed projects.
+2. Fetches the REDCap record and checks its `redcap_data_access_group` against the therapist's allowed DAGs (derived from `clinic_dag` in `config.json`). Returns 403 if the DAG is not allowed.
+
+**Patient fields set on import:**
+
+| Patient field   | Value |
+|-----------------|-------|
+| `patient_code`  | `pat_id` if present, else `record_id` |
+| `project`       | REDCap project name (e.g. `COMPASS`) |
+| `clinic`        | Clinic name resolved from the patient's DAG via reverse `clinic_dag` lookup; falls back to the therapist's first clinic if the DAG is not mapped. |
+| `therapist`     | The importing therapist |
 
 **Response 201:**
 
 ```json
 {
-  "success": true,
-  "message": "Patient imported",
-  "userId": "...",
-  "patientId": "...",
-  "accessWord": "<temporary_password>"
+  "ok": true,
+  "message": "Patient imported successfully.",
+  "identifier": "905-2",
+  "username": "905-2",
+  "project": "COMPASS",
+  "patient_id": "<mongo_id>",
+  "user_id": "<mongo_id>"
 }
 ```
 
-**Errors:** 400 validation / already exists / therapist not found · 404 clinic or project not found · 500
+**Errors:** 400 validation / weak password / already imported · 403 project not allowed / DAG forbidden · 404 therapist not found / record not found in REDCap · 502 REDCap API error · 500
 
 ---
 

--- a/frontend/src/stores/therapistPatientsStore.ts
+++ b/frontend/src/stores/therapistPatientsStore.ts
@@ -217,16 +217,21 @@ export class TherapistPatientsStore {
         },
       });
 
-      const data = (res.data ?? {}) as unknown;
-      const candidates =
-        typeof data === 'object' &&
-        data !== null &&
-        Array.isArray((data as { candidates?: unknown }).candidates)
-          ? ((data as { candidates: RedcapCandidate[] }).candidates as RedcapCandidate[])
-          : [];
+      const data = (res.data ?? {}) as Record<string, unknown>;
+      const candidates = Array.isArray(data.candidates)
+        ? (data.candidates as RedcapCandidate[])
+        : [];
+
+      // Surface per-project errors returned in a 200 response body
+      const apiErrors = Array.isArray(data.errors) ? (data.errors as { project: string; error: string }[]) : [];
+      const errorMessage =
+        apiErrors.length > 0
+          ? apiErrors.map((e) => `${e.project}: ${e.error}`).join(' | ')
+          : '';
 
       runInAction(() => {
         this.redcapCandidates = candidates;
+        if (errorMessage) this.redcapError = errorMessage;
 
         // keep existing rowPasswords for still-present keys
         const nextPw: Record<string, string> = {};

--- a/frontend/src/stores/therapistPatientsStore.ts
+++ b/frontend/src/stores/therapistPatientsStore.ts
@@ -223,11 +223,11 @@ export class TherapistPatientsStore {
         : [];
 
       // Surface per-project errors returned in a 200 response body
-      const apiErrors = Array.isArray(data.errors) ? (data.errors as { project: string; error: string }[]) : [];
+      const apiErrors = Array.isArray(data.errors)
+        ? (data.errors as { project: string; error: string }[])
+        : [];
       const errorMessage =
-        apiErrors.length > 0
-          ? apiErrors.map((e) => `${e.project}: ${e.error}`).join(' | ')
-          : '';
+        apiErrors.length > 0 ? apiErrors.map((e) => `${e.project}: ${e.error}`).join(' | ') : '';
 
       runInAction(() => {
         this.redcapCandidates = candidates;


### PR DESCRIPTION
## Summary

Implements project-based access control for therapists so that users assigned to one study (e.g. COPAIN) cannot see patients from another study running at the same clinic (e.g. COMPASS at Inselspital). Also fixes two REDCap integration issues uncovered during testing: a field-validation error that blocked imports from projects without a `pat_id` field, and silent per-project errors that were never shown to the therapist.

## Changes

### Backend

**`backend/config.json`**
- Added `clinic_dag` mapping under `therapistInfo` — maps each clinic name to its REDCap Data Access Group (DAG) identifier.
**`backend/core/views/therapist_views.py`**
- `list_therapist_patients`: extended the patient queryset filter to include `project__in=therapist.projects` when the therapist has projects assigned. Therapists with `projects=[]` fall back to clinic-only filtering (backward compatible).

**`backend/core/views/template_views.py`**
- Bulk diagnosis template assignment: same project filter applied so mass-assign only targets patients in the therapist's allowed projects.

**`backend/core/views/redcap_import_views.py`**
- `allowed_dags_by_project`: was a stub returning `None` (no filtering). Now uses `clinic_dag` + `clinic_projects` from config to derive the set of allowed REDCap DAGs from the therapist's assigned clinics and project, filtering candidates and blocking imports accordingly.
- `import_patient_from_redcap`: fixed patient creation to set `project` (the REDCap project name) and `clinic` (derived from the patient's DAG via reverse `clinic_dag` lookup, not hardcoded to the therapist's first clinic).
- `redcap_export_minimal`: replaced direct `requests.post` with a new `_post_redcap_minimal` helper that strips fields the REDCap project doesn't recognise (e.g. `pat_id` in COMPASS) and retries once. Previously the entire minimal export failed with HTTP 400 when `pat_id` was not a valid field.

**`backend/tests/`**
- `test_redcap_import_views.py`: updated mock DAG values to match `inselspital` (the real DAG for that clinic); updated `allowed_dags_by_project` assertion to reflect real behaviour.
- `test_therapist_views.py`: added four new tests covering project-based isolation:
  - COPAIN therapist does not see COMPASS patients at the same clinic
  - Therapist with both projects sees patients from both
  - Clinic boundary is respected alongside project filter
  - Legacy therapists with no projects assigned fall back to clinic-only filter

### Frontend

**`frontend/src/stores/therapistPatientsStore.ts`**
- `fetchRedcapCandidates`: reads the `errors` array from the 200-OK response body (per-project failures were already returned by the API but silently discarded). Errors are now formatted as `"PROJECT: reason"` and shown in `redcapError`, which the import modal already renders.

## Why this was needed

The patient list endpoint previously filtered by `clinic__in` only. A therapist at Inselspital assigned to COPAIN would also see COMPASS patients enrolled at Inselspital — the two studies share the clinic but have separate access control requirements. Similarly, REDCap candidates were not filtered by DAG at all, so the import modal showed every available record regardless of the therapist's clinic assignments.

## Test plan

- [ ] Log in as a therapist with `clinics=[Inselspital]` and `projects=[COPAIN]` — verify COMPASS patients at Inselspital are not listed
- [ ] Log in as a therapist with both projects — verify patients from both appear
- [ ] Open the REDCap import modal — verify candidates are scoped to the therapist's DAGs (e.g. no Leuven/Lummezzane records for a therapist without those clinics)
- [ ] Import a COMPASS patient — verify the created `Patient` document has `project="COMPASS"` and `clinic` matching the patient's DAG
- [ ] Check that already-imported patients without `project` set still appear for legacy therapists (backward-compat fallback)
- [ ] Run backend test suite: `docker exec django pytest tests/therapist_views/ tests/redcap_import_views/ -v`
