### PR TITLE
Refactor patient resolution logic to support multiple identifier type…

### DIFF
--- a/backend/core/views/patient_views.py
+++ b/backend/core/views/patient_views.py
@@ -999,7 +999,7 @@ def get_patient_plan(request, patient_id):
     try:
         patient = _resolve_patient_flexible(patient_id)
         if not patient:
-            logger.warning("[get_patient_plan] Patient not found: %s", patient_id)
+            logger.warning("[get_patient_plan] Patient not found")
             return JsonResponse({"error": "Patient not found"}, status=404)
         rehab_plan = RehabilitationPlan.objects(patientId=patient).first()
 
@@ -1083,12 +1083,7 @@ def get_patient_plan(request, patient_id):
         return JsonResponse(out, safe=False, status=200)
 
     except Exception as e:
-        logger.error(
-            "[get_patient_plan] Error for patient %s: %s",
-            patient_id,
-            str(e),
-            exc_info=True,
-        )
+        logger.error("[get_patient_plan] Error while resolving/serializing patient plan: %s", str(e), exc_info=True)
         return JsonResponse({"error": "Internal Server Error", "details": str(e)}, status=500)
 
 
@@ -1777,7 +1772,7 @@ def add_intervention_to_patient(request):
             except Exception:
                 return None
         if timezone.is_naive(dtx):
-            dtx = make_aware(dtx)
+            dtx = timezone.make_aware(dtx, timezone.get_current_timezone())
         return dtx
 
     def lang_fallback_chain(user_lang: str):

--- a/backend/core/views/patient_views.py
+++ b/backend/core/views/patient_views.py
@@ -49,7 +49,6 @@ from utils.utils import (
     generate_custom_id,
     generate_repeat_dates,
     get_labels,
-    resolve_patient,
     sanitize_text,
     serialize_datetime,
     transcribe_file,
@@ -998,10 +997,10 @@ def get_patient_plan(request, patient_id):
         return base_intervention
 
     try:
-        try:
-            patient = Patient.objects.get(userId=ObjectId(patient_id))
-        except Patient.DoesNotExist:
-            patient = Patient.objects.get(id=ObjectId(patient_id))
+        patient = _resolve_patient_flexible(patient_id)
+        if not patient:
+            logger.warning("[get_patient_plan] Patient not found: %s", patient_id)
+            return JsonResponse({"error": "Patient not found"}, status=404)
         rehab_plan = RehabilitationPlan.objects(patientId=patient).first()
 
         if not rehab_plan:
@@ -1083,9 +1082,6 @@ def get_patient_plan(request, patient_id):
 
         return JsonResponse(out, safe=False, status=200)
 
-    except Patient.DoesNotExist:
-        logger.warning("[get_patient_plan] Patient not found: %s", patient_id)
-        return JsonResponse({"error": "Patient not found"}, status=404)
     except Exception as e:
         logger.error(
             "[get_patient_plan] Error for patient %s: %s",
@@ -1679,6 +1675,41 @@ def _merge_dates(existing, incoming, *, return_naive_for_storage=True):
     return merged, added
 
 
+def _resolve_patient_flexible(identifier: str):
+    """
+    Resolve a patient from any commonly-used identifier:
+    - Patient._id (ObjectId string)
+    - User._id (ObjectId string)
+    - User.username / User.email
+    - Patient.patient_code (e.g. "1234", "P15")
+    """
+    raw = (identifier or "").strip()
+    if not raw:
+        return None
+
+    oid = _coerce_object_id(raw)
+    if oid:
+        patient = Patient.objects(id=oid).first()
+        if patient:
+            return patient
+        patient = Patient.objects(userId=oid).first()
+        if patient:
+            return patient
+        user = User.objects(id=oid).first()
+        if user:
+            patient = Patient.objects(userId=user).first()
+            if patient:
+                return patient
+
+    user = User.objects(username=raw).first() or User.objects(email=raw).first()
+    if user:
+        patient = Patient.objects(userId=user).first()
+        if patient:
+            return patient
+
+    return Patient.objects(patient_code=raw).first()
+
+
 # ---------------------------------------------------------------------
 # endpoint
 # ---------------------------------------------------------------------
@@ -1818,34 +1849,18 @@ def add_intervention_to_patient(request):
             status=404,
         )
 
-    # ---- Resolve patient (pk first, then userId) ----
-    patient_oid = _coerce_object_id(patientId)
-    if not patient_oid:
+    # ---- Resolve patient (supports ObjectId, username/email, patient_code) ----
+    patient = _resolve_patient_flexible(str(patientId))
+    if not patient:
         return JsonResponse(
             {
                 "success": False,
                 "message": "Patient not found",
-                "field_errors": {"patientId": ["Invalid patient id."]},
+                "field_errors": {"patientId": ["Patient does not exist."]},
                 "non_field_errors": [],
             },
             status=404,
         )
-
-    try:
-        patient = Patient.objects.get(pk=patient_oid)
-    except Patient.DoesNotExist:
-        try:
-            patient = Patient.objects.get(userId=patient_oid)
-        except Patient.DoesNotExist:
-            return JsonResponse(
-                {
-                    "success": False,
-                    "message": "Patient not found",
-                    "field_errors": {"patientId": ["Patient does not exist."]},
-                    "non_field_errors": [],
-                },
-                status=404,
-            )
 
     # ---- Load/create plan ----
     plan = RehabilitationPlan.objects(patientId=patient).first()
@@ -2474,7 +2489,7 @@ def get_patient_plan_for_therapist(request, patient_id):
         )
 
     try:
