### PR TITLE
150 feature adjust warning chips for ongoing studies hide health score clarify feedback alert thresholds

### DIFF
--- a/FRONTEND_E2E_TEST_DOCUMENTATION.md
+++ b/FRONTEND_E2E_TEST_DOCUMENTATION.md
@@ -19,6 +19,7 @@ frontend/
     home-login-therapist.spec.ts
     home-register-therapist.spec.ts
     patient-page.spec.ts
+    therapist-feedback-chips.spec.ts
     therapist-interventions-templates.spec.ts
     TESTING.md
   playwright.config.ts
@@ -105,6 +106,18 @@ All tests skip gracefully when `E2E_THERAPIST_LOGIN` / `E2E_THERAPIST_PASSWORD` 
 - `page.once('dialog', d => d.accept())` — handle `window.confirm` for delete
 - `test.skip(!value, 'reason')` — conditional skipping per-test when no seeded data
 
+### `therapist-feedback-chips.spec.ts`
+
+Validates therapist patient-list feedback traffic lights on `/therapist` using controlled API fixtures.
+
+- Uses seeded therapist login helper (`loginAsTherapist`) to pass auth/2FA flow.
+- Intercepts `GET /api/therapists/<id>/patients` and returns deterministic patient rows.
+- Verifies:
+  - Recent + high average intervention feedback => `Feedback good`
+  - Downward trend (`trend_lower=true`) => `Feedback bad`
+  - Feedback tooltip includes average-score text for recent answered days
+  - Health chip is hidden for ongoing (active) patients
+
 ---
 
 ## Prerequisites
