### PR TITLE
143 Implement informed consent checks for REDCap patient imports and restrict patient creation to REDCap sources

### DIFF
--- a/backend/core/views/auth_views.py
+++ b/backend/core/views/auth_views.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import os
 import random
 import string
 from datetime import datetime, timedelta
@@ -674,6 +675,21 @@ def register_view(request):
             except (User.DoesNotExist, Therapist.DoesNotExist):
                 rollback()
                 return _err("Assigned therapist not found.", status=404)
+
+            # Optional compliance mode: allow patient creation only via REDCap import.
+            enforce_redcap_only = os.getenv("ENFORCE_REDCAP_ONLY_PATIENT_CREATION", "").strip().lower() in {
+                "1",
+                "true",
+                "yes",
+            }
+            source = str(data.get("source") or "").strip().lower()
+            if enforce_redcap_only and source != "redcap":
+                rollback()
+                return _err(
+                    "Patient creation is restricted to REDCap imports.",
+                    status=403,
+                    field_errors={"source": ['Use "source":"redcap" or import via REDCap endpoint.']},
+                )
 
             # Validate clinic
             clinic = (data.get("clinic") or "").strip()

--- a/backend/core/views/redcap_import_views.py
+++ b/backend/core/views/redcap_import_views.py
@@ -36,6 +36,20 @@ def _is_objectid(v: str) -> bool:
         return False
 
 
+def _has_informed_consent(row: Dict[str, Any]) -> bool:
+    """
+    REDCap informed consent gate:
+    only rows with field `ic == 1` are considered importable.
+    """
+    raw = _norm(row.get("ic"))
+    if raw == "1":
+        return True
+    try:
+        return float(raw) == 1.0
+    except Exception:
+        return False
+
+
 def _bad(message: str, status: int = 400, extra: dict | None = None):
     payload = {"ok": False, "error": message}
     if extra:
