### PR TITLE
Potential fix for code scanning alert no. 98: Clear-text logging of sensitive information

### DIFF
--- a/backend/core/views/wearables_redcap_view.py
+++ b/backend/core/views/wearables_redcap_view.py
@@ -68,7 +68,7 @@ def sync_wearables_to_redcap_view(request, patient_id: str):
     except RedcapError as e:
         return JsonResponse({"error": str(e), "detail": e.detail}, status=502)
     except Exception as e:
-        logger.exception("Unexpected error syncing wearables for patient %s", patient_id)
+        logger.exception("Unexpected error syncing wearables")
         return JsonResponse({"error": str(e)}, status=500)
 
     return JsonResponse({"ok": True, "results": results, "summary": summary})


### PR DESCRIPTION
Potential fix for [https://github.com/ARTORG-GERONTECHNOLOGY/Bearny-RehaAdvisor/security/code-scanning/98](https://github.com/ARTORG-GERONTECHNOLOGY/Bearny-RehaAdvisor/security/code-scanning/98)

General fix: stop logging raw sensitive identifiers; log either a redacted/masked value or a generic message plus non-sensitive context.

Best fix here without changing functionality: replace the exception log statement on line 71 so it no longer includes `patient_id`. Keep exception traceback logging by retaining `logger.exception(...)`, but remove the `%s` argument entirely. This preserves operational visibility (an unexpected error occurred in this endpoint) without exposing patient-linked data in logs.

File/region to change:
- `backend/core/views/wearables_redcap_view.py` around the `except Exception as e:` block in `sync_wearables_to_redcap_view`.

No new imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
