### PR TITLE
Potential fix for code scanning alert no. 83: Incomplete URL substring sanitization

### DIFF
--- a/backend/utils/interventions.py
+++ b/backend/utils/interventions.py
@@ -4,6 +4,7 @@ import mimetypes
 import os
 from datetime import datetime, timedelta
 from typing import Any, Dict, List, Optional, Tuple
+from urllib.parse import urlparse
 
 from bson import ObjectId
 from django.conf import settings
@@ -679,16 +680,21 @@ def ard_embed(url: str) -> str | None:
 
 
 def _guess_provider(url: str) -> str | None:
-    u = (url or "").lower()
-    if "ardaudiothek.de" in u:
+    u = (url or "").strip()
+    if not u:
+        return "website"
+
+    host = (urlparse(u).hostname or "").lower()
+
+    if host == "ardaudiothek.de" or host.endswith(".ardaudiothek.de"):
         return "ard"
-    if "spotify.com" in u:
+    if host == "spotify.com" or host.endswith(".spotify.com"):
         return "spotify"
-    if "youtube.com" in u or "youtu.be" in u:
+    if host == "youtube.com" or host.endswith(".youtube.com") or host == "youtu.be" or host.endswith(".youtu.be"):
         return "youtube"
-    if "soundcloud.com" in u:
+    if host == "soundcloud.com" or host.endswith(".soundcloud.com"):
         return "soundcloud"
-    if "vimeo.com" in u:
+    if host == "vimeo.com" or host.endswith(".vimeo.com"):
         return "vimeo"
     return "website"
 


### PR DESCRIPTION
Potential fix for [https://github.com/ARTORG-GERONTECHNOLOGY/Bearny-RehaAdvisor/security/code-scanning/83](https://github.com/ARTORG-GERONTECHNOLOGY/Bearny-RehaAdvisor/security/code-scanning/83)

Use structured URL parsing and compare against the parsed hostname (netloc host), not arbitrary substrings in the raw URL.

Best fix in this file:
1. Import `urlparse` from `urllib.parse`.
2. In `_guess_provider`, parse the URL, extract `hostname`, normalize to lowercase, and match providers via exact host / subdomain checks:
   - `host == "vimeo.com" or host.endswith(".vimeo.com")`
   - similarly for other providers.
3. Keep fallback behavior unchanged (`"website"`), and keep handling of empty/malformed input by returning `"website"`.

This preserves existing functionality intent (provider inference) while removing substring-bypass behavior.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