@@ -207,7 +221,7 @@ def redcap_export_minimal(
     record_id: Optional[str] = None,
 ) -> List[Dict[str, Any]]:
     """
-    Minimal export: record_id + pat_id (if supported) + DAG.
+    Minimal export: record_id + pat_id (if supported) + ic + DAG.
 
     Automatically retries without fields that the project doesn't have
     (e.g. COMPASS lacks pat_id).
@@ -231,7 +245,7 @@ def redcap_export_minimal(
     if record_id:
         base["records[0]"] = record_id
 
-    rows = _post_redcap_minimal(api_url, base, ["record_id", "pat_id"])
+    rows = _post_redcap_minimal(api_url, base, ["record_id", "pat_id", "ic"])
 
     # client-side filter by patient_id (pat_id)
     if patient_id:
@@ -372,6 +386,10 @@ def available_redcap_patients(request):
             existing_ids = _get_existing_identifiers_for_project(project)
 
             for r in rows:
+                # Compliance gate: only consented participants are import candidates.
+                if not _has_informed_consent(r):
+                    continue
+
                 record_id = _norm(r.get("record_id"))
                 pat_id = _norm(r.get("pat_id"))
                 dag = _norm(r.get("redcap_data_access_group"))
@@ -537,6 +555,13 @@ def import_patient_from_redcap(request):
         return _bad(
             "No REDCap record found for this identifier in this project.",
             status=404,
+            extra={"project": project, "identifier": identifier},
+        )
+
+    if not _has_informed_consent(rc_row):
+        return _bad(
+            "Forbidden: participant has not provided informed consent (ic must be 1).",
+            status=403,
             extra={"project": project, "identifier": identifier},
         )
 

--- a/backend/tests/auth_views/test_register_view.py
+++ b/backend/tests/auth_views/test_register_view.py
@@ -625,3 +625,21 @@ def test_register_patient_created_by_set_to_therapist(mongo_mock):
     assert patient.created_by is not None
     therapist_doc = TherapistModel.objects.filter(userId=th).first()
     assert patient.created_by.id == therapist_doc.id
+
+
+@mock.patch.dict("os.environ", {"ENFORCE_REDCAP_ONLY_PATIENT_CREATION": "1"}, clear=False)
+def test_register_patient_redcap_only_mode_rejects_non_redcap_source(mongo_mock):
+    """
+    When REDCap-only mode is enabled server-side, manual patient registration
+    is rejected unless payload source is "redcap".
+    """
+    th = _create_therapist_with_clinics("t8@example.com", ["Inselspital"], ["COPAIN"])
+    payload = {**_patient_base(th.id), "clinic": "Inselspital", "project": "COPAIN"}
+
+    resp = _post(payload)
+
+    assert resp.status_code == 403
+    body = resp.json()
+    assert "REDCap imports" in body.get("message", "") or "REDCap imports" in body.get("error", "")
+    assert "source" in body.get("field_errors", {})
+    assert User.objects.filter(email=payload["email"]).first() is None

--- a/backend/tests/redcap_import_views/TESTING.md
+++ b/backend/tests/redcap_import_views/TESTING.md
@@ -12,11 +12,11 @@ Tests in [`test_redcap_import_views.py`](test_redcap_import_views.py) cover:
 
 | Group | Tests |
 |---|---|
-| `available_redcap_patients` | 9 |
-| `import_patient_from_redcap` | 12 |
+| `available_redcap_patients` | 10 |
+| `import_patient_from_redcap` | 13 |
 | Utility and service helpers | 6 |
 
-**Total: 27 tests**
+**Total: 29 tests**
 
 ---
 
@@ -48,6 +48,7 @@ Tests in [`test_redcap_import_views.py`](test_redcap_import_views.py) cover:
 - Missing REDCap token → `200` with error in `errors[]`.
 - REDCap export error collected per project → `200` with `errors[]` populated.
 - DAG filter: records whose `redcap_data_access_group` is not in the allowed DAG set are excluded.
+- Informed-consent filter: records with `ic != 1` are excluded from candidates.
 - Deduplication: duplicate `(project, identifier)` pairs collapsed.
 - Already-imported patients excluded from candidates.
 - Successful candidate listing.
@@ -60,6 +61,7 @@ Tests in [`test_redcap_import_views.py`](test_redcap_import_views.py) cover:
 - Already-imported patient (existing `patient_code`) → `409`.
 - Missing REDCap token → `400`.
 - DAG forbidden: record's DAG not in therapist's allowed DAGs → `403`.
+- Non-consented REDCap record (`ic != 1`) is rejected → `403`.
 - Record not found in REDCap → `404`.
 - Fallback: first lookup by `record_id` returns empty → retries by `pat_id` filter.
 - Fallback REDCap error on second attempt → `502`.

--- a/backend/tests/redcap_import_views/TESTING.md
+++ b/backend/tests/redcap_import_views/TESTING.md
@@ -12,11 +12,11 @@ Tests in [`test_redcap_import_views.py`](test_redcap_import_views.py) cover:
 
 | Group | Tests |
 |---|---|
-| `available_redcap_patients` | 10 |
-| `import_patient_from_redcap` | 13 |
+| `available_redcap_patients` | 11 |
+| `import_patient_from_redcap` | 14 |
 | Utility and service helpers | 6 |
 
-**Total: 29 tests**
+**Total: 31 tests**
 
 ---
 
@@ -48,7 +48,7 @@ Tests in [`test_redcap_import_views.py`](test_redcap_import_views.py) cover:
 - Missing REDCap token → `200` with error in `errors[]`.
 - REDCap export error collected per project → `200` with `errors[]` populated.
 - DAG filter: records whose `redcap_data_access_group` is not in the allowed DAG set are excluded.
-- Informed-consent filter: records with `ic != 1` are excluded from candidates.
+- **Informed-consent filter**: records with `ic != 1` are excluded from candidates (`test_available_patients_excludes_non_consented_records`).
 - Deduplication: duplicate `(project, identifier)` pairs collapsed.
 - Already-imported patients excluded from candidates.
 - Successful candidate listing.
@@ -61,7 +61,7 @@ Tests in [`test_redcap_import_views.py`](test_redcap_import_views.py) cover:
 - Already-imported patient (existing `patient_code`) → `409`.
 - Missing REDCap token → `400`.
 - DAG forbidden: record's DAG not in therapist's allowed DAGs → `403`.
-- Non-consented REDCap record (`ic != 1`) is rejected → `403`.
+- **Non-consented REDCap record** (`ic != 1`) is rejected → `403` (`test_import_patient_rejects_non_consented_record`).
 - Record not found in REDCap → `404`.
 - Fallback: first lookup by `record_id` returns empty → retries by `pat_id` filter.
 - Fallback REDCap error on second attempt → `502`.
@@ -77,9 +77,24 @@ Tests in [`test_redcap_import_views.py`](test_redcap_import_views.py) cover:
 |---|---|
 | Inselspital+COPAIN therapist → allowed DAGs = `{"inselspital"}` | `test_env_helpers_and_therapist_resolution_branches` |
 | Record with DAG outside allowed set is blocked | `test_import_patient_dag_forbidden` |
+| Record with `ic = 0` is excluded from available candidates | `test_available_patients_excludes_non_consented_records` |
+| Record with `ic = 0` is rejected at import | `test_import_patient_rejects_non_consented_record` |
+| Mixed-consent list: only `ic = 1` rows appear as candidates | `test_available_patients_dag_filter_and_dedupe` |
 | Imported patient receives `project` field | `test_import_patient_success` |
 | Imported patient `clinic` is derived from DAG, not therapist's first clinic | `test_import_patient_success` |
 | Per-project errors surface in `errors[]` at HTTP 200 | `test_available_patients_collects_errors` |
+
+---
+
+## Informed-Consent Gate
+
+The consent check is applied at two independent points in the flow, so neither endpoint can be bypassed to import a non-consented participant:
+
+1. **List endpoint** (`available_redcap_patients`) — `_has_informed_consent(row)` is called for every row returned by REDCap before it is added to the candidate list. Records with `ic = ""` (no decision recorded) or `ic = "0"` (refused) are silently skipped.
+
+2. **Import endpoint** (`import_patient_from_redcap`) — consent is re-checked on the single row fetched for the specific participant being imported. If `ic != 1` the endpoint returns `403` with an `"informed consent"` message before any database write occurs.
+
+The check itself (`_has_informed_consent`) accepts `"1"` (string) or `1.0` (numeric); anything else — including an empty string or a missing `ic` key — is treated as not consented.
 
 ---
 

--- a/backend/tests/redcap_import_views/test_redcap_import_views.py
+++ b/backend/tests/redcap_import_views/test_redcap_import_views.py
@@ -191,7 +191,7 @@ def test_available_patients_project_not_allowed(mock_get_th):
 
 @patch(
     "core.views.redcap_import_views.redcap_export_minimal",
-    return_value=[{"record_id": "R1", "pat_id": "P17", "redcap_data_access_group": "inselspital"}],
+    return_value=[{"record_id": "R1", "pat_id": "P17", "ic": "1", "redcap_data_access_group": "inselspital"}],
 )
 @patch("core.views.redcap_import_views.get_redcap_token_for_project", return_value="tok")
 @patch("core.views.redcap_import_views.get_therapist_for_user")
@@ -213,7 +213,7 @@ def test_available_patients_returns_candidates(mock_get_th, mock_tok, mock_expor
 
 @patch(
     "core.views.redcap_import_views.redcap_export_minimal",
-    return_value=[{"record_id": "R1", "pat_id": "P17", "redcap_data_access_group": "d1"}],
+    return_value=[{"record_id": "R1", "pat_id": "P17", "ic": "1", "redcap_data_access_group": "d1"}],
 )
 @patch("core.views.redcap_import_views.get_redcap_token_for_project", return_value="tok")
 @patch("core.views.redcap_import_views.get_therapist_for_user")
@@ -255,10 +255,11 @@ def test_available_patients_dag_filter_and_dedupe(mock_get_th, mock_tok, mock_ex
     _, th = create_therapist(projects=["COPAIN"])
     mock_get_th.return_value = th
     mock_export.return_value = [
-        {"record_id": "R1", "pat_id": "P17", "redcap_data_access_group": "d1"},
-        {"record_id": "R2", "pat_id": "P17", "redcap_data_access_group": "d1"},
-        {"record_id": "R3", "pat_id": "P99", "redcap_data_access_group": "d2"},
-        {"record_id": "", "pat_id": "", "redcap_data_access_group": "d1"},
+        {"record_id": "R1", "pat_id": "P17", "ic": "1", "redcap_data_access_group": "d1"},
+        {"record_id": "R2", "pat_id": "P17", "ic": "1", "redcap_data_access_group": "d1"},
+        {"record_id": "R3", "pat_id": "P99", "ic": "1", "redcap_data_access_group": "d2"},
+        {"record_id": "", "pat_id": "", "ic": "1", "redcap_data_access_group": "d1"},
+        {"record_id": "R4", "pat_id": "P20", "ic": "0", "redcap_data_access_group": "d1"},
     ]
     resp = client.get(
         "/api/redcap/available-patients/?project=COPAIN",
@@ -268,6 +269,23 @@ def test_available_patients_dag_filter_and_dedupe(mock_get_th, mock_tok, mock_ex
     body = resp.json()
     assert len(body["candidates"]) == 1
     assert body["candidates"][0]["dag"] == "d1"
+
+
+@patch(
+    "core.views.redcap_import_views.redcap_export_minimal",
+    return_value=[{"record_id": "R1", "pat_id": "P17", "ic": "0", "redcap_data_access_group": "inselspital"}],
+)
+@patch("core.views.redcap_import_views.get_redcap_token_for_project", return_value="tok")
+@patch("core.views.redcap_import_views.get_therapist_for_user")
+def test_available_patients_excludes_non_consented_records(mock_get_th, _tok, _export):
+    _, th = create_therapist(projects=["COPAIN"])
+    mock_get_th.return_value = th
+    resp = client.get(
+        "/api/redcap/available-patients/?project=COPAIN",
+        HTTP_AUTHORIZATION="Bearer test",
+    )
+    assert resp.status_code == 200
+    assert resp.json()["candidates"] == []
 
 
 @patch("core.views.redcap_import_views.redcap_export_minimal")
@@ -364,7 +382,7 @@ def test_import_patient_missing_token(mock_get_th, mock_token):
 @patch("core.views.redcap_import_views.allowed_dags_by_project", return_value={"dag-ok"})
 @patch(
     "core.views.redcap_import_views.redcap_export_minimal",
-    return_value=[{"record_id": "R1", "pat_id": "P17", "redcap_data_access_group": "dag-no"}],
+    return_value=[{"record_id": "R1", "pat_id": "P17", "ic": "1", "redcap_data_access_group": "dag-no"}],
 )
 @patch("core.views.redcap_import_views.get_redcap_token_for_project", return_value="tok")
 @patch("core.views.redcap_import_views.get_therapist_for_user")
@@ -404,7 +422,7 @@ def test_import_patient_fallback_patient_id_mode(mock_get_th, mock_tok, mock_exp
     mock_get_th.return_value = th
     mock_export.side_effect = [
         [],
-        [{"record_id": "R7", "pat_id": "P77", "redcap_data_access_group": "inselspital"}],
+        [{"record_id": "R7", "pat_id": "P77", "ic": "1", "redcap_data_access_group": "inselspital"}],
     ]
     resp = client.post(
         "/api/redcap/import-patient/",
@@ -434,7 +452,7 @@ def test_import_patient_fallback_redcap_error_returns_502(mock_get_th, mock_tok,
 
 @patch(
     "core.views.redcap_import_views.redcap_export_minimal",
-    return_value=[{"record_id": "R1", "pat_id": "P17", "redcap_data_access_group": "inselspital"}],
+    return_value=[{"record_id": "R1", "pat_id": "P17", "ic": "1", "redcap_data_access_group": "inselspital"}],
 )
 @patch("core.views.redcap_import_views.get_redcap_token_for_project", return_value="tok")
 @patch("core.views.redcap_import_views.get_therapist_for_user")
@@ -453,6 +471,26 @@ def test_import_patient_username_collision_suffix(mock_get_th, mock_tok, mock_ex
     assert resp.json()["username"].startswith("P17_")
 
 
+@patch(
+    "core.views.redcap_import_views.redcap_export_minimal",
+    return_value=[{"record_id": "R1", "pat_id": "P17", "ic": "0", "redcap_data_access_group": "inselspital"}],
+)
+@patch("core.views.redcap_import_views.get_redcap_token_for_project", return_value="tok")
+@patch("core.views.redcap_import_views.get_therapist_for_user")
+def test_import_patient_rejects_non_consented_record(mock_get_th, _tok, _export):
+    _, th = create_therapist(projects=["COPAIN"])
+    mock_get_th.return_value = th
+
+    resp = client.post(
+        "/api/redcap/import-patient/",
+        data=json.dumps({"project": "COPAIN", "patient_code": "P17", "password": "Strong1!"}),
+        content_type="application/json",
+        HTTP_AUTHORIZATION="Bearer test",
+    )
+    assert resp.status_code == 403
+    assert "informed consent" in resp.json()["error"]
+
+
 @patch("core.views.redcap_import_views.redcap_export_minimal")
 @patch("core.views.redcap_import_views.get_redcap_token_for_project", return_value="tok")
 @patch("core.views.redcap_import_views.get_therapist_for_user")
@@ -461,7 +499,9 @@ def test_import_patient_success(mock_get_th, mock_tok, mock_export):
     mock_get_th.return_value = th
 
     # record lookup succeeds on first call (record_id mode)
-    mock_export.return_value = [{"record_id": "R1", "pat_id": "P17", "redcap_data_access_group": "inselspital"}]
+    mock_export.return_value = [
+        {"record_id": "R1", "pat_id": "P17", "ic": "1", "redcap_data_access_group": "inselspital"}
+    ]
 
     resp = client.post(
         "/api/redcap/import-patient/",
@@ -490,7 +530,9 @@ def test_import_patient_creates_redcap_import_log(mock_get_th, mock_tok, mock_ex
 
     _, th = create_therapist(projects=["COPAIN"])
     mock_get_th.return_value = th
-    mock_export.return_value = [{"record_id": "R2", "pat_id": "P99", "redcap_data_access_group": "inselspital"}]
+    mock_export.return_value = [
+        {"record_id": "R2", "pat_id": "P99", "ic": "1", "redcap_data_access_group": "inselspital"}
+    ]
 
     resp = client.post(
         "/api/redcap/import-patient/",

--- a/docs/15-STUDY_INTEGRATION.md
+++ b/docs/15-STUDY_INTEGRATION.md
@@ -1,0 +1,213 @@
+# Study Integration Guide
+
+How to connect the platform to a clinical study managed in REDCap, enrol participants, and keep wearables data flowing back.
+
+---
+
+## Overview
+
+The platform integrates with REDCap for two purposes:
+
+1. **Patient import** — a therapist looks up consented participants from REDCap and creates their platform account in one step.
+2. **Wearables sync** — Fitbit data (steps, activity, sleep) collected by the platform is written back into REDCap automatically via a scheduled Celery task.
+
+Both flows use the same REDCap API URL and project tokens. Neither flow exposes raw API tokens to the browser; all calls are made server-side.
+
+---
+
+## Prerequisites
+
+- A REDCap project with the standard instruments (Eligibility, Wearables).
+- A REDCap API token with **Export** rights for the project (read-only is enough for patient import; **Import** rights are additionally required for wearables sync).
+- The REDCap project must have the `ic` field (informed consent) on the **Eligibility** instrument. Only participants where `ic = 1` can be imported.
+
+---
+
+## Environment Variables
+
+Set these in the `.env` file that is loaded by your Docker Compose stack (`.env.dev` for development, `.env.prod` for production).
+
+### Core REDCap connection
+
+| Variable | Required | Example | Description |
+|---|---|---|---|
+| `REDCAP_API_URL` | Yes | `https://redcap.unibe.ch/api/` | Full URL to the REDCap API endpoint, including the trailing slash. All projects share this URL. |
+| `REDCAP_TOKEN_<PROJECT>` | Yes, per project | `REDCAP_TOKEN_COPAIN=abc123` | API token for the named project. Replace `<PROJECT>` with the uppercase project name exactly as it appears in `config.json` (e.g. `COPAIN`, `COMPASS`). Add one variable per project. |
+
+### Optional compliance mode
+
+| Variable | Default | Example | Description |
+|---|---|---|---|
+| `ENFORCE_REDCAP_ONLY_PATIENT_CREATION` | *(unset / off)* | `1` | When set to `1`, `true`, or `yes`, the patient registration endpoint rejects any account creation request that does not come through the REDCap import flow. Useful for study deployments where no manual patient creation should be allowed. |
+
+### Wearables sync event names
+
+These only need to be set if the REDCap event names in your project differ from the built-in defaults. The defaults are hard-coded per project in `wearables_redcap_service.py`:
+
+| Project | Default baseline event | Default follow-up event |
+|---|---|---|
+| COMPASS | `visit_baseline_arm_1` | `visit_6m_arm_1` |
+| COPAIN | `t0_at_disch_arm_1` | `t2_six_months_afte_arm_1` |
+
+| Variable | Description |
+|---|---|
+| `REDCAP_WEARABLES_EVENT_BASELINE` | Override the baseline REDCap event name for all projects in this deployment. |
+| `REDCAP_WEARABLES_EVENT_FOLLOWUP` | Override the follow-up REDCap event name for all projects in this deployment. |
+
+---
+
+## Connecting a New Project
+
+### 1. Add the project to `config.json`
+
+`backend/config.json` controls which projects exist, which clinics participate in each, and what REDCap Data Access Group (DAG) each clinic maps to.
+
+```jsonc
+"therapistInfo": {
+  // Full list of project names the platform knows about.
+  "projects": ["COPAIN", "COMPASS"],
+
+  // Maps each clinic name to the projects it participates in.
+  // A therapist assigned to a clinic can only see that clinic's projects.
+  "clinic_projects": {
+    "Inselspital": ["COPAIN", "COMPASS"],
+    "Bern":        ["COMPASS"]
+  },
+
+  // Maps each clinic name to its REDCap Data Access Group identifier.
+  // Must match the DAG slug in REDCap exactly (lowercase, underscores).
+  "clinic_dag": {
+    "Inselspital": "inselspital",
+    "Bern":        "bern"
+  }
+}
+```
+
+If your new project is hosted in the same REDCap instance, only `config.json` and the token variable need updating — no code changes required.
+
+### 2. Set the API token
+
+```bash
+# .env.dev (or .env.prod)
+REDCAP_TOKEN_MYPROJECT=your_redcap_api_token_here
+```
+
+The token is looked up by uppercasing the project name and prefixing with `REDCAP_TOKEN_`. So project `"MYPROJECT"` in `config.json` requires `REDCAP_TOKEN_MYPROJECT`.
+
+### 3. Restart the backend
+
+```bash
+docker compose -f docker-compose.dev.yml restart django celery
+```
+
+### 4. Verify the connection
+
+```bash
+docker exec django python3 -c "
+import os, requests
+r = requests.post(
+    os.environ['REDCAP_API_URL'],
+    data={
+        'token': os.environ['REDCAP_TOKEN_MYPROJECT'],
+        'content': 'record',
+        'format': 'json',
+        'returnFormat': 'json',
+        'fields[0]': 'record_id',
+        'fields[1]': 'ic',
+        'events[0]': 'your_baseline_event_arm_1',
+        'rawOrLabel': 'raw',
+        'exportDataAccessGroups': 'true',
+    },
+    timeout=15,
+)
+print(r.status_code, r.json()[:3])
+"
+```
+
+A `200` response with a list of records confirms the token and event name are correct.
+
+---
+
+## How Patient Import Works
+
+### Consent gate
+
+Only participants with `ic = 1` in the REDCap Eligibility instrument are importable. The platform checks this at two points:
+
+1. When listing available candidates (`GET /api/redcap/available-patients/`) — non-consented rows are silently excluded before the list is returned to the UI.
+2. When importing a specific participant (`POST /api/redcap/import-patient/`) — consent is re-verified server-side before any account is created. A `403` is returned if `ic != 1`.
+
+This means a therapist will never see or be able to import a participant who has not signed the informed consent form.
+
+### DAG access control
+
+REDCap Data Access Groups restrict which records a therapist can import. A therapist can only import participants whose REDCap DAG matches one of the DAGs derived from their assigned clinics. The mapping is defined in `config.json → clinic_dag`.
+
+Example: a therapist assigned to `"Inselspital"` has DAG `"inselspital"`. They can only import records where `redcap_data_access_group = "inselspital"`.
+
+### Import flow (step by step)
+
+1. Therapist opens the import panel in the UI and selects a project.
+2. UI calls `GET /api/redcap/available-patients/?project=COPAIN`.
+3. Backend fetches `record_id`, `pat_id`, and `ic` from REDCap for the baseline event.
+4. Rows are filtered: non-consented removed, DAG-restricted to the therapist's clinics, already-imported participants removed.
+5. The filtered list is returned to the UI as import candidates.
+6. Therapist selects a participant, sets a password, and clicks import.
+7. UI calls `POST /api/redcap/import-patient/` with `project`, `patient_code` (the identifier), and `password`.
+8. Backend re-fetches the participant's record from REDCap, re-checks consent and DAG, then creates a `User` and `Patient` document. The patient's `clinic` field is derived from the DAG value via `clinic_dag`.
+9. An import log entry (`action = "REDCAP_IMPORT"`) is written for audit purposes.
+
+---
+
+## How Wearables Sync Works
+
+A Celery beat task runs periodically and writes Fitbit data back into REDCap for every patient who has a `project` field set and a completed `reha_end_date`.
+
+The task selects the best monitoring week in each period (highest wear time), averages the Fitbit metrics, and writes them to the REDCap Wearables instrument. After writing, the form status is set to `wearables_complete = 1` (Unverified) so that a researcher can review and mark it complete.
+
+For the full field mapping, period definitions, and per-project sleep format differences, see [`wearables_redcap_sync.md`](./wearables_redcap_sync.md).
+
+---
+
+## Troubleshooting
+
+### No candidates appear in the import list
+
+- Check that `REDCAP_TOKEN_<PROJECT>` is set and not empty: `docker exec django printenv | grep REDCAP_TOKEN`.
+- Verify that the clinic has the project listed under `clinic_projects` in `config.json`, and that the therapist is assigned to that clinic.
+- Confirm that participants have `ic = 1` in REDCap. Records with `ic = 0` or blank are intentionally hidden.
+- Check that the participant's DAG in REDCap matches the `clinic_dag` value for the therapist's clinic.
+
+### `403 Forbidden` on import
+
+The most common causes:
+
+| Cause | Fix |
+|---|---|
+| `ic` is not `1` in REDCap | Wait until the participant has signed the consent form |
+| Participant's DAG is not in the therapist's allowed set | Assign the therapist to the correct clinic, or correct the DAG in REDCap |
+| Project is not in `therapist.projects` | Add the project to the therapist's profile |
+
+### `502` on import
+
+The second REDCap lookup (fallback by `pat_id`) failed. Check that the REDCap API is reachable from the server and that the token has Export rights.
+
+### Token accepted but wrong records returned
+
+Check the event name. The platform requests records for the baseline event only. If your project uses a non-standard event name, set `REDCAP_WEARABLES_EVENT_BASELINE` / `REDCAP_WEARABLES_EVENT_FOLLOWUP` to match.
+
+### Wearables not appearing in REDCap
+
+- The Celery beat task must be running: `docker compose ps celery-beat`.
+- The patient must have `reha_end_date` set on their profile.
+- The API token must have **Import** rights (not just Export).
+- Check Celery logs: `docker compose logs celery | grep -i redcap`.
+
+---
+
+## Security Notes
+
+- API tokens are read from environment variables at runtime and are never stored in the database or logged.
+- The platform never exposes a raw token to the browser; all REDCap calls are server-side only.
+- The `ENFORCE_REDCAP_ONLY_PATIENT_CREATION` flag prevents therapists from bypassing the REDCap import flow by calling the registration endpoint directly. Enable it for study deployments.
+- Import actions are audit-logged in the `Logs` collection with `action = "REDCAP_IMPORT"` and the therapist's ID.

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -4,7 +4,7 @@ Complete technical documentation and guides for RehaAdvisor developers and users
 
 ## 📋 Complete File List
 
-### Core Documentation (14 files)
+### Core Documentation (15 files)
 
 | File | Purpose | Audience | Length |
 |------|---------|----------|--------|
@@ -24,6 +24,7 @@ Complete technical documentation and guides for RehaAdvisor developers and users
 | [10-USER_GUIDE.md](./10-USER_GUIDE.md) | End-user application guide | End Users | 11 KB |
 | [11-FAQ.md](./11-FAQ.md) | Frequently asked questions | Everyone | 10 KB |
 | [12-CONTRIBUTING.md](./12-CONTRIBUTING.md) | Code contribution guidelines | Contributors | 11 KB |
+| [15-STUDY_INTEGRATION.md](./15-STUDY_INTEGRATION.md) | REDCap connection, patient import, consent gate, wearables sync | Study Coordinators, DevOps | — |
 | [13-CODE_STANDARDS.md](./13-CODE_STANDARDS.md) | Code style and best practices | Developers | 15 KB |
 | [14-CI_ENVIRONMENT_CONTRACT.md](./14-CI_ENVIRONMENT_CONTRACT.md) | CI test environment and security contract | DevOps, Backend Developers | 3 KB |
 


### PR DESCRIPTION
# Description

This PR adds informed-consent enforcement for REDCap patient flows and introduces an optional compliance mode to restrict manual patient creation.

Motivation and context:
- Only consented REDCap participants should be importable.
- Some deployments require that patients are created only through REDCap import workflows.

What changed:
- In `backend/core/views/redcap_import_views.py`:
  - Added `_has_informed_consent(row)` helper.
  - Extended minimal REDCap export fields to include `ic`.
  - `available_redcap_patients` now filters out records where `ic != 1`.
  - `import_patient_from_redcap` now rejects non-consented records with `403`.
- In `backend/core/views/auth_views.py`:
  - Added env-gated restriction:
    - `ENFORCE_REDCAP_ONLY_PATIENT_CREATION=1|true|yes`
    - If enabled, non-REDCap patient registration is rejected (`403`) unless payload `source` is `"redcap"`.

Dependencies / config:
- No new package dependencies.
- Optional env var: `ENFORCE_REDCAP_ONLY_PATIENT_CREATION`.

## Related Issue
[#143](https://github.com/ARTORG-GERONTECHNOLOGY/Bearny-RehaAdvisor/issues/143)

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Documentation update
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] A new research paper code implementation
- [x] Other (Compliance hardening / access restriction)

## Tests

Added/updated tests:
- `backend/tests/auth_views/test_register_view.py`
  - `test_register_patient_redcap_only_mode_rejects_non_redcap_source`
- `backend/tests/redcap_import_views/test_redcap_import_views.py`
  - `test_available_patients_excludes_non_consented_records`
  - `test_import_patient_rejects_non_consented_record`
  - Existing REDCap mocks updated to include `ic` where appropriate
- `backend/tests/redcap_import_views/TESTING.md`
  - Updated documented counts and informed-consent coverage.

Repro commands:
```bash
pytest -q backend/tests/auth_views/test_register_view.py -k redcap_only_mode_rejects_non_redcap_source
pytest -q backend/tests/redcap_import_views/test_redcap_import_views.py -k "consented or informed_consent or available_patients or import_patient"
```

Execution note:
- Could not run tests in this shell (`pytest: command not found`).

**Test Configuration**:
- Backend Django/MongoEngine test suite
- Targeted auth + REDCap import view tests

## Checklist

- [x] I have read the [guidelines for contributing](https://github.com/fastmachinelearning/hls4ml/blob/main/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have installed and run `pre-commit` on the files I edited or added.
- [x] I have added tests that prove my fix is effective or that my feature works.
