### PR TITLE
Potential fix for code scanning alert no. 21: Information exposure through an exception

### DIFF
--- a/backend/core/views/auth_views.py
+++ b/backend/core/views/auth_views.py
@@ -480,8 +480,9 @@ def reset_password_view(request):
 
     except json.JSONDecodeError:
         return JsonResponse({"error": "Invalid JSON"}, status=400)
-    except Exception as e:
-        return JsonResponse({"error": str(e)}, status=500)
+    except Exception:
+        logger.exception("Unexpected error during password reset.")
+        return JsonResponse({"error": "Internal server error"}, status=500)
 
 
 def _norm_email(raw: str) -> str:


### PR DESCRIPTION
Potential fix for [https://github.com/ARTORG-GERONTECHNOLOGY/Bearny-RehaAdvisor/security/code-scanning/21](https://github.com/ARTORG-GERONTECHNOLOGY/Bearny-RehaAdvisor/security/code-scanning/21)

To fix this, keep detailed exception info in server logs and return a generic error message to clients.

Best fix (without changing functionality): in `backend/core/views/auth_views.py`, update the `except Exception as e:` block in `reset_password_view` to:
1. Log the exception server-side using `logger.exception(...)` (captures traceback for developers).
2. Return a non-sensitive generic message like `"Internal server error"` instead of `str(e)`.

No new imports are needed because `logger` is already defined in this file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