-        patient = resolve_patient(patient_id)
+        patient = _resolve_patient_flexible(patient_id)
         if not patient:
             logger.warning(
                 "[get_patient_plan_for_therapist] Could not resolve patient: %s",

--- a/backend/tests/patient_views/test_patient_views.py
+++ b/backend/tests/patient_views/test_patient_views.py
@@ -610,6 +610,87 @@ def test_add_intervention_to_patient_success(mongo_mock):
     assert "message" in data
 
 
+@pytest.mark.django_db
+def test_add_intervention_to_patient_accepts_patient_code(mongo_mock):
+    """
+    Regression: patientId in add-to-patient may be sent as patient_code (e.g. "1234").
+    The assignment must still be created and visible in the patient's plan.
+    """
+    therapist_user = User(
+        username="therapist-code",
+        email="therapist-code@example.com",
+        phone="123",
+        createdAt=datetime.now(),
+        isActive=True,
+    ).save()
+    therapist = Therapist(
+        userId=therapist_user,
+        name="Doe",
+        first_name="Jane",
+        specializations=["Cardiology"],
+        clinics=["Inselspital"],
+    ).save()
+
+    patient_user = User(
+        username="p15",
+        email="p15@example.com",
+        phone="456",
+        createdAt=datetime.now(),
+        isActive=True,
+    ).save()
+    patient = Patient(
+        userId=patient_user,
+        patient_code="1234",
+        therapist=therapist,
+        access_word="pass",
+        reha_end_date=datetime.now() + timedelta(days=30),
+    ).save()
+
+    intervention = Intervention(
+        external_id="test_ext_code_001",
+        language="en",
+        title="Breathing",
+        description="Breathing exercise",
+        content_type="Video",
+        keywords=["Breathing"],
+        patient_types=[],
+        duration=15,
+        media=[],
+    ).save()
+
+    payload = {
+        "therapistId": str(therapist.userId.id),
+        "patientId": "1234",
+        "interventions": [
+            {
+                "interval": 1,
+                "interventionId": str(intervention.id),
+                "unit": "day",
+                "startDate": datetime.now().isoformat(),
+                "selectedDays": [],
+                "end": {"type": "count", "count": 1, "date": None},
+                "require_video_feedback": False,
+                "notes": "",
+            }
+        ],
+    }
+
+    resp = client.post(
+        "/api/interventions/add-to-patient/",
+        data=json.dumps(payload),
+        content_type="application/json",
+        HTTP_AUTHORIZATION="Bearer test",
+    )
+
+    assert resp.status_code in (200, 201), resp.content.decode()
+    assert resp.json().get("success") is True
+
+    plan = RehabilitationPlan.objects(patientId=patient).first()
+    assert plan is not None
+    assert len(plan.interventions or []) == 1
+    assert str(plan.interventions[0].interventionId.id) == str(intervention.id)
+
+
 def test_get_patient_plan_no_plan_returns_empty_list(mongo_mock):
     """
     If patient exists but has no RehabilitationPlan, endpoint returns [] with message.
@@ -1379,6 +1460,45 @@ def test_get_patient_plan_by_patient_id(mongo_mock):
     # Use Patient._id instead of User._id
     resp = client.get(
         f"/api/patients/rehabilitation-plan/patient/{patient.id}/",
+        HTTP_AUTHORIZATION="Bearer test",
+    )
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert isinstance(data, list)
+    assert len(data) == 1
+    assert data[0]["intervention_id"] == str(intervention.id)
+
+
+def test_get_patient_plan_by_patient_code(mongo_mock):
+    """
+    Regression: patient endpoint must also accept patient_code identifiers
+    used in older UI flows (e.g. "1234").
+    """
+    patient, _, intervention, _ = setup_patient_with_plan()
+    patient.patient_code = "1234"
+    patient.save()
+
+    resp = client.get(
+        "/api/patients/rehabilitation-plan/patient/1234/",
+        HTTP_AUTHORIZATION="Bearer test",
+    )
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert isinstance(data, list)
+    assert len(data) == 1
+    assert data[0]["intervention_id"] == str(intervention.id)
+
+
+def test_get_patient_plan_by_username(mongo_mock):
+    """
+    Regression: patient endpoint must resolve via patient user's username too.
+    """
+    patient, _, intervention, _ = setup_patient_with_plan()
+
+    resp = client.get(
+        f"/api/patients/rehabilitation-plan/patient/{patient.userId.username}/",
         HTTP_AUTHORIZATION="Bearer test",
     )
 

--- a/backend/tests/patient_views/test_patient_views.py
+++ b/backend/tests/patient_views/test_patient_views.py
@@ -747,16 +747,16 @@ def test_get_patient_plan_patient_not_found_404(mongo_mock):
     assert "Patient not found" in resp.content.decode()
 
 
-def test_get_patient_plan_invalid_patient_id_500_or_400(mongo_mock):
+def test_get_patient_plan_invalid_patient_id_returns_not_found(mongo_mock):
     """
-    If patient_id cannot be ObjectId, current code will raise and hit 500.
-    (If you later harden it, you can change expected to 400.)
+    Non-ObjectId identifiers are valid inputs in this endpoint (e.g. patient_code),
+    so an unknown string identifier should resolve to a clean 404.
     """
     resp = client.get(
         "/api/patients/rehabilitation-plan/patient/not-an-objectid/",
         HTTP_AUTHORIZATION="Bearer test",
     )
-    assert resp.status_code in (400, 500)
+    assert resp.status_code == 404
 
 
 def test_get_patient_plan_returns_interventions_with_meta_and_flat_fields(mongo_mock):


### PR DESCRIPTION
# Description

This PR fixes a patient identifier resolution mismatch that caused assigned interventions to not appear in the patient-facing content view (reported for patient `p15` / `1234`).

### What changed
- Added robust patient resolution logic in backend patient views to accept:
  - `Patient._id`
  - `User._id`
  - `User.username`
  - `User.email`
  - `Patient.patient_code` (e.g. `1234`)
- Updated assignment and plan retrieval flows to use consistent patient resolution:
  - `POST /api/interventions/add-to-patient/`
  - `GET /api/patients/rehabilitation-plan/patient/<patient_id>/`
  - `GET /api/patients/rehabilitation-plan/therapist/<patient_id>/`
- Added regression tests for:
  - assigning by `patient_code`
  - fetching patient plan by `patient_code`
  - fetching patient plan by username

### Motivation / context
Therapist-side assignment and patient-side retrieval were resolving patient IDs differently. In some flows, assignment used one identifier shape while patient view queried with another, resulting in an empty patient content view despite valid assignments.

### Dependencies
No new dependencies.

## Related Issue
[Assigned content not visible in patient view (p15/1234)](IssueLink)

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Documentation update
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] A new research paper code implementation
- [ ] Other (Specify)

## Tests

Added/updated backend regression tests in:
- `backend/tests/patient_views/test_patient_views.py`

### Repro / verification
1. As therapist, open patient `p15` (`1234`).
2. Assign one or more interventions.
3. Open patient view.
4. Confirm assigned content is now visible.

### Test commands
```bash
cd backend
pytest tests/patient_views/test_patient_views.py -q
# or full suite
pytest -q
```

**Test Configuration**:
- Backend: Django + MongoEngine (mongomock in test suite)
- Branch: `146-bug-assigned-content-does-not-appear-in-patient-view`

## Checklist

- [ ] I have read the [guidelines for contributing](https://github.com/fastmachinelearning/hls4ml/blob/main/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have installed and run `pre-commit` on the files I edited or added.
- [x] I have added tests that prove my fix is effective or that my feature works.
