### PR TITLE
Bug intervention links

### DIFF
--- a/backend/core/views/intervention_import.py
+++ b/backend/core/views/intervention_import.py
@@ -505,6 +505,28 @@ def _is_raw_file_name(s: str) -> bool:
     return bool(re.search(r"\.(pdf|mp4|mov|m4a|mp3|wav|webm|ogg|png|jpg|jpeg|webp)$", v.lower()))
 
 
+def _normalize_external_url(s: str) -> str:
+    """
+    Normalize URL-like strings from Excel cells.
+
+    - Preserve absolute http(s) URLs
+    - Upgrade bare "www.example.com/..." to "https://..."
+    - Leave non-URL strings untouched
+    """
+    v = _norm(s)
+    if not v:
+        return ""
+    if re.match(r"^https?://", v, flags=re.IGNORECASE):
+        return v
+    if re.match(r"^www\.", v, flags=re.IGNORECASE):
+        return f"https://{v}"
+    return v
+
+
+def _is_http_url(s: str) -> bool:
+    return bool(re.match(r"^https?://", _norm(s), flags=re.IGNORECASE))
+
+
 def _col_index_map(header_row: List[str]) -> Dict[str, int]:
     def find_col(pattern: str) -> Optional[int]:
         rx = re.compile(pattern, re.IGNORECASE)
