### PR TITLE
Bug - Login Problems [WIP]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ secrets/
 .env.dev
 .env.prod
 backups/
+.codex
+.claude

--- a/backend/core/jwt_auth.py
+++ b/backend/core/jwt_auth.py
@@ -1,19 +1,16 @@
 """
-Custom JWT authentication backend for MongoEngine.
+Custom JWT helpers for MongoEngine-backed users.
 
-Django's default User model uses an integer primary key. This app stores users
-in MongoDB (MongoEngine) with ObjectId PKs. The simplejwt default get_user()
-calls Django ORM and crashes with:
+Django's default auth stack assumes integer primary keys on the SQL auth.User
+model. This app stores users in MongoDB (MongoEngine) with ObjectId PKs, so
+simplejwt's default helpers crash when they try to resolve a token's user_id
+claim through the Django ORM:
 
     ValueError: Field 'id' expected a number but got '<ObjectId string>'
 
-This subclass overrides get_user() to return a minimal user-like object that:
-  - satisfies DRF's IsAuthenticated permission check (is_authenticated=True)
-  - exposes `id` as the raw MongoDB ObjectId string from the JWT user_id claim
-    so that _get_therapist() and get_therapist_for_user() can look up Therapist
-
-No database (SQL or Mongo) query is made during authentication; the Therapist
-lookup happens inside each view function after the token is validated.
+This module provides a Mongo-aware authentication override:
+  - MongoJWTAuthentication: returns a lightweight authenticated user object
+    instead of querying Django's auth.User table.
 """
 
 from types import SimpleNamespace

--- a/backend/core/jwt_refresh.py
+++ b/backend/core/jwt_refresh.py
@@ -1,0 +1,55 @@
+"""Mongo-aware JWT refresh serializer/view."""
+
+from rest_framework.exceptions import AuthenticationFailed
+from rest_framework_simplejwt.serializers import TokenRefreshSerializer
+from rest_framework_simplejwt.settings import api_settings
+from rest_framework_simplejwt.views import TokenRefreshView
+
+from core.models import User
+
+
+class MongoTokenRefreshSerializer(TokenRefreshSerializer):
+    """
+    Refresh JWTs without querying Django's SQL auth.User model.
+
+    The stock TokenRefreshSerializer validates the token's ``user_id`` claim
+    via ``get_user_model().objects.get(id=...)``, which crashes for our Mongo
+    ObjectId strings. We instead resolve the token subject against the
+    MongoEngine ``core.models.User`` collection.
+    """
+
+    def validate(self, attrs):
+        refresh = self.token_class(attrs["refresh"])
+
+        user_id = refresh.payload.get(api_settings.USER_ID_CLAIM, None)
+        if user_id:
+            user = User.objects(id=str(user_id)).first()
+            if not user or not getattr(user, "isActive", False):
+                raise AuthenticationFailed(
+                    self.error_messages["no_active_account"],
+                    "no_active_account",
+                )
+
+        data = {"access": str(refresh.access_token)}
+
+        if api_settings.ROTATE_REFRESH_TOKENS:
+            if api_settings.BLACKLIST_AFTER_ROTATION:
+                try:
+                    refresh.blacklist()
+                except AttributeError:
+                    pass
+
+            refresh.set_jti()
+            refresh.set_exp()
+            refresh.set_iat()
+            refresh.outstand()
+
+            data["refresh"] = str(refresh)
+
+        return data
+
+
+class MongoTokenRefreshView(TokenRefreshView):
+    """Use the Mongo-aware refresh serializer for /api/auth/token/refresh/."""
+
+    serializer_class = MongoTokenRefreshSerializer

--- a/backend/core/urls.py
+++ b/backend/core/urls.py
@@ -1,7 +1,6 @@
 from django.conf import settings
 from django.conf.urls.static import static
 from django.urls import path
-from rest_framework_simplejwt.views import TokenRefreshView
 
 import core.views.auth_views as auth_views
 import core.views.fitbit_view as fitbit_views
@@ -43,6 +42,7 @@ from core.views.redcap_views import redcap_projects, redcap_record
 from core.views.therapist_access_views import therapist_access
 from core.views.therapist_projects import therapist_projects
 from core.views.wearables_redcap_view import sync_wearables_to_redcap_view
