### PR TITLE
Potential fix for code scanning alert no. 95: Clear-text logging of sensitive information

### DIFF
--- a/backend/core/views/patient_views.py
+++ b/backend/core/views/patient_views.py
@@ -2663,8 +2663,7 @@ def remove_intervention_from_patient(request):
         plan = RehabilitationPlan.objects.get(patientId=patient)
     except RehabilitationPlan.DoesNotExist:
         logger.warning(
-            "[remove_intervention_from_patient] Plan not found for patient: %s",
-            patient_id,
+            "[remove_intervention_from_patient] Plan not found for provided patient identifier"
         )
         return JsonResponse(
             {


### PR DESCRIPTION
Potential fix for [https://github.com/ARTORG-GERONTECHNOLOGY/Bearny-RehaAdvisor/security/code-scanning/95](https://github.com/ARTORG-GERONTECHNOLOGY/Bearny-RehaAdvisor/security/code-scanning/95)

General fix: never log raw sensitive/untrusted identifiers. Replace direct logging of `patient_id` with a redacted or non-sensitive surrogate (for example, presence/length/constant marker), while keeping the functional behavior and response payloads unchanged.

Best fix here: in `backend/core/views/patient_views.py`, update the warning log in the `RehabilitationPlan.DoesNotExist` block to remove `%s` and stop passing `patient_id`. This preserves the warning event without leaking the identifier. No additional imports or helper methods are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
