### PR TITLE
Potential fix for code scanning alert no. 68: Information exposure through an exception

### DIFF
--- a/backend/core/views/user_views.py
+++ b/backend/core/views/user_views.py
@@ -763,9 +763,9 @@ def accept_user(request):
 
         return JsonResponse({"message": "User accepted successfully."}, status=200)
 
-    except Exception as e:
+    except Exception:
         logger.exception("accept_user failed")
-        return JsonResponse({"error": str(e)}, status=500)
+        return JsonResponse({"error": "An internal error occurred."}, status=500)
 
 
 @csrf_exempt
@@ -806,6 +806,6 @@ def decline_user(request):
 
         return JsonResponse({"message": "User declined and deleted successfully."}, status=200)
 
-    except Exception as e:
+    except Exception:
         logger.exception("decline_user failed")
-        return JsonResponse({"error": str(e)}, status=500)
+        return JsonResponse({"error": "An internal error occurred."}, status=500)


### PR DESCRIPTION
Potential fix for [https://github.com/ARTORG-GERONTECHNOLOGY/Bearny-RehaAdvisor/security/code-scanning/68](https://github.com/ARTORG-GERONTECHNOLOGY/Bearny-RehaAdvisor/security/code-scanning/68)

Use a generic client-facing error message for unexpected exceptions, and keep detailed diagnostics only in server logs.

Best fix without changing functionality:
- In `backend/core/views/user_views.py`, update the `except` blocks in both `accept_user` and `decline_user`.
- Keep `logger.exception(...)` as-is (it already captures traceback server-side).
- Replace `return JsonResponse({"error": str(e)}, status=500)` with a generic message like `{"error": "An internal error occurred."}`.

No new imports, methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
