### PR TITLE
Potential fix for code scanning alert no. 96: Clear-text logging of sensitive information

### DIFF
--- a/backend/core/views/patient_views.py
+++ b/backend/core/views/patient_views.py
@@ -2649,7 +2649,7 @@ def remove_intervention_from_patient(request):
     try:
         patient = Patient.objects.get(id=ObjectId(patient_id))
     except Patient.DoesNotExist:
-        logger.warning("[remove_intervention_from_patient] Patient not found: %s", patient_id)
+        logger.warning("[remove_intervention_from_patient] Patient not found for supplied identifier.")
         return JsonResponse(
             {
                 "success": False,
@@ -2663,8 +2663,7 @@ def remove_intervention_from_patient(request):
         plan = RehabilitationPlan.objects.get(patientId=patient)
     except RehabilitationPlan.DoesNotExist:
         logger.warning(
-            "[remove_intervention_from_patient] Plan not found for patient: %s",
-            patient_id,
+            "[remove_intervention_from_patient] Plan not found for supplied patient identifier."
         )
         return JsonResponse(
             {
@@ -2710,9 +2709,7 @@ def remove_intervention_from_patient(request):
 
     except Exception as e:
         logger.error(
-            "[remove_intervention_from_patient] Unexpected error while removing " "intervention %s from patient %s: %s",
-            intervention_id,
-            patient_id,
+            "[remove_intervention_from_patient] Unexpected error while removing intervention from patient: %s",
             str(e),
             exc_info=True,
         )


### PR DESCRIPTION
Potential fix for [https://github.com/ARTORG-GERONTECHNOLOGY/Bearny-RehaAdvisor/security/code-scanning/96](https://github.com/ARTORG-GERONTECHNOLOGY/Bearny-RehaAdvisor/security/code-scanning/96)

General fix: do not log raw patient identifiers (or other request-derived sensitive values). Replace them with redacted constants or minimal/non-identifying metadata.

Best fix here (without changing functionality): update the logger calls in `backend/core/views/patient_views.py` to remove `patient_id` (and similarly remove `intervention_id` from the same error log to avoid similar issues). Keep exception stack traces via `exc_info=True`, and keep user-facing API behavior unchanged.

Changes needed in `backend/core/views/patient_views.py` in the shown region:
- Replace warning log at `Patient.DoesNotExist` to avoid `%s` with `patient_id`.
- Replace warning log at `RehabilitationPlan.DoesNotExist` to avoid `%s` with `patient_id`.
- Replace error log in generic `except Exception as e` to avoid logging `intervention_id` and `patient_id` directly.
- No new imports, methods, or dependencies required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
