### PR TITLE
146 bug assigned content does not appear in patient view

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,7 +23,7 @@ name: Tests
 
 on:
   push:
-    branches: [main, dev]
+    branches: ['**']
     paths:
       - 'frontend/**'
       - 'backend/**'

--- a/backend/core/views/patient_views.py
+++ b/backend/core/views/patient_views.py
@@ -999,7 +999,7 @@ def get_patient_plan(request, patient_id):
     try:
         patient = _resolve_patient_flexible(patient_id)
         if not patient:
-            logger.warning("[get_patient_plan] Patient not found")
+            logger.warning("[get_patient_plan] Patient not found: %s", patient_id)
             return JsonResponse({"error": "Patient not found"}, status=404)
         rehab_plan = RehabilitationPlan.objects(patientId=patient).first()
 

--- a/backend/core/views/patient_views.py
+++ b/backend/core/views/patient_views.py
@@ -999,7 +999,7 @@ def get_patient_plan(request, patient_id):
     try:
         patient = _resolve_patient_flexible(patient_id)
         if not patient:
-            logger.warning("[get_patient_plan] Patient not found: %s", patient_id)
+            logger.warning("[get_patient_plan] Patient not found")
             return JsonResponse({"error": "Patient not found"}, status=404)
         rehab_plan = RehabilitationPlan.objects(patientId=patient).first()
 


### PR DESCRIPTION
# Description

This PR fixes a patient-resolution mismatch that caused assigned interventions to not appear in the patient view in some flows.

Previously, endpoints relied mainly on ObjectId-based lookup (`patient._id` / `userId`) and could fail when older or alternate identifiers were used (for example `patient_code` like `1234`, or username).  
This branch introduces flexible patient resolution and uses it in key patient-plan endpoints, so assigned content is consistently found and returned.

Main changes:
- Added `_resolve_patient_flexible(identifier)` in `backend/core/views/patient_views.py`
- Updated patient lookup in:
  - `get_patient_plan`
  - `add_intervention_to_patient`
  - `get_patient_plan_for_therapist`
- Improved `get_patient_plan` error handling/logging to return clean `404` when identifier is unknown
- Added/updated regression tests for:
  - assigning intervention by `patient_code`
  - fetching plan by `patient_code`
  - fetching plan by username
  - unknown non-ObjectId identifier returns `404`

Dependencies:
- No new package dependencies

## Related Issue
[#146](https://github.com/<org>/<repo>/issues/146)

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Documentation update
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] A new research paper code implementation
- [ ] Other (Specify)

## Tests

Added/updated tests in:
- `backend/tests/patient_views/test_patient_views.py`

Relevant test cases:
- `test_add_intervention_to_patient_accepts_patient_code`
- `test_get_patient_plan_by_patient_code`
- `test_get_patient_plan_by_username`
- `test_get_patient_plan_invalid_patient_id_returns_not_found`

Run command:
```bash
pytest -q backend/tests/patient_views/test_patient_views.py -k "add_intervention_to_patient_accepts_patient_code or get_patient_plan_by_patient_code or get_patient_plan_by_username or get_patient_plan_invalid_patient_id_returns_not_found"
```

Execution note:
- Could not run tests in this shell because `pytest` is not installed (`/bin/bash: pytest: command not found`).

**Test Configuration**:
- Backend Django tests
- Target file: `backend/tests/patient_views/test_patient_views.py`

## Checklist

- [x] I have read the [guidelines for contributing](https://github.com/fastmachinelearning/hls4ml/blob/main/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have installed and run `pre-commit` on the files I edited or added.
- [x] I have added tests that prove my fix is effective or that my feature works.