+from core.jwt_refresh import MongoTokenRefreshView
 
 urlpatterns = [
     path("api/", core_views.index, name="index"),
@@ -68,7 +68,7 @@ urlpatterns = [
         name="send_verification_code",
     ),
     path("api/auth/verify-code/", auth_views.verify_code_view, name="verify_code"),
-    path("api/auth/token/refresh/", TokenRefreshView.as_view(), name="token_refresh"),
+    path("api/auth/token/refresh/", MongoTokenRefreshView.as_view(), name="token_refresh"),
     # User Profile
     path(
         "api/users/<str:user_id>/profile/",

--- a/backend/core/urls.py
+++ b/backend/core/urls.py
@@ -10,6 +10,7 @@ import core.views.template_views as template_views
 import core.views.therapist_views as therapist_views
 import core.views.user_views as user_views
 import core.views.views as core_views
+from core.jwt_refresh import MongoTokenRefreshView
 from core.views.access_change_views import (
     admin_access_change_requests,
     submit_access_change_request,
@@ -42,7 +43,6 @@ from core.views.redcap_views import redcap_projects, redcap_record
 from core.views.therapist_access_views import therapist_access
 from core.views.therapist_projects import therapist_projects
 from core.views.wearables_redcap_view import sync_wearables_to_redcap_view
-from core.jwt_refresh import MongoTokenRefreshView
 
 urlpatterns = [
     path("api/", core_views.index, name="index"),

--- a/backend/tests/auth_views/test_refresh_view.py
+++ b/backend/tests/auth_views/test_refresh_view.py
@@ -1,0 +1,99 @@
+"""
+Authentication refresh-token view tests — ``/api/auth/token/refresh/``
+=======================================================================
+
+These tests guard the MongoDB-specific refresh flow. The stock simplejwt
+refresh serializer looks up the token's ``user_id`` against Django's SQL
+``auth.User`` table, which crashes when our JWT contains a Mongo ObjectId
+string. The custom refresh view must accept those tokens and rotate them
+normally.
+"""
+
+import json
+from datetime import datetime
+
+import mongomock
+import pytest
+from django.test import Client
+from mongoengine import connect, disconnect
+from rest_framework_simplejwt.tokens import RefreshToken
+
+from core.models import User
+
+
+@pytest.fixture(autouse=True)
+def mongo_mock():
+    """Provide an isolated in-memory MongoDB for every test in this module."""
+    alias = "default"
+    from mongoengine.connection import _connections
+
+    if alias in _connections:
+        disconnect(alias)
+
+    conn = connect(
+        "mongoenginetest",
+        alias=alias,
+        host="mongodb://localhost",
+        mongo_client_class=mongomock.MongoClient,
+    )
+    yield conn
+    disconnect(alias)
+
+
+client = Client()
+
+REFRESH_URL = "/api/auth/token/refresh/"
+
+
+def _post(payload):
+    return client.post(
+        REFRESH_URL,
+        data=json.dumps(payload),
+        content_type="application/json",
+    )
+
+
+def _make_user(email="refresh@example.com", is_active=True):
+    return User(
+        username=email.split("@")[0],
+        role="Patient",
+        email=email,
+        createdAt=datetime.now(),
+        isActive=is_active,
+    ).save()
+
+
+def _make_refresh_token(user):
+    token = RefreshToken()
+    token["user_id"] = str(user.id)
+    token["role"] = user.role
+    token["username"] = getattr(user, "username", "") or ""
+    return str(token)
+
+
+def test_refresh_token_accepts_mongo_user_id(mongo_mock):
+    """
+    A refresh token whose ``user_id`` claim is a Mongo ObjectId string should
+    return 200 with a fresh access token instead of crashing with a Django ORM
+    integer-id lookup error.
+    """
+    user = _make_user()
+
+    resp = _post({"refresh": _make_refresh_token(user)})
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "access" in data
+    assert "refresh" in data
+
+
+def test_refresh_token_rejects_inactive_mongo_user(mongo_mock):
+    """
+    Refresh must still deny inactive users even though it no longer uses the
+    default Django auth model lookup.
+    """
+    user = _make_user(email="inactive-refresh@example.com", is_active=False)
+
+    resp = _post({"refresh": _make_refresh_token(user)})
+
+    assert resp.status_code == 401


### PR DESCRIPTION
## Summary
This PR fixes login session renewal for MongoDB users by replacing the default SimpleJWT refresh behavior with a Mongo-aware implementation.

The previous `/api/auth/token/refresh/` flow attempted a Django SQL `auth.User` lookup using `user_id`, which fails when the token contains a Mongo `ObjectId` string (`Field 'id' expected a number ...`). This caused refresh requests to fail and users to be logged out unexpectedly.

## Problem
`rest_framework_simplejwt`’s default refresh serializer validates `user_id` via Django ORM (`get_user_model().objects.get(id=...)`), but this project stores users in MongoEngine with string/ObjectId IDs.

Result:
- refresh endpoint returned errors for valid Mongo-issued tokens
- access token renewal failed during active sessions

## Changes
- Added Mongo-aware refresh serializer and view:
  - `backend/core/jwt_refresh.py`
  - `MongoTokenRefreshSerializer`
  - `MongoTokenRefreshView`
- Updated route to use custom refresh view:
  - `backend/core/urls.py`
  - `/api/auth/token/refresh/` now points to `MongoTokenRefreshView`
- Kept active-user enforcement:
  - refresh is rejected (`401`) if Mongo user is missing or inactive (`isActive=False`)
- Clarified JWT helper documentation:
  - `backend/core/jwt_auth.py` docstring updates
- Added tests for refresh behavior:
  - `backend/tests/auth_views/test_refresh_view.py`
  - accepts valid Mongo `user_id` refresh tokens
  - rejects inactive Mongo users

## Validation
Run in Docker:
```bash
docker exec django sh -lc 'cd /app && pytest tests/auth_views/test_refresh_view.py -q'
```

Result:
- `2 passed`

## Notes
Also includes a small `.gitignore` update to ignore local tool folders:
- `.codex`
- `.claude`