### PR TITLE
Add yellow intermediate state to threshold status badge

### DIFF
--- a/frontend/src/__tests__/components/PatientProcess/ThresholdStatusBadge.test.tsx
+++ b/frontend/src/__tests__/components/PatientProcess/ThresholdStatusBadge.test.tsx
@@ -9,19 +9,26 @@ jest.mock('react-i18next', () => ({
 
 describe('ThresholdStatusBadge', () => {
   it('renders nothing when status is unknown', () => {
-    const { container } = render(<ThresholdStatusBadge isReached={null} />);
+    const { container } = render(<ThresholdStatusBadge status={null} />);
     expect(container.firstChild).toBeNull();
   });
 
   it('renders success state text and icon when threshold is reached', () => {
-    render(<ThresholdStatusBadge isReached={true} />);
+    render(<ThresholdStatusBadge status="green" />);
 
     expect(screen.getByText('Reached')).toBeInTheDocument();
     expect(screen.getByTestId('svg-mock')).toBeInTheDocument();
   });
 
+  it('renders warning state text and icon when threshold is partially reached', () => {
+    render(<ThresholdStatusBadge status="yellow" />);
+
+    expect(screen.getByText('Not reached')).toBeInTheDocument();
+    expect(screen.getByTestId('svg-mock')).toBeInTheDocument();
+  });
+
   it('renders failure state text and icon when threshold is not reached', () => {
-    render(<ThresholdStatusBadge isReached={false} />);
+    render(<ThresholdStatusBadge status="red" />);
 
     expect(screen.getByText('Not reached')).toBeInTheDocument();
     expect(screen.getByTestId('svg-mock')).toBeInTheDocument();

--- a/frontend/src/__tests__/hooks/usePatientProcess.test.tsx
+++ b/frontend/src/__tests__/hooks/usePatientProcess.test.tsx
@@ -147,15 +147,19 @@ describe('usePatientProcess', () => {
     expect(result.current.chartThresholds).toEqual({
       steps: 6000,
       activeMinutes: 120,
+      activeMinutesYellow: null,
       sleepMinutes: 420,
+      sleepMinutesYellow: null,
       bpSysMax: 125,
+      bpSysYellowMax: null,
       bpDiaMax: 85,
+      bpDiaYellowMax: null,
     });
-    expect(result.current.isReachedStatus).toEqual({
-      steps: true,
-      activeMinutes: true,
-      sleepMinutes: true,
-      bloodPressure: true,
+    expect(result.current.thresholdStatus).toEqual({
+      steps: 'green',
+      activeMinutes: 'green',
+      sleepMinutes: 'green',
+      bloodPressure: 'green',
     });
     expect(result.current.chartYMax.steps).toBe(8800);
   });
@@ -202,11 +206,15 @@ describe('usePatientProcess', () => {
     expect(result.current.chartThresholds).toEqual({
       steps: null,
       activeMinutes: null,
+      activeMinutesYellow: null,
       sleepMinutes: null,
+      sleepMinutesYellow: null,
       bpSysMax: null,
+      bpSysYellowMax: null,
       bpDiaMax: null,
+      bpDiaYellowMax: null,
     });
-    expect(result.current.isReachedStatus).toEqual({
+    expect(result.current.thresholdStatus).toEqual({
       steps: null,
       activeMinutes: null,
       sleepMinutes: null,

--- a/frontend/src/components/PatientProcess/BloodPressureCard.tsx
+++ b/frontend/src/components/PatientProcess/BloodPressureCard.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { CartesianGrid, Line, LineChart, ReferenceLine, XAxis, YAxis } from 'recharts';
 import { ChartContainer, ChartTooltip, ChartTooltipContent } from '@/components/ui/chart';
 import type { ChartConfig } from '@/components/ui/chart';
-import type { DailyMetricsDatum } from '@/hooks/usePatientProcess';
+import type { DailyMetricsDatum, ThresholdStatus } from '@/hooks/usePatientProcess';
 import ThresholdStatusBadge from '@/components/PatientProcess/ThresholdStatusBadge';
 import { useTranslation } from 'react-i18next';
 
@@ -10,7 +10,7 @@ type Props = {
   title: string;
   bpSys: number | null;
   bpDia: number | null;
-  isReached: boolean | null;
+  status: ThresholdStatus;
   chartConfig: ChartConfig;
   data: DailyMetricsDatum[];
   yMax: number;
@@ -29,7 +29,7 @@ const BloodPressureCard: React.FC<Props> = ({
   title,
   bpSys,
   bpDia,
-  isReached,
+  status,
   chartConfig,
   data,
   yMax,
@@ -48,7 +48,7 @@ const BloodPressureCard: React.FC<Props> = ({
           <div className="font-bold text-lg text-zinc-800">{title}</div>
           <div className="font-medium text-sm text-zinc-500">{t('Average per day')}</div>
         </div>
-        <ThresholdStatusBadge isReached={isReached} />
+        <ThresholdStatusBadge status={status} />
       </div>
 
       <div className="flex items-end">

--- a/frontend/src/components/PatientProcess/MetricBarCard.tsx
+++ b/frontend/src/components/PatientProcess/MetricBarCard.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Bar, BarChart, CartesianGrid, ReferenceLine, XAxis, YAxis } from 'recharts';
 import { ChartContainer, ChartTooltip, ChartTooltipContent } from '@/components/ui/chart';
 import type { ChartConfig } from '@/components/ui/chart';
-import type { BarMetricKey, DailyMetricsDatum } from '@/hooks/usePatientProcess';
+import type { BarMetricKey, DailyMetricsDatum, ThresholdStatus } from '@/hooks/usePatientProcess';
 import ThresholdStatusBadge from '@/components/PatientProcess/ThresholdStatusBadge';
 import { useTranslation } from 'react-i18next';
 
@@ -13,7 +13,7 @@ type Props = {
   data: DailyMetricsDatum[];
   yMax: number;
   threshold: number | null;
-  isReached: boolean | null;
+  status: ThresholdStatus;
   chartConfig: ChartConfig;
   accentColor: string;
   thresholdLineProps: {
@@ -30,7 +30,7 @@ const MetricBarCard: React.FC<Props> = ({
   data,
   yMax,
   threshold,
-  isReached,
+  status,
   chartConfig,
   accentColor,
   thresholdLineProps,
@@ -44,7 +44,7 @@ const MetricBarCard: React.FC<Props> = ({
           <div className="font-bold text-lg text-zinc-800">{title}</div>
           <div className="font-medium text-sm text-zinc-500">{t('Average per day')}</div>
         </div>
-        <ThresholdStatusBadge isReached={isReached} />
+        <ThresholdStatusBadge status={status} />
       </div>
 
       <div className="flex items-end">

--- a/frontend/src/components/PatientProcess/ThresholdStatusBadge.tsx
+++ b/frontend/src/components/PatientProcess/ThresholdStatusBadge.tsx
@@ -2,19 +2,29 @@ import React from 'react';
 import CircleCheckFill from '@/assets/icons/circle-check-fill.svg?react';
 import CircleXFill from '@/assets/icons/circle-xmark-fill.svg?react';
 import { useTranslation } from 'react-i18next';
+import type { ThresholdStatus } from '@/hooks/usePatientProcess';
 
 type Props = {
-  isReached: boolean | null;
+  status: ThresholdStatus;
 };
 
-const ThresholdStatusBadge: React.FC<Props> = ({ isReached }) => {
+const ThresholdStatusBadge: React.FC<Props> = ({ status }) => {
   const { t } = useTranslation();
-  if (isReached === null) return null;
+  if (status === null) return null;
+
+  const color =
+    status === 'green' ? 'text-[#16A34A]' : status === 'yellow' ? 'text-[#EFA73B]' : 'text-red-600';
 
   return (
-    <div className={`flex gap-2 ${isReached ? 'text-[#16A34A]' : 'text-red-600'}`}>
-      <div className="font-bold text-lg">{isReached ? t('Reached') : t('Not reached')}</div>
-      {isReached ? <CircleCheckFill className="w-8 h-8" /> : <CircleXFill className="w-8 h-8" />}
+    <div className={`flex gap-2 ${color}`}>
+      <div className="font-bold text-lg">
+        {status === 'green' ? t('Reached') : t('Not reached')}
+      </div>
+      {status === 'green' ? (
+        <CircleCheckFill className="w-8 h-8" />
+      ) : (
+        <CircleXFill className="w-8 h-8" />
+      )}
     </div>
   );
 };

--- a/frontend/src/hooks/usePatientProcess.ts
+++ b/frontend/src/hooks/usePatientProcess.ts
@@ -64,11 +64,13 @@ export type DailyMetricsDatum = {
   bpDia: number | null;
 };
 
-export type IsReachedStatus = {
-  steps: boolean | null;
-  activeMinutes: boolean | null;
-  sleepMinutes: boolean | null;
-  bloodPressure: boolean | null;
+export type ThresholdStatus = 'green' | 'yellow' | 'red' | null;
+
+export type ThresholdStatusRecord = {
+  steps: ThresholdStatus;
+  activeMinutes: ThresholdStatus;
+  sleepMinutes: ThresholdStatus;
+  bloodPressure: ThresholdStatus;
 };
 
 type AverageMetrics = {
@@ -85,9 +87,13 @@ type AverageMetrics = {
 type ChartThresholds = {
   steps: number | null;
   activeMinutes: number | null;
+  activeMinutesYellow: number | null;
   sleepMinutes: number | null;
+  sleepMinutesYellow: number | null;
   bpSysMax: number | null;
+  bpSysYellowMax: number | null;
   bpDiaMax: number | null;
+  bpDiaYellowMax: number | null;
 };
 
 type ChartYMax = {
@@ -290,9 +296,13 @@ export function usePatientProcess() {
     return {
       steps: asNumberOrNull(thresholds?.steps_goal),
       activeMinutes: asNumberOrNull(thresholds?.active_minutes_green),
+      activeMinutesYellow: asNumberOrNull(thresholds?.active_minutes_yellow),
       sleepMinutes: asNumberOrNull(thresholds?.sleep_green_min),
+      sleepMinutesYellow: asNumberOrNull(thresholds?.sleep_yellow_min),
       bpSysMax: asNumberOrNull(thresholds?.bp_sys_green_max),
+      bpSysYellowMax: asNumberOrNull(thresholds?.bp_sys_yellow_max),
       bpDiaMax: asNumberOrNull(thresholds?.bp_dia_green_max),
+      bpDiaYellowMax: asNumberOrNull(thresholds?.bp_dia_yellow_max),
     };
   }, [thresholds]);
 
@@ -317,7 +327,9 @@ export function usePatientProcess() {
     const maxBloodPressure = Math.max(
       ...dailyMetrics.flatMap((entry) => [entry.bpSys ?? 0, entry.bpDia ?? 0]),
       chartThresholds.bpSysMax ?? 0,
+      chartThresholds.bpSysYellowMax ?? 0,
       chartThresholds.bpDiaMax ?? 0,
+      chartThresholds.bpDiaYellowMax ?? 0,
       0
     );
 
@@ -329,30 +341,54 @@ export function usePatientProcess() {
     };
   }, [dailyMetrics, chartThresholds]);
 
-  const isReachedStatus = useMemo<IsReachedStatus>(() => {
-    const isReached = (value: number | null, threshold: number | null) =>
-      value !== null && threshold !== null && value >= threshold;
+  const thresholdStatus = useMemo<ThresholdStatusRecord>(() => {
+    const minStatus = (
+      value: number | null,
+      green: number | null,
+      yellow: number | null
+    ): ThresholdStatus => {
+      if (green === null) return null;
+      if (value === null) return 'red';
+      if (value >= green) return 'green';
+      if (yellow !== null && value >= yellow) return 'yellow';
+      return 'red';
+    };
+
+    const maxStatus = (
+      value: number | null,
+      green: number | null,
+      yellow: number | null
+    ): ThresholdStatus => {
+      if (green === null) return null;
+      if (value === null) return 'red';
+      if (value <= green) return 'green';
+      if (yellow !== null && value <= yellow) return 'yellow';
+      return 'red';
+    };
+
+    const worstOf = (a: ThresholdStatus, b: ThresholdStatus): ThresholdStatus => {
+      if (a === 'red' || b === 'red') return 'red';
+      if (a === 'yellow' || b === 'yellow') return 'yellow';
+      if (a === 'green' || b === 'green') return 'green';
+      return null;
+    };
 
     return {
-      steps:
-        chartThresholds.steps !== null
-          ? isReached(averageMetrics.steps, chartThresholds.steps)
-          : null,
-      activeMinutes:
-        chartThresholds.activeMinutes !== null
-          ? isReached(averageMetrics.activeMinutes, chartThresholds.activeMinutes)
-          : null,
-      sleepMinutes:
-        chartThresholds.sleepMinutes !== null
-          ? isReached(averageMetrics.sleepMinutes, chartThresholds.sleepMinutes)
-          : null,
-      bloodPressure:
-        chartThresholds.bpSysMax !== null && chartThresholds.bpDiaMax !== null
-          ? averageMetrics.bpSys !== null &&
-            averageMetrics.bpDia !== null &&
-            averageMetrics.bpSys <= chartThresholds.bpSysMax &&
-            averageMetrics.bpDia <= chartThresholds.bpDiaMax
-          : null,
+      steps: minStatus(averageMetrics.steps, chartThresholds.steps, null),
+      activeMinutes: minStatus(
+        averageMetrics.activeMinutes,
+        chartThresholds.activeMinutes,
+        chartThresholds.activeMinutesYellow
+      ),
+      sleepMinutes: minStatus(
+        averageMetrics.sleepMinutes,
+        chartThresholds.sleepMinutes,
+        chartThresholds.sleepMinutesYellow
+      ),
+      bloodPressure: worstOf(
+        maxStatus(averageMetrics.bpSys, chartThresholds.bpSysMax, chartThresholds.bpSysYellowMax),
+        maxStatus(averageMetrics.bpDia, chartThresholds.bpDiaMax, chartThresholds.bpDiaYellowMax)
+      ),
     };
   }, [averageMetrics, chartThresholds]);
 
@@ -368,6 +404,6 @@ export function usePatientProcess() {
     averageMetrics,
     chartThresholds,
     chartYMax,
-    isReachedStatus,
+    thresholdStatus,
   };
 }

--- a/frontend/src/pages/PatientProcess.tsx
+++ b/frontend/src/pages/PatientProcess.tsx
@@ -44,7 +44,7 @@ const PatientProcess: React.FC = observer(() => {
     averageMetrics,
     chartThresholds,
     chartYMax,
-    isReachedStatus,
+    thresholdStatus,
   } = usePatientProcess();
 
   const chartConfigs = React.useMemo(
@@ -82,7 +82,7 @@ const PatientProcess: React.FC = observer(() => {
       average: averageMetrics.steps !== null ? averageMetrics.steps.toLocaleString() : '--',
       threshold: chartThresholds.steps,
       yMax: chartYMax.steps,
-      isReached: isReachedStatus.steps,
+      status: thresholdStatus.steps,
     },
     {
       metricKey: 'activeMinutes' as const,
@@ -90,7 +90,7 @@ const PatientProcess: React.FC = observer(() => {
       average: averageMetrics.activeMinutesLabel ?? '--',
       threshold: chartThresholds.activeMinutes,
       yMax: chartYMax.activeMinutes,
-      isReached: isReachedStatus.activeMinutes,
+      status: thresholdStatus.activeMinutes,
     },
     {
       metricKey: 'sleepMinutes' as const,
@@ -98,7 +98,7 @@ const PatientProcess: React.FC = observer(() => {
       average: averageMetrics.sleepMinutesLabel ?? '--',
       threshold: chartThresholds.sleepMinutes,
       yMax: chartYMax.sleepMinutes,
-      isReached: isReachedStatus.sleepMinutes,
+      status: thresholdStatus.sleepMinutes,
     },
   ];
 
@@ -187,7 +187,7 @@ const PatientProcess: React.FC = observer(() => {
                   data={dailyMetrics}
                   yMax={card.yMax}
                   threshold={card.threshold}
-                  isReached={card.isReached}
+                  status={card.status}
                   chartConfig={chartConfigs[card.metricKey]}
                   accentColor={CHART_ACCENT}
                   thresholdLineProps={THRESHOLD_LINE_PROPS}
@@ -202,7 +202,7 @@ const PatientProcess: React.FC = observer(() => {
                 title={t('Blood pressure')}
                 bpSys={averageMetrics.bpSys}
                 bpDia={averageMetrics.bpDia}
-                isReached={isReachedStatus.bloodPressure}
+                status={thresholdStatus.bloodPressure}
                 chartConfig={chartConfigs.bloodPressure}
                 data={dailyMetrics}
                 yMax={chartYMax.bloodPressure}


### PR DESCRIPTION
## Description
Adds a yellow state to the threshold status badge on the Patient Process page. Metrics that fall between the yellow and green thresholds now show "Not reached" in yellow instead of red.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Related Issue
Cannot create Features in Notion anymore :(

## Changes Made
- ThresholdStatus is now 'green' | 'yellow' | 'red' | null (was boolean | null)
- Yellow threshold values from the API are now used in the status calculation
- ThresholdStatusBadge renders yellow text for the 'yellow' state
 
## Testing
### How to test
Open the Patient Process page with Fitbit data where averages fall between yellow and green thresholds.
The badge should appear yellow.

### Test Cases
- ThresholdStatusBadge renders correctly for all four states
- usePatientProcess returns correct tri-state values for all metrics

## Checklist
- [x] Code follows style guidelines
- [x] Tests added/updated
- [x] Documentation updated (if applicable)
- [x] No new warnings generated