@@ -677,7 +699,22 @@ def import_interventions_from_excel(
             language = (lang_from_id or lang_from_col or default_lang).lower()
 
             provider = _norm(row[col["provider"]]) if col.get("provider") is not None else ""
-            link_val = _norm(row[col["link"]]) if col.get("link") is not None else ""
+
+            link_val = ""
+            if col.get("link") is not None:
+                link_col_idx = int(col["link"]) + 1  # openpyxl is 1-based
+                link_cell = ws.cell(row_idx, link_col_idx)
+                link_display = _norm(link_cell.value)
+                link_target = _norm(
+                    (getattr(link_cell, "hyperlink", None) and getattr(link_cell.hyperlink, "target", None))
+                    or (
+                        getattr(link_cell, "hyperlink", None)
+                        and getattr(link_cell.hyperlink, "location", None)
+                    )
+                )
+                # Prefer explicit hyperlink target when present; fallback to visible cell value.
+                link_val = _normalize_external_url(link_target or link_display)
+
             title = _norm(row[col["title"]])
             desc = _norm(row[col["description"]])
 
@@ -763,14 +800,15 @@ def import_interventions_from_excel(
             if db_warn and duration_bucket_raw:
                 row_warnings.append(f"duration_bucket: {db_warn}")
 
-            primary_diagnosis_val, pd_warn = _validate_single(
-                primary_diagnosis_raw,
+            primary_diagnosis_list = _split_any(primary_diagnosis_raw)
+            primary_diagnosis_list, pd_warns = _validate_list(
+                primary_diagnosis_list,
                 _TX["primary_diagnoses"],
                 "primary diagnosis",
                 _TAXONOMY.get("primary_diagnoses", []),
             )
-            if pd_warn:
-                row_warnings.append(f"primary_diagnosis: {pd_warn}")
+            for w in pd_warns:
+                row_warnings.append(f"primary_diagnosis: {w}")
 
             input_from_list = _split_any(input_from_raw)
             input_from_list, if_warns = _validate_list(
@@ -815,8 +853,8 @@ def import_interventions_from_excel(
                 _set_if_exists(doc, "physical_level", physical_level_val)
             if sex_specific_val:
                 _set_if_exists(doc, "sex_specific", sex_specific_val)
-            if primary_diagnosis_val:
-                _set_if_exists(doc, "primary_diagnosis", primary_diagnosis_val)
+            if primary_diagnosis_list:
+                _set_if_exists(doc, "primary_diagnosis", primary_diagnosis_list)
             if input_from_list:
                 # input_from is a StringField on the model — join list to CSV string
                 _set_if_exists(doc, "input_from", ", ".join(input_from_list))
@@ -840,7 +878,7 @@ def import_interventions_from_excel(
                             mime=None,
                         )
                     )
-                else:
+                elif _is_http_url(link_val):
                     prov = _guess_provider(link_val)
                     embed = (
                         _spotify_embed(link_val)
@@ -859,6 +897,8 @@ def import_interventions_from_excel(
                             embed_url=embed,
                         )
                     )
+                else:
+                    row_warnings.append(f'link: "{link_val}" is not a valid http(s) URL; media was skipped.')
 
             def _media_key(m: InterventionMedia) -> str:
                 return (
@@ -872,6 +912,12 @@ def import_interventions_from_excel(
             seen_keys = set()
 
             for m in getattr(doc, "media", None) or []:
+                existing_kind = _norm(getattr(m, "kind", ""))
+                if existing_kind == "external":
+                    existing_url = _norm(getattr(m, "url", ""))
+                    if existing_url and not _is_http_url(existing_url):
+                        # Cleanup old broken entries created from non-URL display text.
+                        continue
                 k = _media_key(m)
                 if k not in seen_keys:
                     merged.append(m)

--- a/backend/core/views/intervention_import.py
+++ b/backend/core/views/intervention_import.py
@@ -707,10 +707,7 @@ def import_interventions_from_excel(
                 link_display = _norm(link_cell.value)
                 link_target = _norm(
                     (getattr(link_cell, "hyperlink", None) and getattr(link_cell.hyperlink, "target", None))
-                    or (
-                        getattr(link_cell, "hyperlink", None)
-                        and getattr(link_cell.hyperlink, "location", None)
-                    )
+                    or (getattr(link_cell, "hyperlink", None) and getattr(link_cell.hyperlink, "location", None))
                 )
                 # Prefer explicit hyperlink target when present; fallback to visible cell value.
                 link_val = _normalize_external_url(link_target or link_display)

--- a/backend/tests/intervention_import_views/test_intervention_import_view.py
+++ b/backend/tests/intervention_import_views/test_intervention_import_view.py
@@ -9,7 +9,7 @@ import pytest
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import Client
 
-from core.models import Intervention
+from core.models import Intervention, InterventionMedia
 from core.views.intervention_import import (
     _guess_file_media_type,
     _guess_media_type_for_url,
@@ -290,3 +290,88 @@ def test_import_interventions_from_excel_header_fallback_and_update_dedupe():
         assert "home" in doc.where and "outside" in doc.where
         assert "individual" in doc.setting and "group" in doc.setting
         assert len(doc.media or []) >= 1
+
+
+def test_import_uses_hyperlink_target_instead_of_display_text():
+    with tempfile.TemporaryDirectory() as td:
+        p = Path(td) / "x.xlsx"
+        wb = openpyxl.Workbook()
+        ws = wb.active
+        ws.title = "Content"
+        ws.append(["intervention_id", "title", "description", "content_type", "link"])
+        ws.append(["7001_en", "Pain Intro", "Desc", "Video", "Wo entstehen Schmerzen?"])
+        ws.cell(2, 5).hyperlink = (
+            "https://www.youtube.com/watch?v=BUJJuzTM2AE&list=PLLdU1J1EAwgPmCDdhF4w5hu37NI-WWtij&index=1"
+        )
+        wb.save(p)
+
+        result = import_interventions_from_excel(str(p), dry_run=False)
+        assert result["created"] == 1
+
+        doc = Intervention.objects(external_id="7001", language="en").first()
+        assert doc is not None
+        assert len(doc.media or []) == 1
+        assert doc.media[0].kind == "external"
+        assert doc.media[0].url.startswith("https://www.youtube.com/watch")
+
+
+def test_import_cleans_existing_invalid_external_media_urls():
+    # Simulate previously imported bad data where display text was saved as URL.
+    Intervention(
+        external_id="7002",
+        language="en",
+        title="Old",
+        description="Old",
+        content_type="Website",
+        media=[InterventionMedia(kind="external", media_type="website", url="Wo entstehen Schmerzen?")],
+    ).save()
+
+    with tempfile.TemporaryDirectory() as td:
+        p = Path(td) / "x.xlsx"
+        wb = openpyxl.Workbook()
+        ws = wb.active
+        ws.title = "Content"
+        ws.append(["intervention_id", "title", "description", "content_type", "link"])
+        ws.append(["7002_en", "New", "Desc", "Video", "Wie über Schmerzen reden?"])
+        ws.cell(2, 5).hyperlink = (
+            "https://www.youtube.com/watch?v=PS27RAlM3As&list=PLLdU1J1EAwgPmCDdhF4w5hu37NI-WWtij&index=3"
+        )
+        wb.save(p)
+
+        result = import_interventions_from_excel(str(p), dry_run=False)
+        assert result["updated"] == 1
+
+        doc = Intervention.objects(external_id="7002", language="en").first()
+        assert doc is not None
+        urls = [m.url for m in (doc.media or []) if getattr(m, "kind", "") == "external"]
+        assert all((u or "").startswith("http") for u in urls)
+        assert any((u or "").startswith("https://www.youtube.com/watch") for u in urls)
+
+
+def test_import_primary_diagnosis_is_stored_as_list_field():
+    with tempfile.TemporaryDirectory() as td:
+        p = Path(td) / "x.xlsx"
+        wb = openpyxl.Workbook()
+        ws = wb.active
+        ws.title = "Content"
+        ws.append(
+            [
+                "intervention_id",
+                "title",
+                "description",
+                "content_type",
+                "primary diagnosis (single choice)",
+            ]
+        )
+        ws.append(["7100_web_de", "Dx", "Desc", "Website", "heart failure"])
+        wb.save(p)
+
+        result = import_interventions_from_excel(str(p), dry_run=False)
+        assert result["created"] == 1
+        assert result["skipped"] == 0
+        assert not [e for e in result["errors"] if e.get("severity") != "warning"]
+
+        doc = Intervention.objects(external_id="7100_web", language="de").first()
+        assert doc is not None
+        assert isinstance(doc.primary_diagnosis, list)
+        assert "heart failure" in [x.lower() for x in (doc.primary_diagnosis or [])]


### PR DESCRIPTION
## Summary
This PR fixes Excel intervention import issues on `bug-intervention-links` that caused missing/broken intervention links and row-level import failures.

It addresses two root causes:
1. Hyperlink cells were imported from visible text instead of the real hyperlink target URL.
2. `primary_diagnosis` was written as a string even though the model expects a list.

## User-Visible Problem
- Re-importing the provided Excel (`COPAIN_MSK_LINKS_UPLOAD.xlsm`) still left many intervention links broken or missing.
- Import results showed errors like:
  - `Field 'primary_diagnosis': Only lists and tuples may be used in a list field`

## Root Cause
- In Excel, some link cells contain display text (e.g., titles) while the actual URL is stored in `cell.hyperlink.target`.
- Import logic previously read only `cell.value`.
- `Intervention.primary_diagnosis` is a `ListField(StringField())`, but importer assigned a scalar string.

## Changes

### Backend import fixes
File: `backend/core/views/intervention_import.py`

- Link extraction now:
  - prefers `cell.hyperlink.target` (or hyperlink location)
  - falls back to visible cell text only when no hyperlink target exists
- URL normalization:
  - keeps `http(s)://...` as-is
  - upgrades `www...` to `https://...`
- Media creation safety:
  - only creates external media for valid `http(s)` URLs
  - skips non-URL text with a warning instead of creating broken media entries
- Re-import cleanup:
  - drops previously stored invalid external media URLs during merge
- `primary_diagnosis` handling:
  - parses as list
  - validates as list
  - stores as list (matching model schema)

### Tests
File: `backend/tests/intervention_import_views/test_intervention_import_view.py`

Added regression tests for:
- hyperlink-target import when display text is non-URL
- cleanup of pre-existing invalid external media URLs
- `primary_diagnosis` stored as list without list-field validation errors

## Validation
Run in Docker:
```bash
docker exec django sh -lc 'cd /app && pytest tests/intervention_import_views/test_intervention_import_view.py -q'
```

Result:
- **12 passed**

## Impact
- Re-importing the Excel fixture now correctly preserves real intervention URLs.
- Broken link variants caused by hyperlink display text are prevented.
- `primary_diagnosis` list-field errors are resolved.