@@ -151,6 +164,17 @@ E2E_THERAPIST_PASSWORD=<therapist-password> \
 npm run test:e2e -- e2e/home-login-therapist.spec.ts'
 ```
 
+Run therapist feedback-chip regression:
+
+```bash
+docker exec react sh -lc 'cd /app && \
+E2E_API_URL=http://django:8000/api \
+E2E_THERAPIST_LOGIN=<therapist-login> \
+E2E_THERAPIST_PASSWORD=<therapist-password> \
+E2E_EMAIL_DIR=<shared-email-dir> \
+npm run test:e2e -- e2e/therapist-feedback-chips.spec.ts'
+```
+
 ### Direct host run (without Docker)
 
 From `frontend/`:
@@ -174,6 +198,7 @@ E2E_API_URL=http://127.0.0.1:8001/api npm run test:e2e
 | `E2E_ADMIN_PASSWORD` | Redirect tests only | Seeded admin password |
 | `E2E_THERAPIST_LOGIN` | Therapist login + templates tests | Seeded therapist login identifier |
 | `E2E_THERAPIST_PASSWORD` | Therapist login + templates tests | Seeded therapist password |
+| `E2E_EMAIL_DIR` | Therapist 2FA-based E2E tests | File-based email directory shared with backend for OTP retrieval |
 
 ## CI Integration
 
@@ -188,6 +213,7 @@ The `frontend-e2e` job:
   - `e2e/patient-interventions-page.spec.ts`
 - Runs therapist 2FA E2E test when `E2E_THERAPIST_LOGIN` and `E2E_THERAPIST_PASSWORD` are configured
 - Runs named-template E2E tests (`e2e/therapist-interventions-templates.spec.ts`) when `E2E_THERAPIST_LOGIN` and `E2E_THERAPIST_PASSWORD` are configured
+- Runs therapist feedback-chip E2E test (`e2e/therapist-feedback-chips.spec.ts`) when therapist creds are configured
 
 Required GitHub secrets for seeded redirect tests:
 - `E2E_PATIENT_LOGIN`

--- a/backend/core/views/therapist_views.py
+++ b/backend/core/views/therapist_views.py
@@ -244,6 +244,88 @@ def _sum_points_for_day(rating_docs, question_ids_set):
     return total
 
 
+def _intervention_feedback_summary(patient, recent_days: int = 3):
+    """
+    Summarize intervention feedback for therapist traffic-light logic.
+
+    Uses only numeric answer keys from PatientInterventionLogs.feedback.
+    Returns recency, recent average score (last N answered days), and trend
+    versus the previous N answered days.
+    """
+
+    now = timezone.now()
+
+    def _aware(dt):
+        if not isinstance(dt, datetime):
+            return None
+        if timezone.is_naive(dt):
+            try:
+                return timezone.make_aware(dt, timezone.get_current_timezone())
+            except Exception:
+                return timezone.make_aware(dt, timezone.utc)
+        return dt
+
+    day_to_values = {}
+    latest_dt = None
+
+    logs = (
+        PatientInterventionLogs.objects(userId=patient, feedback__exists=True, feedback__ne=[])
+        .only("date", "updatedAt", "feedback")
+        .order_by("-date")
+    )
+    for lg in logs:
+        dt = _aware(getattr(lg, "date", None) or getattr(lg, "updatedAt", None))
+        if not dt:
+            continue
+
+        numeric_values = []
+        for fe in getattr(lg, "feedback", None) or []:
+            for ak in getattr(fe, "answerKey", None) or []:
+                key = ak if isinstance(ak, str) else getattr(ak, "key", None)
+                try:
+                    v = int(str(key).strip())
+                except Exception:
+                    continue
+                if v > 0:
+                    numeric_values.append(v)
+
+        if not numeric_values:
+            continue
+
+        if latest_dt is None or dt > latest_dt:
+            latest_dt = dt
+
+        dkey = dt.date()
+        day_to_values.setdefault(dkey, []).extend(numeric_values)
+
+    day_scores = sorted(
+        [(d, mean(vals)) for d, vals in day_to_values.items() if vals],
+        key=lambda x: x[0],
+        reverse=True,
+    )
+
+    recent_scores = [s for _, s in day_scores[:recent_days]]
+    prev_scores = [s for _, s in day_scores[recent_days : recent_days * 2]]
+
+    recent_avg = round(mean(recent_scores), 2) if recent_scores else None
+    prev_avg = round(mean(prev_scores), 2) if prev_scores else None
+    trend_delta = round(recent_avg - prev_avg, 2) if recent_avg is not None and prev_avg is not None else None
+    trend_lower = trend_delta is not None and trend_delta < 0
+
+    days_since_last = (now.date() - latest_dt.date()).days if latest_dt else None
+
+    return {
+        "last_answered_at": latest_dt.isoformat() if latest_dt else None,
+        "days_since_last": days_since_last,
+        "answered_days_total": len(day_scores),
+        "recent_days_count": len(recent_scores),
+        "recent_avg_score": recent_avg,
+        "previous_avg_score": prev_avg,
+        "trend_delta": trend_delta,
+        "trend_lower": trend_lower,
+    }
+
+
 def _feedback_computing(patient):
     """
     Build a questionnaires_summary for a patient and return (summary, last_feedback_at_dt).
@@ -488,6 +570,7 @@ def list_therapist_patients(request, therapist_id):
             try:
                 summary, questionnaire_last_fb_dt = _feedback_computing(patient)
                 last_fb_dt = _latest_feedback_at(patient, questionnaire_last_fb_dt)
+                intervention_feedback = _intervention_feedback_summary(patient)
             except Exception as e:
                 logger.error(
                     "[list_therapist_patients] feedback summary error %s: %s",
@@ -495,6 +578,16 @@ def list_therapist_patients(request, therapist_id):
                     str(e),
                 )
                 summary, last_fb_dt = [], None
+                intervention_feedback = {
+                    "last_answered_at": None,
+                    "days_since_last": None,
+                    "answered_days_total": 0,
+                    "recent_days_count": 0,
+                    "recent_avg_score": None,
+                    "previous_avg_score": None,
+                    "trend_delta": None,
+                    "trend_lower": False,
+                }
 
             steps_vals, activity_vals, sleep_mins, wear_vals = [], [], [], []
             bp_sys_vals, bp_dia_vals = [], []
@@ -562,6 +655,7 @@ def list_therapist_patients(request, therapist_id):
                     "last_online": (last_online_dt.isoformat() if last_online_dt else None),
                     "last_feedback_at": last_fb_dt.isoformat() if last_fb_dt else None,
                     "questionnaires": summary,
+                    "intervention_feedback": intervention_feedback,
                     "feedback_low": any(it.get("low_score") for it in summary),
                     "thresholds": _thresholds_to_dict(getattr(patient, "thresholds", None)),
                     "biomarker": biomarker,

--- a/backend/tests/therapist_views/TESTING.md
+++ b/backend/tests/therapist_views/TESTING.md
@@ -12,10 +12,10 @@ endpoints in `core/views/therapist_views.py`.
 |---|---|---|---|
 | `/api/therapists/<therapist_id>/patients/` | GET | `list_therapist_patients` | 14 |
 | `/api/analytics/log` | POST | `create_log` | 4 |
-| Internal helpers (unit-level) | N/A | `_avg`, `_day_key`, `_sum_points_for_day`, `_adherence`, `_feedback_computing` | 9 |
+| Internal helpers (unit-level) | N/A | `_avg`, `_day_key`, `_sum_points_for_day`, `_adherence`, `_feedback_computing`, `_intervention_feedback_summary` | 9 |
 | Project-based access filter (unit-level) | N/A | `list_therapist_patients` queryset | 4 |
 
-**Total: 31 tests** (previously 23; 4 new project-access isolation tests + 4 existing `list_therapist_patients` tests renamed)
+**Total: 35 tests**
 
 ---
 
@@ -63,7 +63,21 @@ Returns the therapist's active patients as a flat list used by therapist patient
 | `biomarker` | `{ sleep_avg_h, activity_min, steps_avg, wear_time_avg_min, wear_time_days_since }` (7-day averages) |
 | `adherence_rate`, `adherence_total` | Adherence percentages |
 | `questionnaires` | Questionnaire summary entries |
+| `intervention_feedback` | Intervention-feedback summary: recency, recent average score, and trend |
 | `feedback_low` | `true` if any questionnaire is flagged low-score |
+
+**`intervention_feedback` fields:**
+
+| Field | Meaning |
+|---|---|
+| `last_answered_at` | Latest intervention feedback timestamp with numeric score |
+| `days_since_last` | Days since latest scored intervention feedback |
+| `answered_days_total` | Number of calendar days with scored intervention feedback |
+| `recent_days_count` | Number of answered days in the recent window |
+| `recent_avg_score` | Mean score across recent answered days |
+| `previous_avg_score` | Mean score across previous answered-day window |
+| `trend_delta` | `recent_avg_score - previous_avg_score` |
+| `trend_lower` | `true` if `trend_delta < 0` |
 
 **Biomarker fields detail:**
 

--- a/backend/tests/therapist_views/test_therapist_views.py
+++ b/backend/tests/therapist_views/test_therapist_views.py
@@ -826,7 +826,7 @@ def test_list_therapist_patients_exposes_thresholds_and_non_questionnaire_feedba
         questionKey=f"fb-{ObjectId()}",
         translations=[Translation(language="en", text="How did it go?")],
         possibleAnswers=[],
-        answer_type="text",
+        answer_type="select",
     ).save()
     plan = RehabilitationPlan(
         patientId=patient,
@@ -841,12 +841,28 @@ def test_list_therapist_patients_exposes_thresholds_and_non_questionnaire_feedba
         userId=patient,
         interventionId=intervention,
         rehabilitationPlanId=plan,
-        date=datetime.now() - timedelta(hours=12),
+        date=datetime.now() - timedelta(days=1),
         status=["completed"],
         feedback=[
             FeedbackEntry(
                 questionId=feedback_question,
-                answerKey=[AnswerOption(key="text", translations=[Translation(language="en", text="ok")])],
+                answerKey=[
+                    AnswerOption(key="4", translations=[Translation(language="en", text="4")]),
+                    AnswerOption(key="5", translations=[Translation(language="en", text="5")]),
+                ],
+            )
+        ],
+    ).save()
+    PatientInterventionLogs(
+        userId=patient,
+        interventionId=intervention,
+        rehabilitationPlanId=plan,
+        date=datetime.now() - timedelta(days=3),
+        status=["completed"],
+        feedback=[
+            FeedbackEntry(
+                questionId=feedback_question,
+                answerKey=[AnswerOption(key="2", translations=[Translation(language="en", text="2")])],
             )
         ],
     ).save()
@@ -874,6 +890,10 @@ def test_list_therapist_patients_exposes_thresholds_and_non_questionnaire_feedba
     assert row["biomarker"]["bp_sys_avg"] == pytest.approx(133.0, rel=1e-3)
     assert row["biomarker"]["bp_dia_avg"] == pytest.approx(88.0, rel=1e-3)
     assert row["last_feedback_at"] is not None
+    assert "intervention_feedback" in row
+    assert row["intervention_feedback"]["answered_days_total"] >= 2
+    assert row["intervention_feedback"]["recent_avg_score"] is not None
+    assert row["intervention_feedback"]["last_answered_at"] is not None
 
 
 # ---------------------------------------------------------------------------

--- a/docs/09-API_DOCUMENTATION.md
+++ b/docs/09-API_DOCUMENTATION.md
@@ -634,6 +634,16 @@ JWT required. Returns patients the therapist is allowed to see, filtered by both
     "last_online": "2025-03-01T10:00:00Z",
     "last_feedback_at": "2025-02-28T10:00:00Z",
     "questionnaires": [],
+    "intervention_feedback": {
+      "last_answered_at": "2025-03-01T08:00:00Z",
+      "days_since_last": 1,
+      "answered_days_total": 4,
+      "recent_days_count": 3,
+      "recent_avg_score": 3.67,
+      "previous_avg_score": 4.1,
+      "trend_delta": -0.43,
+      "trend_lower": true
+    },
     "feedback_low": false,
     "biomarker": {
       "sleep_avg_h": 7.2,
@@ -645,6 +655,12 @@ JWT required. Returns patients the therapist is allowed to see, filtered by both
   }
 ]
 ```
