### PR TITLE
Potential fix for code scanning alert no. 97: Clear-text logging of sensitive information

### DIFF
--- a/backend/core/views/patient_views.py
+++ b/backend/core/views/patient_views.py
@@ -2758,7 +2758,7 @@ def initial_patient_questionaire(request, patient_id):
     try:
         patient = Patient.objects.get(userId=ObjectId(patient_id))
     except Patient.DoesNotExist:
-        logger.warning("[initial_patient_questionaire] Patient not found: %s", patient_id)
+        logger.warning("[initial_patient_questionaire] Patient not found for provided patient identifier.")
         return error_response("Patient not found.", status=404)
 
     # ----------------------------


### PR DESCRIPTION
Potential fix for [https://github.com/ARTORG-GERONTECHNOLOGY/Bearny-RehaAdvisor/security/code-scanning/97](https://github.com/ARTORG-GERONTECHNOLOGY/Bearny-RehaAdvisor/security/code-scanning/97)

To fix this without changing endpoint behavior, stop logging the raw `patient_id` value. Keep the warning log (so observability remains), but replace the sensitive argument with a redacted placeholder.

Best single change:
- In `backend/core/views/patient_views.py`, inside `initial_patient_questionaire`, update the `except Patient.DoesNotExist:` block.
- Replace:
  - `logger.warning("[initial_patient_questionaire] Patient not found: %s", patient_id)`
- With:
  - `logger.warning("[initial_patient_questionaire] Patient not found for provided patient identifier.")`

No new imports, dependencies, or helper methods are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