+
+**Feedback summary fields:**
+- `intervention_feedback` is computed from `PatientInterventionLogs.feedback` numeric answer keys (`>0`) grouped by answered day.
+- `recent_avg_score` uses the most recent answered days (currently window size `3`).
+- `trend_delta = recent_avg_score - previous_avg_score`; `trend_lower` is `true` when this delta is negative.
+- `feedback_low` remains available as a questionnaire-derived compatibility flag (`questionnaires[].low_score`), but therapist traffic-light UI logic now prioritizes `intervention_feedback`.
 
 **Errors:** 400 invalid therapist ID · 404 therapist not found · 500
 

--- a/frontend/e2e/TESTING.md
+++ b/frontend/e2e/TESTING.md
@@ -23,6 +23,7 @@ Current scope starts with the home/login journey.
 | `spurious-logout.spec.ts`                           | Spurious logout regression: concurrent 401 refresh-token race, stale `expiresAt` on reload, corrupted `expiresAt`, multi-tab logout sync. Requires `E2E_THERAPIST_LOGIN` / `E2E_THERAPIST_PASSWORD`.                                                                                                                                                          |
 | `therapist-rehabtable-questionnaires.spec.ts`       | Therapist RehabTable questionnaire tab: endpoint fetches, schedule modal open, questionnaire-content visibility, and answered-results rendering for assigned questionnaires. Requires `E2E_THERAPIST_LOGIN` / `E2E_THERAPIST_PASSWORD` / `E2E_PATIENT_ID`.                                                                                                    |
 | `therapist-health-export-questionnaire-csv.spec.ts` | Therapist Health page export regression: CSV questionnaire section includes question text, multi-answer keys/texts, comments, and media URLs. Requires `E2E_THERAPIST_LOGIN` / `E2E_THERAPIST_PASSWORD` / `E2E_PATIENT_ID`.                                                                                                                                   |
+| `therapist-feedback-chips.spec.ts`                  | Therapist patient-list feedback chip logic: uses mocked `/api/therapists/<id>/patients` response to verify intervention-feedback-based chip level and tooltip text, and that Health chip remains hidden for ongoing patients. Requires seeded therapist login.                                                                                                |
 | `patient-health-questionnaire-ui.spec.ts`           | Patient UI questionnaire flow: therapist assigns questionnaire (API setup), patient logs in, answers popup questions, and submits to `/patients/feedback/questionaire/`. Requires seeded therapist + patient credentials.                                                                                                                                     |
 
 ---
@@ -101,6 +102,11 @@ Current scope starts with the home/login journey.
   - CSV export flow works from `/health` page
   - Questionnaire CSV columns include question key/text, all answer keys/texts, comment, and media URLs
   - Multi-answer values are serialized as `value1 | value2`
+- Therapist feedback chips (`therapist-feedback-chips.spec.ts`, seeded therapist required):
+  - Intercepts `GET /api/therapists/<id>/patients` with controlled fixtures
+  - Verifies `Feedback good` for recent/high-average intervention feedback and tooltip average text
+  - Verifies `Feedback bad` when trend is lower
+  - Verifies Health chip is hidden for ongoing (active) patient rows
 - Patient questionnaire UI submission (`patient-health-questionnaire-ui.spec.ts`, seeded therapist + patient required):
   - Setup assigns a due Healthstatus questionnaire for the patient
   - Patient login opens the questionnaire popup
@@ -153,6 +159,7 @@ npx playwright install --with-deps chromium
 - `E2E_ADMIN_PASSWORD`: seeded admin password.
 - `E2E_THERAPIST_LOGIN`: seeded therapist login identifier (email).
 - `E2E_THERAPIST_PASSWORD`: seeded therapist password.
+- `E2E_EMAIL_DIR`: directory used by Django file-based email backend so Playwright can read therapist 2FA codes.
 
 Example:
 
@@ -227,6 +234,16 @@ E2E_THERAPIST_LOGIN=<seeded-therapist-email> \
 E2E_THERAPIST_PASSWORD=<seeded-therapist-password> \
 E2E_PATIENT_ID=<patient-object-id> \
 npm run test:e2e -- e2e/therapist-rehabtable-questionnaires.spec.ts e2e/therapist-health-export-questionnaire-csv.spec.ts
+```
+
+Therapist feedback-chip regression (requires seeded therapist):
+
+```bash
+E2E_API_URL=http://localhost:8001/api \
+E2E_THERAPIST_LOGIN=<seeded-therapist-email> \
+E2E_THERAPIST_PASSWORD=<seeded-therapist-password> \
+E2E_EMAIL_DIR=<shared-email-dir-for-2fa> \
+npm run test:e2e -- e2e/therapist-feedback-chips.spec.ts
 ```
 
 Patient questionnaire popup submission (requires seeded therapist + patient):

--- a/frontend/e2e/therapist-feedback-chips.spec.ts
+++ b/frontend/e2e/therapist-feedback-chips.spec.ts
@@ -1,0 +1,152 @@
+import { expect, test, type Page } from '@playwright/test';
+
+import { loginAsTherapist } from './helpers/auth';
+
+type TherapistPatientRow = {
+  _id: string;
+  username: string;
+  patient_code: string;
+  first_name: string;
+  name: string;
+  sex: string;
+  diagnosis: string[];
+  age: string;
+  created_at: string;
+  last_online: string | null;
+  last_feedback_at: string | null;
+  questionnaires: unknown[];
+  feedback_low: boolean;
+  thresholds: Record<string, unknown>;
+  biomarker: Record<string, unknown>;
+  adherence_rate: number | null;
+  adherence_total: number | null;
+  intervention_feedback: {
+    last_answered_at: string | null;
+    days_since_last: number | null;
+    answered_days_total: number;
+    recent_days_count: number;
+    recent_avg_score: number | null;
+    previous_avg_score: number | null;
+    trend_delta: number | null;
+    trend_lower: boolean;
+  };
+};
+
+function skipUnlessSeeded() {
+  test.skip(
+    !process.env.E2E_THERAPIST_LOGIN || !process.env.E2E_THERAPIST_PASSWORD,
+    'Missing seeded therapist credentials for E2E therapist tests'
+  );
+}
+
+async function mockTherapistPatients(page: Page, rows: TherapistPatientRow[]) {
+  await page.route('**/api/therapists/*/patients*', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(rows),
+    });
+  });
+}
+
+function basePatient(overrides: Partial<TherapistPatientRow>): TherapistPatientRow {
+  const nowIso = new Date().toISOString();
+  return {
+    _id: 'p-e2e-feedback',
+    username: 'e2e-user',
+    patient_code: 'P-E2E',
+    first_name: 'E2E',
+    name: 'Patient',
+    sex: 'Male',
+    diagnosis: ['Stroke'],
+    age: '1990-01-01',
+    created_at: nowIso,
+    last_online: null,
+    last_feedback_at: nowIso,
+    questionnaires: [],
+    feedback_low: false,
+    thresholds: {},
+    biomarker: {},
+    adherence_rate: null,
+    adherence_total: null,
+    intervention_feedback: {
+      last_answered_at: nowIso,
+      days_since_last: 1,
+      answered_days_total: 3,
+      recent_days_count: 3,
+      recent_avg_score: 4.0,
+      previous_avg_score: 3.5,
+      trend_delta: 0.5,
+      trend_lower: false,
+    },
+    ...overrides,
+  };
+}
+
+test.describe('Therapist feedback chips', () => {
+  test.beforeEach(async ({ page }) => {
+    skipUnlessSeeded();
+    await loginAsTherapist(page);
+  });
+
+  test('shows good feedback chip and tooltip for recent high average intervention feedback', async ({
+    page,
+  }) => {
+    await mockTherapistPatients(page, [
+      basePatient({
+        _id: 'p-feedback-good',
+        first_name: 'Feedback',
+        name: 'Good',
+        intervention_feedback: {
+          last_answered_at: new Date(Date.now() - 1 * 24 * 60 * 60 * 1000).toISOString(),
+          days_since_last: 1,
+          answered_days_total: 4,
+          recent_days_count: 3,
+          recent_avg_score: 4.0,
+          previous_avg_score: 3.5,
+          trend_delta: 0.5,
+          trend_lower: false,
+        },
+      }),
+    ]);
+
+    await page.goto('/therapist');
+    const row = page.locator('tr', { hasText: 'Feedback Good' });
+    await expect(row).toBeVisible();
+
+    const chip = row.getByLabel('Feedback good');
+    await expect(chip).toBeVisible();
+    await chip.hover();
+
+    await expect(page.getByText(/Avg score \(last 3 answered days\): 4\.00/i)).toBeVisible();
+  });
+
+  test('shows bad feedback chip when trend is lower and hides health chip for ongoing patient', async ({
+    page,
+  }) => {
+    await mockTherapistPatients(page, [
+      basePatient({
+        _id: 'p-feedback-bad',
+        first_name: 'Trend',
+        name: 'Down',
+        intervention_feedback: {
+          last_answered_at: new Date(Date.now() - 2 * 24 * 60 * 60 * 1000).toISOString(),
+          days_since_last: 2,
+          answered_days_total: 6,
+          recent_days_count: 3,
+          recent_avg_score: 2.5,
+          previous_avg_score: 4.0,
+          trend_delta: -1.5,
+          trend_lower: true,
+        },
+      }),
+    ]);
+
+    await page.goto('/therapist');
+    const row = page.locator('tr', { hasText: 'Trend Down' });
+    await expect(row).toBeVisible();
+
+    await expect(row.getByLabel('Feedback bad')).toBeVisible();
+    await expect(row.getByLabel(/Health/i)).toHaveCount(0);
+  });
+});

--- a/frontend/src/__tests__/pages/Therapist.test.tsx
+++ b/frontend/src/__tests__/pages/Therapist.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-require-imports, react/display-name, @typescript-eslint/no-explicit-any */
 import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import Therapist from '@/pages/Therapist';
 import { MemoryRouter } from 'react-router-dom';
@@ -377,6 +378,7 @@ describe('Therapist traffic lights', () => {
       name: 'Patient',
       diagnosis: ['Stroke'],
       duration: 30,
+      rehab_status: 'completed',
       biomarker: {
         sleep_avg_h: 7.5,
         steps_avg: 7000,
@@ -396,6 +398,32 @@ describe('Therapist traffic lights', () => {
     });
 
     expect(screen.queryByLabelText('Health good')).not.toBeInTheDocument();
+  });
+
+  test('hides Health badge for ongoing studies (active patients)', async () => {
+    renderWithPatient({
+      _id: 'ongoing-patient',
+      therapist: 'T',
+      created_at: '2026-01-01T00:00:00',
+      username: 'ongoinguser',
+      age: '1990-01-01',
+      sex: 'Male',
+      first_name: 'Ongoing',
+      name: 'Patient',
+      diagnosis: ['Stroke'],
+      duration: 30,
+      biomarker: {
+        sleep_avg_h: 7.5,
+        steps_avg: 7000,
+        activity_min: 80,
+      },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Login unknown')).toBeInTheDocument();
+    });
+
+    expect(screen.queryByLabelText(/Health/i)).not.toBeInTheDocument();
   });
 
   test('uses last_feedback_at when questionnaires list is empty', async () => {
@@ -421,6 +449,69 @@ describe('Therapist traffic lights', () => {
     });
   });
 
+  test('uses intervention feedback recency + average score for feedback chip', async () => {
+    renderWithPatient({
+      _id: 'feedback-intervention-good',
+      therapist: 'T',
+      created_at: '2026-01-01T00:00:00',
+      username: 'feedbackgood',
+      age: '1990-01-01',
+      sex: 'Male',
+      first_name: 'Feedback',
+      name: 'Threshold',
+      diagnosis: ['Stroke'],
+      duration: 30,
+      intervention_feedback: {
+        last_answered_at: new Date(Date.now() - 1 * 24 * 60 * 60 * 1000).toISOString(),
+        days_since_last: 1,
+        answered_days_total: 4,
+        recent_days_count: 3,
+        recent_avg_score: 4.0,
+        previous_avg_score: 3.5,
+        trend_delta: 0.5,
+        trend_lower: false,
+      },
+      biomarker: {},
+    });
+
+    const feedbackChip = await screen.findByLabelText('Feedback good');
+    fireEvent.mouseOver(feedbackChip);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Avg score \(last 3 answered days\): 4\.00/i)).toBeInTheDocument();
+    });
+  });
+
+  test('marks feedback as bad when intervention trend is lower', async () => {
+    renderWithPatient({
+      _id: 'feedback-intervention-trend-down',
+      therapist: 'T',
+      created_at: '2026-01-01T00:00:00',
+      username: 'feedbacktrend',
+      age: '1990-01-01',
+      sex: 'Male',
+      first_name: 'Feedback',
+      name: 'Trend',
+      diagnosis: ['Stroke'],
+      duration: 30,
+      intervention_feedback: {
+        last_answered_at: new Date(Date.now() - 2 * 24 * 60 * 60 * 1000).toISOString(),
+        days_since_last: 2,
+        answered_days_total: 6,
+        recent_days_count: 3,
+        recent_avg_score: 2.5,
+        previous_avg_score: 4.0,
+        trend_delta: -1.5,
+        trend_lower: true,
+      },
+      biomarker: {},
+    });
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Feedback bad')).toBeInTheDocument();
+    });
+  });
+
   test('uses personalized blood pressure thresholds in health scoring', async () => {
     renderWithPatient({
       _id: 'bp-threshold-test-patient',
@@ -433,6 +524,7 @@ describe('Therapist traffic lights', () => {
       name: 'Pressure',
       diagnosis: ['Stroke'],
       duration: 30,
+      rehab_status: 'completed',
       biomarker: {
         bp_sys_avg: 150,
         bp_dia_avg: 95,

--- a/frontend/src/__tests__/pages/TherapistTrafficLights.TESTING.md
+++ b/frontend/src/__tests__/pages/TherapistTrafficLights.TESTING.md
@@ -16,27 +16,27 @@ Inputs used by the chip:
 
 Current level mapping:
 
-| Condition | Level |
-|---|---|
-| `days_since_last > 7` | `bad` |
-| `days_since_last > 3` | `warn` |
-| `recent_avg_score <= 2` | `bad` |
-| `recent_avg_score < 3` (and not already bad) | `warn` |
-| `trend_lower = true` | degrade one level (`good->warn`, `warn->bad`) |
+| Condition                                    | Level                                         |
+| -------------------------------------------- | --------------------------------------------- |
+| `days_since_last > 7`                        | `bad`                                         |
+| `days_since_last > 3`                        | `warn`                                        |
+| `recent_avg_score <= 2`                      | `bad`                                         |
+| `recent_avg_score < 3` (and not already bad) | `warn`                                        |
+| `trend_lower = true`                         | degrade one level (`good->warn`, `warn->bad`) |
 
 When no scored intervention feedback is present, the chip falls back to
 `last_feedback_at` recency behavior.
 
 ## Related tests in `Therapist.test.tsx`
 
-| Test | What is validated |
-|---|---|
+| Test                                                                   | What is validated                                               |
+| ---------------------------------------------------------------------- | --------------------------------------------------------------- |
 | `uses intervention feedback recency + average score for feedback chip` | Good chip and tooltip content for recent, high average feedback |
-| `marks feedback as bad when intervention trend is lower` | Trend-down signal can push feedback level to bad |
-| `uses last_feedback_at when questionnaires list is empty` | Fallback recency path remains functional |
+| `marks feedback as bad when intervention trend is lower`               | Trend-down signal can push feedback level to bad                |
+| `uses last_feedback_at when questionnaires list is empty`              | Fallback recency path remains functional                        |
 
 ## Other traffic-light updates covered
 
-| Test | What is validated |
-|---|---|
+| Test                                                       | What is validated                                    |
+| ---------------------------------------------------------- | ---------------------------------------------------- |
 | `hides Health badge for ongoing studies (active patients)` | Health chip is not shown for active/ongoing patients |

--- a/frontend/src/__tests__/pages/TherapistTrafficLights.TESTING.md
+++ b/frontend/src/__tests__/pages/TherapistTrafficLights.TESTING.md
@@ -1,0 +1,42 @@
+# Therapist Traffic Lights — Test Documentation
+
+This note documents the traffic-light behavior covered in
+[`Therapist.test.tsx`](./Therapist.test.tsx), especially the Feedback chip logic.
+
+## Feedback chip source and rules
+
+The therapist patient-list Feedback chip now prefers `intervention_feedback` from
+`GET /api/therapists/<therapist_id>/patients/`.
+
+Inputs used by the chip:
+
+- `last_answered_at` / `days_since_last`
+- `recent_avg_score` (last answered-day window)
+- `trend_lower` / `trend_delta`
+
+Current level mapping:
+
+| Condition | Level |
+|---|---|
+| `days_since_last > 7` | `bad` |
+| `days_since_last > 3` | `warn` |
+| `recent_avg_score <= 2` | `bad` |
+| `recent_avg_score < 3` (and not already bad) | `warn` |
+| `trend_lower = true` | degrade one level (`good->warn`, `warn->bad`) |
+
+When no scored intervention feedback is present, the chip falls back to
+`last_feedback_at` recency behavior.
+
+## Related tests in `Therapist.test.tsx`
+
+| Test | What is validated |
+|---|---|
+| `uses intervention feedback recency + average score for feedback chip` | Good chip and tooltip content for recent, high average feedback |
+| `marks feedback as bad when intervention trend is lower` | Trend-down signal can push feedback level to bad |
+| `uses last_feedback_at when questionnaires list is empty` | Fallback recency path remains functional |
+
+## Other traffic-light updates covered
+
+| Test | What is validated |
+|---|---|
+| `hides Health badge for ongoing studies (active patients)` | Health chip is not shown for active/ongoing patients |

--- a/frontend/src/pages/Therapist.tsx
+++ b/frontend/src/pages/Therapist.tsx
@@ -56,17 +56,15 @@ type ThresholdsLike = {
   bp_dia_yellow_max?: unknown;
 };
 
-type QuestionnaireLike = {
-  title?: unknown;
-  key?: unknown;
+type InterventionFeedbackLike = {
   last_answered_at?: unknown;
-  last_score?: unknown;
-  prev_score?: unknown;
-  delta_score?: unknown;
-  adherence_7?: unknown;
-  answered_7?: unknown;
-  expected_7?: unknown;
-  low_score?: unknown;
+  days_since_last?: unknown;
+  answered_days_total?: unknown;
+  recent_days_count?: unknown;
+  recent_avg_score?: unknown;
+  previous_avg_score?: unknown;
+  trend_delta?: unknown;
+  trend_lower?: unknown;
 };
 
 type PatientExtra = {
@@ -85,6 +83,7 @@ type PatientExtra = {
 
   last_feedback_at?: unknown;
   questionnaires?: unknown;
+  intervention_feedback?: unknown;
 
   thresholds?: unknown;
   biomarker?: unknown;
@@ -93,17 +92,6 @@ type PatientExtra = {
 
 const asRecord = (v: unknown): Record<string, unknown> =>
   v && typeof v === 'object' ? (v as Record<string, unknown>) : {};
-
-const toStr = (v: unknown): string => {
-  if (v == null) return '';
-  if (typeof v === 'string') return v;
-  if (typeof v === 'number' || typeof v === 'boolean') return String(v);
-  try {
-    return JSON.stringify(v);
-  } catch {
-    return String(v);
-  }
-};
 
 const toNum = (v: unknown): number | null => {
   if (typeof v === 'number') return Number.isFinite(v) ? v : null;
@@ -460,89 +448,85 @@ const Therapist: React.FC = observer(() => {
 
   const feedbackLevelAndTip = (p: PatientType): { level: Traffic; tip: string } => {
     const extra = getPatientExtra(p);
-    const qsRaw = extra.questionnaires;
+    const summary = asRecord(extra.intervention_feedback) as InterventionFeedbackLike;
 
-    const qs: QuestionnaireLike[] = Array.isArray(qsRaw)
-      ? (qsRaw as unknown[]).map((x) => asRecord(x) as QuestionnaireLike)
-      : [];
+    const lastIso = getIsoMaybe(summary.last_answered_at);
+    const daysSinceLast = toNum(summary.days_since_last);
+    const answeredDaysTotal = toNum(summary.answered_days_total) ?? 0;
+    const recentDaysCount = toNum(summary.recent_days_count) ?? 0;
+    const recentAvg = toNum(summary.recent_avg_score);
+    const prevAvg = toNum(summary.previous_avg_score);
+    const trendDelta = toNum(summary.trend_delta);
+    const trendLower = summary.trend_lower === true;
 
-    if (qs.length === 0) {
-      const last = getIsoMaybe(extra.last_feedback_at);
-      const d = daysSince(last || undefined);
+    if (answeredDaysTotal > 0 && lastIso) {
+      let level: Traffic = 'good';
 
-      let level: Traffic = 'unknown';
-      if (!last || d === Number.POSITIVE_INFINITY) level = 'warn';
-      else if (d <= 14) level = 'good';
-      else if (d <= 30) level = 'warn';
-      else level = 'bad';
+      if (daysSinceLast != null) {
+        if (daysSinceLast > 7) level = 'bad';
+        else if (daysSinceLast > 3) level = 'warn';
+      }
 
-      const tip = last
-        ? `${t('Last feedback')}: ${fmtDateTime(last)} (${d} ${t('days ago')})`
-        : String(t('No recent feedback'));
-      return { level, tip };
+      if (recentAvg != null) {
+        if (recentAvg <= 2) level = 'bad';
+        else if (recentAvg < 3 && level !== 'bad') level = 'warn';
+      }
+
+      if (trendLower) {
+        if (level === 'good') level = 'warn';
+        else if (level === 'warn') level = 'bad';
+      }
+
+      const trendText =
+        trendDelta == null
+          ? String(t('n/a'))
+          : trendDelta < 0
+            ? `${t('lower')} (${trendDelta.toFixed(2)})`
+            : trendDelta > 0
+              ? `${t('higher')} (+${trendDelta.toFixed(2)})`
+              : String(t('stable'));
+
+      const parts: string[] = [
+        `${t('Last intervention feedback')}: ${fmtDateTime(lastIso)}${daysSinceLast != null ? ` (${daysSinceLast} ${t('days ago')})` : ''}`,
+      ];
+      if (recentAvg != null) {
+        parts.push(
+          `${t('Avg score')} (${t('last')} ${recentDaysCount} ${t('answered days')}): ${recentAvg.toFixed(2)}`
+        );
+      }
+      if (prevAvg != null) parts.push(`${t('Previous avg score')}: ${prevAvg.toFixed(2)}`);
+      parts.push(`${t('Trend')}: ${trendText}`);
+
+      return { level, tip: parts.join(' • ') };
     }
 
-    let worst: Traffic = 'good';
-    const ord = (lvl: Traffic) =>
-      lvl === 'bad' ? 3 : lvl === 'warn' ? 2 : lvl === 'unknown' ? 1 : 0;
-    const lines: string[] = [];
-
-    qs.forEach((q) => {
-      const title =
-        (typeof q.title === 'string' && q.title) ||
-        (typeof q.key === 'string' && q.key) ||
-        String(t('Questionnaire'));
-
-      const lastISO = typeof q.last_answered_at === 'string' ? q.last_answered_at : null;
-
-      const lastScore = toNum(q.last_score);
-      const prevScore = toNum(q.prev_score);
-
-      let delta = toNum(q.delta_score);
-      if (delta == null && lastScore != null && prevScore != null) delta = lastScore - prevScore;
-
-      const adh7 = toNum(q.adherence_7);
-      const answered7 = toNum(q.answered_7);
-      const expected7 = toNum(q.expected_7);
-
-      const low = q.low_score === true;
-      const days = daysSince(lastISO || undefined);
-
-      let lvl: Traffic = 'good';
-      if (low) lvl = 'bad';
-      else if (!lastISO) lvl = 'warn';
-      else if (days > 30) lvl = 'bad';
-      else if (days > 14) lvl = 'warn';
-      if (typeof adh7 === 'number' && adh7 < 50) lvl = lvl === 'bad' ? 'bad' : 'warn';
-
-      if (ord(lvl) > ord(worst)) worst = lvl;
-
-      const parts: string[] = [];
-      parts.push(title);
-      parts.push(lastISO ? fmtDate(lastISO) : String(t('No answers yet')));
-      if (lastScore != null) parts.push(`${t('Score')}: ${lastScore}`);
-      if (delta != null && delta !== 0) {
-        const arrow = delta < 0 ? '↓' : '↑';
-        parts.push(`${arrow} ${Math.abs(delta)}`);
-      }
-      if (typeof answered7 === 'number' && typeof expected7 === 'number')
-        parts.push(`${t('7d')}: ${answered7}/${expected7}`);
-      else if (typeof adh7 === 'number') parts.push(`${t('7d adh')}: ${adh7}%`);
-
-      lines.push(parts.join(' • '));
-    });
-
-    return { level: worst || 'unknown', tip: lines.join('\n') || String(t('No recent feedback')) };
+    // Fallback when intervention feedback has no numeric scored entries yet
+    const last = getIsoMaybe(extra.last_feedback_at);
+    const d = daysSince(last || undefined);
+    let level: Traffic = 'unknown';
+    if (!last || d === Number.POSITIVE_INFINITY) level = 'warn';
+    else if (d <= 14) level = 'good';
+    else if (d <= 30) level = 'warn';
+    else level = 'bad';
+    return {
+      level,
+      tip: last
+        ? `${t('Last feedback')}: ${fmtDateTime(last)} (${d} ${t('days ago')})`
+        : String(t('No recent feedback')),
+    };
   };
+
+  const shouldHideHealthChip = (p: PatientType): boolean => !store.isCompletedPatient(p);
 
   const ampelComposite = (p: PatientType) => {
     const l = loginLevelAndTip(p);
     const a = adherenceLevelAndTip(p);
     const h = healthLevelAndTip(p);
     const f = feedbackLevelAndTip(p);
+    const includeHealth = !shouldHideHealthChip(p);
 
-    const base =
-      levelToNum(l.level) + levelToNum(a.level) + levelToNum(h.level) + levelToNum(f.level);
+    const base = levelToNum(l.level) + levelToNum(a.level) + levelToNum(f.level);
+    const baseWithHealth = includeHealth ? base + levelToNum(h.level) : base;
 
     const extra = getPatientExtra(p);
     const lastLogin =
@@ -570,10 +554,10 @@ const Therapist: React.FC = observer(() => {
     const tweak =
       (Number.isFinite(dLogin) ? dLogin / 50 : 0) +
       (adh >= 0 ? (100 - adh) / 100 : 0.5) +
-      (hScore >= 0 ? (2 - hScore) / 2 : 0.5) +
       (Number.isFinite(dFb) ? dFb / 100 : 0.25);
+    const healthTweak = includeHealth ? (hScore >= 0 ? (2 - hScore) / 2 : 0.5) : 0;
 
-    return base + tweak;
+    return baseWithHealth + tweak + healthTweak;
   };
 
   const renderStatusChips = (p: PatientType) => {
@@ -582,6 +566,7 @@ const Therapist: React.FC = observer(() => {
     const health = healthLevelAndTip(p);
     const fb = feedbackLevelAndTip(p);
     const wear = wearLevelAndTip(p);
+    const hideHealthChip = shouldHideHealthChip(p);
 
     const Chip = ({ label, level, tip }: { label: string; level: Traffic; tip: string }) => (
       <OverlayTrigger
@@ -606,7 +591,9 @@ const Therapist: React.FC = observer(() => {
       <div className="status-stack">
         <Chip label={String(t('Login'))} level={login.level} tip={login.tip} />
         <Chip label={String(t('Adherence'))} level={adh.level} tip={adh.tip} />
-        <Chip label={String(t('Health'))} level={health.level} tip={health.tip} />
+        {!hideHealthChip && (
+          <Chip label={String(t('Health'))} level={health.level} tip={health.tip} />
+        )}
         <Chip label={String(t('Feedback'))} level={fb.level} tip={fb.tip} />
         {wear.level !== 'unknown' && (
           <Chip label={String(t('Wear'))} level={wear.level} tip={wear.tip} />


### PR DESCRIPTION
# Description

This PR updates therapist patient-list warning chips to align with ongoing-study requirements and clarifies Feedback logic by moving it to intervention-feedback recency/average/trend.

### Summary of changes
- Hid **Health** chip for ongoing (active) patients in therapist list.
- Kept Health chip behavior for completed patients.
- Updated performance/composite sorting to match visible chips (Health excluded for ongoing patients).
- Reworked **Feedback** chip logic to use intervention feedback summary:
  - last answered timestamp (`days_since_last`)
  - recent average score (last answered-day window)
  - trend direction (`trend_lower`, `trend_delta`)
- Added backend aggregation for intervention feedback and exposed it in therapist patient-list API as `intervention_feedback`.
- Preserved `feedback_low` (questionnaire-derived) for compatibility.
- Added/updated unit and UI tests.
- Added new Playwright E2E coverage for therapist feedback chips.
- Updated API docs and testing docs accordingly.

### Motivation / context
Study stakeholders asked to remove Health score/chip for ongoing studies and requested clearer, actionable feedback status behavior. This PR implements that directly in UI and API data flow.

### Dependencies
No new package dependencies.

## Related Issue
[Feature 150: Adjust warning chips for ongoing studies + clarify feedback alert thresholds](https://github.com/<org>/<repo>/issues/150)

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Documentation update
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] A new research paper code implementation
- [ ] Other (Specify)

## Tests

### Backend
```bash
docker exec django pytest tests/therapist_views/test_therapist_views.py -q
```
Result: `35 passed`

### Frontend unit/integration
```bash
docker exec react npx jest --no-coverage --runTestsByPath src/__tests__/pages/Therapist.test.tsx
```
Result: `13 passed`

### Frontend E2E (new)
```bash
docker exec react npx playwright test e2e/therapist-feedback-chips.spec.ts --project=chromium
```
Result: runs; skips when seeded therapist creds/2FA email dir are not configured.

### Scoped lint/format checks
```bash
docker exec react npx prettier --write src/pages/Therapist.tsx src/__tests__/pages/Therapist.test.tsx e2e/therapist-feedback-chips.spec.ts e2e/TESTING.md
docker exec django black core/views/therapist_views.py tests/therapist_views/test_therapist_views.py
docker exec react npx eslint src/pages/Therapist.tsx src/__tests__/pages/Therapist.test.tsx e2e/therapist-feedback-chips.spec.ts
```
Result: clean for scoped files.

**Test Configuration**:
- Dockerized `react` and `django` services
- Playwright project: `chromium`
- Seeded creds required for non-skipped therapist E2E:
  - `E2E_THERAPIST_LOGIN`
  - `E2E_THERAPIST_PASSWORD`
  - `E2E_EMAIL_DIR`

## Checklist

- [ ] I have read the [guidelines for contributing](https://github.com/fastmachinelearning/hls4ml/blob/main/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have installed and run `pre-commit` on the files I edited or added.
- [x] I have added tests that prove my fix is effective or that my feature works.