### PR TITLE
bug fitbitbearny connection shows as linked but no wearable data appears sync wearables flow unclear

### DIFF
--- a/FRONTEND_E2E_TEST_DOCUMENTATION.md
+++ b/FRONTEND_E2E_TEST_DOCUMENTATION.md
@@ -22,6 +22,7 @@ frontend/
     therapist-feedback-chips.spec.ts
     therapist-characteristics-space-input.spec.ts
     therapist-interventions-templates.spec.ts
+    therapist-wearables-sync.spec.ts
     TESTING.md
   playwright.config.ts
 ```
@@ -127,6 +128,16 @@ Validates therapist patient-popup Characteristics input behavior:
 - Types multi-word comma-separated values (containing spaces)
 - Verifies the profile save payload keeps internal spaces while normalizing by comma split
 
+### `therapist-wearables-sync.spec.ts`
+
+Validates therapist patient-popup wearables sync behavior:
+- Opens `/therapist` and opens the patient popup via the `Info` action
+- Triggers `POST /wearables/sync-to-redcap/<patient_id>/`
+- Verifies successful sync alert shows period-level statuses
+- Verifies sync payload details are rendered in table form (from `sent_payloads`)
+- Verifies skip reasons are visible (for example `no_fitbit_data_in_period`)
+- Verifies informative backend error messages are shown on failed sync
+
 ---
 
 ## Prerequisites
@@ -195,6 +206,17 @@ E2E_EMAIL_DIR=<email-dir-shared-with-django> \
 npm run test:e2e -- e2e/therapist-characteristics-space-input.spec.ts'
 ```
 
+Run therapist wearables sync regression:
+
+```bash
+docker exec react sh -lc 'cd /app && \
+E2E_API_URL=http://django:8000/api \
+E2E_THERAPIST_LOGIN=<therapist-login> \
+E2E_THERAPIST_PASSWORD=<therapist-password> \
+E2E_EMAIL_DIR=<email-dir-shared-with-django> \
+npm run test:e2e -- e2e/therapist-wearables-sync.spec.ts'
+```
+
 ### Direct host run (without Docker)
 
 From `frontend/`:
@@ -218,7 +240,7 @@ E2E_API_URL=http://127.0.0.1:8001/api npm run test:e2e
 | `E2E_ADMIN_PASSWORD` | Redirect tests only | Seeded admin password |
 | `E2E_THERAPIST_LOGIN` | Therapist login + templates tests | Seeded therapist login identifier |
 | `E2E_THERAPIST_PASSWORD` | Therapist login + templates tests | Seeded therapist password |
-| `E2E_EMAIL_DIR` | Therapist 2FA-based E2E tests | File-based email directory shared with backend for OTP retrieval |
+| `E2E_EMAIL_DIR` | Therapist 2FA-based tests | Directory where Django writes file-based OTP emails (read by E2E helper) |
 
 ## CI Integration
 

--- a/backend/core/services/wearables_redcap_service.py
+++ b/backend/core/services/wearables_redcap_service.py
@@ -233,7 +233,8 @@ def export_wearables_to_redcap(
     patient: Patient,
     event_baseline: Optional[str] = None,
     event_followup: Optional[str] = None,
-) -> Dict[str, str]:
+    return_payloads: bool = False,
+) -> Dict[str, str] | Tuple[Dict[str, str], Dict[str, Dict[str, Any]]]:
     """
     Compute wearables summary for both periods and import into REDCap.
 
@@ -241,6 +242,8 @@ def export_wearables_to_redcap(
     Override per-call or via REDCAP_WEARABLES_EVENT_BASELINE / FOLLOWUP env vars.
 
     Returns {"baseline": "ok" | "skipped" | "error: ...", "followup": ...}
+    Optionally returns payload details when return_payloads=True:
+      (results, payloads)
     """
     project_name = (patient.project or "").strip()
     if not project_name:
@@ -267,10 +270,15 @@ def export_wearables_to_redcap(
     ev_baseline, ev_followup = _resolve_event_names(project_name, event_baseline, event_followup)
 
     results: Dict[str, str] = {}
+    payloads: Dict[str, Dict[str, Any]] = {}
     for period, ev_name in [("baseline", ev_baseline), ("followup", ev_followup)]:
         data = summary.get(period)
         if not data:
             results[period] = "skipped"
+            payloads[period] = {
+                "status": "skipped",
+                "reason": "no_fitbit_data_in_period",
+            }
             logger.info(
                 "Wearables [%s] for %s: no Fitbit data in period — skipped",
                 period,
@@ -287,6 +295,11 @@ def export_wearables_to_redcap(
         if ev_name:
             record["redcap_event_name"] = ev_name
 
+        payloads[period] = {
+            "status": "prepared",
+            "record": record,
+        }
+
         payload = {
             "content": "record",
             "action": "import",
@@ -300,6 +313,7 @@ def export_wearables_to_redcap(
         try:
             _post_redcap(token, payload)
             results[period] = "ok"
+            payloads[period]["status"] = "sent"
             logger.info(
                 "Exported wearables [%s] for %s → REDCap %s (record_id=%s, event=%s)",
                 period,
@@ -310,6 +324,8 @@ def export_wearables_to_redcap(
             )
         except RedcapError as e:
             results[period] = f"error: {e}"
+            payloads[period]["status"] = "error"
+            payloads[period]["error"] = str(e)
             logger.error(
                 "Failed to export wearables [%s] for %s: %s",
                 period,
@@ -317,4 +333,6 @@ def export_wearables_to_redcap(
                 e,
             )
 
+    if return_payloads:
+        return results, payloads
     return results

--- a/backend/core/views/fitbit_sync.py
+++ b/backend/core/views/fitbit_sync.py
@@ -204,7 +204,7 @@ def fetch_fitbit_today_for_user(user) -> int:
         }
         return len(worn_minutes)
 
-    all_dates = {today}
+    all_dates = set()
     for m in series.values():
         if isinstance(m, dict):
             all_dates |= set(m.keys())
@@ -247,6 +247,11 @@ def fetch_fitbit_today_for_user(user) -> int:
             upsert=True,
         )
         upserted += 1
+
+    if upserted == 0:
+        logger.info(f"[fitbit] no wearable payload returned for user={user} on {date_str}; no row written")
+        print(f"[fitbit] no wearable payload returned for user={user} on {date_str}; no row written")
+        return 0
 
     logger.info(f"[fitbit] stored {upserted} row for user={user} on {date_str}")
     print(f"[fitbit] stored {upserted} row for user={user} on {date_str}")

--- a/backend/core/views/fitbit_view.py
+++ b/backend/core/views/fitbit_view.py
@@ -383,7 +383,7 @@ def _merge_thresholds(patient):
 def fitbit_status(request, patient_id):
     user = _resolve_user_for_fitbit_status(patient_id)
     if not user:
-        logger.info("[fitbit_status] unresolved identifier=%s connected=False", patient_id)
+        logger.info("[fitbit_status] unresolved identifier connected=False has_data=False")
         return JsonResponse({"connected": False, "has_data": False, "last_data": None})
 
     connected = FitbitUserToken.objects(user=user).count() > 0
@@ -391,13 +391,7 @@ def fitbit_status(request, patient_id):
     has_data = latest_row is not None
     last_data = latest_row.date.isoformat() if latest_row else None
 
-    logger.info(
-        "[fitbit_status] identifier=%s user=%s connected=%s has_data=%s",
-        patient_id,
-        str(user.id),
-        connected,
-        has_data,
-    )
+    logger.info("[fitbit_status] status connected=%s has_data=%s", connected, has_data)
     return JsonResponse({"connected": connected, "has_data": has_data, "last_data": last_data})
 
 

--- a/backend/core/views/fitbit_view.py
+++ b/backend/core/views/fitbit_view.py
@@ -8,7 +8,6 @@ from django.conf import settings
 from django.http import JsonResponse
 from django.shortcuts import redirect
 from django.utils import timezone
-from django.utils.timezone import is_naive, make_aware
 from django.views.decorators.csrf import csrf_exempt
 from rest_framework.decorators import permission_classes
 from rest_framework.permissions import IsAuthenticated
@@ -17,20 +16,8 @@ from core.models import FitbitData, FitbitUserToken, Patient, User
 
 logger = logging.getLogger(__name__)
 FITBIT_API_URL = "https://api.fitbit.com/1/user/-"
-from django.utils.timezone import is_naive, make_aware, now
 
 from core.views.fitbit_sync import fetch_fitbit_today_for_user
-
-
-def _resolve_patient(patient_id: str):
-    """Try Patient.pk first; then Patient.userId."""
-    try:
-        return Patient.objects.get(pk=patient_id)
-    except Exception:
-        try:
-            return Patient.objects.get(userId=ObjectId(patient_id))
-        except Exception:
-            return None
 
 
 def _sleep_minutes(entry: FitbitData) -> int:
@@ -85,6 +72,25 @@ def _resolve_patient(request, patient_id: str | None):
                 continue
 
     return None
+
+
+def _resolve_user_for_fitbit_status(patient_identifier: str):
+    """
+    Resolve either:
+    - Patient.id -> patient.userId
+    - User.id -> user
+    Returns None when the identifier cannot be resolved.
+    """
+    try:
+        patient = Patient.objects.get(pk=patient_identifier)
+        return patient.userId
+    except Exception:
+        pass
+
+    try:
+        return User.objects.get(pk=patient_identifier)
+    except Exception:
+        return None
 
 
 def avg_excluding_zero(values):
@@ -375,9 +381,24 @@ def _merge_thresholds(patient):
 @csrf_exempt
 @permission_classes([IsAuthenticated])
 def fitbit_status(request, patient_id):
-    connected = FitbitUserToken.objects.filter(user=ObjectId(patient_id)).count() > 0
-    logger.info(f"[fitbit_status] Patient {patient_id} connected: {connected}")
-    return JsonResponse({"connected": connected})
+    user = _resolve_user_for_fitbit_status(patient_id)
+    if not user:
+        logger.info("[fitbit_status] unresolved identifier=%s connected=False", patient_id)
+        return JsonResponse({"connected": False, "has_data": False, "last_data": None})
+
+    connected = FitbitUserToken.objects(user=user).count() > 0
+    latest_row = FitbitData.objects(user=user).order_by("-date").first()
+    has_data = latest_row is not None
+    last_data = latest_row.date.isoformat() if latest_row else None
+
+    logger.info(
+        "[fitbit_status] identifier=%s user=%s connected=%s has_data=%s",
+        patient_id,
+        str(user.id),
+        connected,
+        has_data,
+    )
+    return JsonResponse({"connected": connected, "has_data": has_data, "last_data": last_data})
 
 
 @csrf_exempt

--- a/backend/core/views/wearables_redcap_view.py
+++ b/backend/core/views/wearables_redcap_view.py
@@ -60,7 +60,12 @@ def sync_wearables_to_redcap_view(request, patient_id: str):
 
     try:
         summary = compute_wearables_summary(patient)
-        results = export_wearables_to_redcap(patient, event_baseline, event_followup)
+        results, sent_payloads = export_wearables_to_redcap(
+            patient,
+            event_baseline,
+            event_followup,
+            return_payloads=True,
+        )
     except WearablesSyncError as e:
         return JsonResponse({"error": str(e), "code": e.code}, status=400)
     except ValueError as e:
@@ -71,4 +76,11 @@ def sync_wearables_to_redcap_view(request, patient_id: str):
         logger.exception("Unexpected error syncing wearables")
         return JsonResponse({"error": str(e)}, status=500)
 
-    return JsonResponse({"ok": True, "results": results, "summary": summary})
+    return JsonResponse(
+        {
+            "ok": True,
+            "results": results,
+            "summary": summary,
+            "sent_payloads": sent_payloads,
+        }
+    )

--- a/backend/tests/fitbit_sync/TESTING.md
+++ b/backend/tests/fitbit_sync/TESTING.md
@@ -10,9 +10,9 @@ Tests in [`test_fitbit_sync.py`](test_fitbit_sync.py) cover service logic in
 | Function | Tests |
 |---|---|
 | `get_valid_access_token` | 3 |
-| `fetch_fitbit_today_for_user` | 3 |
+| `fetch_fitbit_today_for_user` | 7 |
 
-**Total: 6 tests**
+**Total: 10 tests**
 
 ---
 
@@ -23,6 +23,7 @@ Tests in [`test_fitbit_sync.py`](test_fitbit_sync.py) cover service logic in
 - Expired-token refresh non-200 failure.
 - Sync short-circuit when no token exists.
 - Full today-sync upsert path with mocked Fitbit API responses.
+- No-row behavior when Fitbit returns no usable payload for the day.
 - Additional today-sync branch coverage:
   - non-200 intraday response path
   - fallback parsing on malformed values

--- a/backend/tests/fitbit_sync/test_fitbit_sync.py
+++ b/backend/tests/fitbit_sync/test_fitbit_sync.py
@@ -166,6 +166,58 @@ def test_fetch_fitbit_today_for_user_upserts_today(mock_get, mock_get_token):
 
 @patch("core.views.fitbit_sync.get_valid_access_token", return_value="access")
 @patch("core.views.fitbit_sync.requests.get")
+def test_fetch_fitbit_today_for_user_does_not_write_empty_row(mock_get, _):
+    user, _token = make_user_with_token(expired=False)
+
+    def mk_resp(status=200, payload=None):
+        r = Mock()
+        r.status_code = status
+        r.json.return_value = payload or {}
+        r.text = "ok"
+        return r
+
+    def side_effect(url, headers=None, timeout=None):
+        if "activities/steps" in url:
+            return mk_resp(payload={"activities-steps": []})
+        if "activities/floors" in url:
+            return mk_resp(status=500, payload={})
+        if "activities/distance" in url:
+            return mk_resp(payload={"activities-distance": []})
+        if "activities/calories" in url:
+            return mk_resp(payload={"activities-calories": []})
+        if "minutesVeryActive" in url:
+            return mk_resp(payload={"activities-minutesVeryActive": []})
+        if "minutesFairlyActive" in url:
+            return mk_resp(payload={"activities-minutesFairlyActive": []})
+        if "minutesLightlyActive" in url:
+            return mk_resp(payload={"activities-minutesLightlyActive": []})
+        if "minutesSedentary" in url:
+            return mk_resp(payload={"activities-minutesSedentary": []})
+        if "activities/heart/date/" in url and "1d/1sec" not in url:
+            return mk_resp(payload={"activities-heart": []})
+        if "active-zone-minutes" in url:
+            return mk_resp(payload={"activities-activeZoneMinutes": []})
+        if "/br/date/" in url:
+            return mk_resp(payload={"br": []})
+        if "/hrv/date/" in url:
+            return mk_resp(payload={"hrv": []})
+        if "/sleep/date/" in url:
+            return mk_resp(payload={"sleep": []})
+        if "activities/list.json" in url:
+            return mk_resp(payload={"activities": []})
+        if "1d/1sec" in url:
+            return mk_resp(payload={"activities-heart-intraday": {"dataset": []}})
+        return mk_resp(payload={})
+
+    mock_get.side_effect = side_effect
+
+    out = fetch_fitbit_today_for_user(user)
+    assert out == 0
+    assert FitbitData.objects(user=user).count() == 0
+
+
+@patch("core.views.fitbit_sync.get_valid_access_token", return_value="access")
+@patch("core.views.fitbit_sync.requests.get")
 @patch("core.views.fitbit_sync.FitbitData.objects")
 def test_fetch_fitbit_today_for_user_covers_branches_and_parsing(mock_objects, mock_get, _):
     user, _token = make_user_with_token(expired=False)

--- a/backend/tests/fitbit_views/TESTING.md
+++ b/backend/tests/fitbit_views/TESTING.md
@@ -9,7 +9,7 @@ This document describes tests in
 
 | Endpoint | HTTP verb | Tests |
 |---|---|---|
-| `/api/fitbit/status/<patient_id>/` | GET | 2 |
+| `/api/fitbit/status/<patient_id>/` | GET | 4 |
 | `/api/fitbit/callback/` | GET | 5 |
 | `/api/fitbit/health-data/<patient_id>/` | GET | 3 |
 | `/api/fitbit/manual_steps/<patient_id>/` | POST/GET | 5 |
@@ -17,13 +17,15 @@ This document describes tests in
 | `health_combined_history(<patient_id>)` | GET (direct view test) | 6 |
 | Helper functions | N/A | 5 |
 
-**Total: 31 tests**
+**Total: 33 tests**
 
 ---
 
 ## Scenarios covered
 
 - Fitbit connection state with/without persisted token.
+- Fitbit status resolution for both `User.id` and `Patient.id`.
+- Fitbit status returns safe false values for unresolved identifiers.
 - OAuth callback redirect branches:
   - missing code
   - missing state

--- a/backend/tests/fitbit_views/test_fitbit_views.py
+++ b/backend/tests/fitbit_views/test_fitbit_views.py
@@ -154,6 +154,32 @@ def test_fitbit_status_true_when_token_exists():
     assert resp.json()["connected"] is True
 
 
+def test_fitbit_status_true_when_called_with_patient_id():
+    _, _, patient_user, patient = create_patient_graph()
+    FitbitUserToken(
+        user=patient_user,
+        access_token="a",
+        refresh_token="r",
+        fitbit_user_id="fu",
+    ).save()
+
+    resp = client.get(f"/api/fitbit/status/{patient.id}/", HTTP_AUTHORIZATION="Bearer test")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["connected"] is True
+    assert body["has_data"] is False
+    assert body["last_data"] is None
+
+
+def test_fitbit_status_unresolved_identifier_returns_false():
+    resp = client.get("/api/fitbit/status/not-an-id/", HTTP_AUTHORIZATION="Bearer test")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["connected"] is False
+    assert body["has_data"] is False
+    assert body["last_data"] is None
+
+
 def test_fitbit_callback_missing_code_redirects():
     _, _, patient_user, _ = create_patient_graph()
     resp = client.get(

--- a/backend/tests/wearables_redcap/test_wearables_redcap_service.py
+++ b/backend/tests/wearables_redcap/test_wearables_redcap_service.py
@@ -484,6 +484,32 @@ class TestExportWearablesToRedcap:
         start = record["monitoring_start"]
         assert start[2] == "-" and start[5] == "-" and start[-4:] == "2024"
 
+    def test_return_payloads_includes_sent_and_skipped_details(self, monkeypatch):
+        reha_end = datetime(2024, 1, 1, tzinfo=dt_tz.utc)
+        user, patient = _make_patient(project="COMPASS", reha_end_date=reha_end)
+        _make_fitbit_day(
+            user,
+            reha_end + timedelta(days=2),
+            steps=5000,
+            active_min=30,
+            inactive_min=300,
+            wear_min=600,
+        )
+        monkeypatch.setenv("REDCAP_TOKEN_COMPASS", "tok")
+
+        with patch(
+            "core.services.wearables_redcap_service.export_record_by_pat_id", return_value=[{"record_id": "99"}]
+        ):
+            with patch("core.services.wearables_redcap_service._post_redcap", return_value='{"count":1}'):
+                results, payloads = export_wearables_to_redcap(patient, return_payloads=True)
+
+        assert results["baseline"] == "ok"
+        assert results["followup"] == "skipped"
+        assert payloads["baseline"]["status"] == "sent"
+        assert payloads["baseline"]["record"]["record_id"] == "99"
+        assert payloads["followup"]["status"] == "skipped"
+        assert payloads["followup"]["reason"] == "no_fitbit_data_in_period"
+
     def test_copain_sleep_format_in_payload(self, monkeypatch):
         reha_end = datetime(2024, 1, 1, tzinfo=dt_tz.utc)
         user, patient = _make_patient(project="COPAIN", reha_end_date=reha_end)

--- a/backend/tests/wearables_redcap/test_wearables_redcap_view.py
+++ b/backend/tests/wearables_redcap/test_wearables_redcap_view.py
@@ -187,6 +187,10 @@ def test_success_returns_results_and_summary():
         "followup": None,
     }
     fake_results = {"baseline": "ok", "followup": "skipped"}
+    fake_payloads = {
+        "baseline": {"status": "sent", "record": {"record_id": "1"}},
+        "followup": {"status": "skipped", "reason": "no_fitbit_data_in_period"},
+    }
 
     with patch(
         "core.views.wearables_redcap_view.compute_wearables_summary",
@@ -194,7 +198,7 @@ def test_success_returns_results_and_summary():
     ):
         with patch(
             "core.views.wearables_redcap_view.export_wearables_to_redcap",
-            return_value=fake_results,
+            return_value=(fake_results, fake_payloads),
         ) as mock_export:
             resp = client.post(URL(patient.id), **AUTH)
 
@@ -203,13 +207,16 @@ def test_success_returns_results_and_summary():
     assert body["ok"] is True
     assert body["results"] == fake_results
     assert body["summary"]["baseline"]["fitbit_steps"] == 5000
+    assert body["sent_payloads"] == fake_payloads
 
     # export was called without explicit event names (body was empty)
     args, kwargs = mock_export.call_args
     event_b = args[1] if len(args) > 1 else kwargs.get("event_baseline")
     event_f = args[2] if len(args) > 2 else kwargs.get("event_followup")
+    return_payloads = args[3] if len(args) > 3 else kwargs.get("return_payloads")
     assert event_b is None
     assert event_f is None
+    assert return_payloads is True
 
 
 def test_event_names_from_body_passed_to_service():
@@ -221,7 +228,13 @@ def test_event_names_from_body_passed_to_service():
     ):
         with patch(
             "core.views.wearables_redcap_view.export_wearables_to_redcap",
-            return_value={"baseline": "skipped", "followup": "skipped"},
+            return_value=(
+                {"baseline": "skipped", "followup": "skipped"},
+                {
+                    "baseline": {"status": "skipped", "reason": "no_fitbit_data_in_period"},
+                    "followup": {"status": "skipped", "reason": "no_fitbit_data_in_period"},
+                },
+            ),
         ) as mock_export:
             resp = client.post(
                 URL(patient.id),
@@ -240,6 +253,8 @@ def test_event_names_from_body_passed_to_service():
     args, kwargs = mock_export.call_args
     assert args[1] == "custom_bl_arm_1" or kwargs.get("event_baseline") == "custom_bl_arm_1"
     assert args[2] == "custom_fu_arm_1" or kwargs.get("event_followup") == "custom_fu_arm_1"
+    return_payloads = kwargs.get("return_payloads") if "return_payloads" in kwargs else (args[3] if len(args) > 3 else None)
+    assert return_payloads is True
 
 
 def test_invalid_json_body_treated_as_empty():
@@ -251,7 +266,13 @@ def test_invalid_json_body_treated_as_empty():
     ):
         with patch(
             "core.views.wearables_redcap_view.export_wearables_to_redcap",
-            return_value={"baseline": "skipped", "followup": "skipped"},
+            return_value=(
+                {"baseline": "skipped", "followup": "skipped"},
+                {
+                    "baseline": {"status": "skipped", "reason": "no_fitbit_data_in_period"},
+                    "followup": {"status": "skipped", "reason": "no_fitbit_data_in_period"},
+                },
+            ),
         ):
             resp = client.post(
                 URL(patient.id),

--- a/backend/tests/wearables_redcap/test_wearables_redcap_view.py
+++ b/backend/tests/wearables_redcap/test_wearables_redcap_view.py
@@ -253,7 +253,9 @@ def test_event_names_from_body_passed_to_service():
     args, kwargs = mock_export.call_args
     assert args[1] == "custom_bl_arm_1" or kwargs.get("event_baseline") == "custom_bl_arm_1"
     assert args[2] == "custom_fu_arm_1" or kwargs.get("event_followup") == "custom_fu_arm_1"
-    return_payloads = kwargs.get("return_payloads") if "return_payloads" in kwargs else (args[3] if len(args) > 3 else None)
+    return_payloads = (
+        kwargs.get("return_payloads") if "return_payloads" in kwargs else (args[3] if len(args) > 3 else None)
+    )
     assert return_payloads is True
 
 

--- a/docs/09-API_DOCUMENTATION.md
+++ b/docs/09-API_DOCUMENTATION.md
@@ -1755,11 +1755,33 @@ If omitted, defaults come from `REDCAP_WEARABLES_EVENT_BASELINE` / `REDCAP_WEARA
       "sleep_duration": "07:30"
     },
     "followup": null
+  },
+  "sent_payloads": {
+    "baseline": {
+      "status": "sent",
+      "record": {
+        "record_id": "99",
+        "monitoring_start": "03-01-2024",
+        "monitoring_end": "09-01-2024",
+        "monitoring_days": "7",
+        "fitbit_steps": "6843",
+        "fitbit_pa": "42",
+        "fitbit_inactivity": "891",
+        "sleep_duration": "07:30",
+        "wearables_complete": "1",
+        "redcap_event_name": "visit_baseline_arm_1"
+      }
+    },
+    "followup": {
+      "status": "skipped",
+      "reason": "no_fitbit_data_in_period"
+    }
   }
 }
 ```
 
 `results` values: `"ok"` (written), `"skipped"` (no Fitbit data in period), or `"error: <message>"`.
+`sent_payloads` contains what was prepared/sent per period (`status`: `sent`, `skipped`, or `error`).
 
 **Errors:**
 

--- a/docs/wearables_redcap_sync.md
+++ b/docs/wearables_redcap_sync.md
@@ -106,7 +106,13 @@ The **"Sync Wearables"** button appears in the footer (view mode only, not while
 
 - The button is disabled while a sync is in progress
 - On success a green alert shows the per-period result (`ok` / `skipped`)
+- The success alert also shows the per-period payload (`sent_payloads`) that was prepared/sent to REDCap
 - On failure a red alert shows the error message
+
+### Interpreting `ok` vs `skipped`
+
+- `ok`: a best-monitoring week was found for that period and exported to REDCap.
+- `skipped`: the patient is eligible, but no Fitbit records existed in that period, so nothing is written.
 
 ---
 
@@ -138,6 +144,27 @@ Example success response:
       "sleep_duration": "07:30"
     },
     "followup": null
+  },
+  "sent_payloads": {
+    "baseline": {
+      "status": "sent",
+      "record": {
+        "record_id": "123",
+        "monitoring_start": "03-01-2024",
+        "monitoring_end": "09-01-2024",
+        "monitoring_days": "7",
+        "fitbit_steps": "6843",
+        "fitbit_pa": "42",
+        "fitbit_inactivity": "891",
+        "sleep_duration": "07:30",
+        "wearables_complete": "1",
+        "redcap_event_name": "visit_baseline_arm_1"
+      }
+    },
+    "followup": {
+      "status": "skipped",
+      "reason": "no_fitbit_data_in_period"
+    }
   }
 }
 ```
@@ -149,6 +176,21 @@ Possible error responses:
 | 400 | Patient has no `reha_end_date`, or no `project` set |
 | 404 | `patient_id` not found |
 | 502 | REDCap API rejected the write (check `detail` field for the REDCap error message) |
+
+---
+
+## Fitbit connection and data visibility
+
+- Fitbit OAuth can be successfully connected while daily wearable data is still empty.
+- The backend now avoids creating placeholder Fitbit rows when no upstream Fitbit payload is returned.
+- This prevents misleading "synced" records with all-zero values.
+- `GET /api/fitbit/status/<id>/` accepts both `Patient.id` and `User.id` and returns:
+  - `connected`: token exists
+  - `has_data`: at least one stored Fitbit row exists
+  - `last_data`: latest stored Fitbit timestamp (or `null`)
+
+Practical implication:
+- If `connected=true` and `has_data=false`, OAuth is linked but Fitbit has not provided wearable payload yet (or permissions/scopes/device wear are missing).
 
 ---
 

--- a/frontend/e2e/TESTING.md
+++ b/frontend/e2e/TESTING.md
@@ -25,6 +25,7 @@ Current scope starts with the home/login journey.
 | `therapist-health-export-questionnaire-csv.spec.ts` | Therapist Health page export regression: CSV questionnaire section includes question text, multi-answer keys/texts, comments, and media URLs. Requires `E2E_THERAPIST_LOGIN` / `E2E_THERAPIST_PASSWORD` / `E2E_PATIENT_ID`.                                                                                                                                   |
 | `therapist-feedback-chips.spec.ts`                  | Therapist patient-list feedback chip logic: uses mocked `/api/therapists/<id>/patients` response to verify intervention-feedback-based chip level and tooltip text, and that Health chip remains hidden for ongoing patients. Requires seeded therapist login.                                                                                                |
 | `therapist-characteristics-space-input.spec.ts`     | Therapist patient-popup characteristics regression: verifies multi-word values can be typed in comma-separated fields and that save payload preserves spaces within words (normalizing by comma). Requires `E2E_THERAPIST_LOGIN` / `E2E_THERAPIST_PASSWORD` / `E2E_EMAIL_DIR`.                                                                                |
+| `therapist-wearables-sync.spec.ts`                  | Therapist patient popup wearables sync regression: verifies sync success status (`ok`/`skipped`), payload detail rendering (`sent_payloads` table view), and informative backend error visibility on failed sync. Requires `E2E_THERAPIST_LOGIN` / `E2E_THERAPIST_PASSWORD` / `E2E_EMAIL_DIR`.                                                                |
 | `patient-health-questionnaire-ui.spec.ts`           | Patient UI questionnaire flow: therapist assigns questionnaire (API setup), patient logs in, answers popup questions, and submits to `/patients/feedback/questionaire/`. Requires seeded therapist + patient credentials.                                                                                                                                     |
 
 ---
@@ -112,6 +113,11 @@ Current scope starts with the home/login journey.
   - Opens patient popup from `/therapist`
   - Enters multi-word comma-separated text in Characteristics input
   - Confirms saved profile payload keeps internal spaces while normalizing by commas
+- Therapist wearables sync (`therapist-wearables-sync.spec.ts`, seeded therapist required):
+  - Opens patient popup from `/therapist` and triggers `POST /wearables/sync-to-redcap/<patient_id>/`
+  - Confirms success alert shows per-period sync outcomes and the rendered payload detail table (`sent_payloads`)
+  - Confirms skipped period reason is visible (for example `no_fitbit_data_in_period`)
+  - Confirms sync failure shows informative backend error text to the user
 - Patient questionnaire UI submission (`patient-health-questionnaire-ui.spec.ts`, seeded therapist + patient required):
   - Setup assigns a due Healthstatus questionnaire for the patient
   - Patient login opens the questionnaire popup
@@ -164,7 +170,7 @@ npx playwright install --with-deps chromium
 - `E2E_ADMIN_PASSWORD`: seeded admin password.
 - `E2E_THERAPIST_LOGIN`: seeded therapist login identifier (email).
 - `E2E_THERAPIST_PASSWORD`: seeded therapist password.
-- `E2E_EMAIL_DIR`: directory used by Django file-based email backend so Playwright can read therapist 2FA codes.
+- `E2E_EMAIL_DIR`: directory used by Django file-based email backend so E2E can read therapist OTP codes.
 
 Example:
 
@@ -259,6 +265,16 @@ E2E_THERAPIST_LOGIN=<seeded-therapist-email> \
 E2E_THERAPIST_PASSWORD=<seeded-therapist-password> \
 E2E_EMAIL_DIR=<shared-email-dir> \
 npm run test:e2e -- e2e/therapist-characteristics-space-input.spec.ts
+```
+
+Therapist wearables sync regression (requires seeded therapist + OTP email directory):
+
+```bash
+E2E_API_URL=http://localhost:8001/api \
+E2E_THERAPIST_LOGIN=<seeded-therapist-email> \
+E2E_THERAPIST_PASSWORD=<seeded-therapist-password> \
+E2E_EMAIL_DIR=<shared-email-dir> \
+npm run test:e2e -- e2e/therapist-wearables-sync.spec.ts
 ```
 
 Patient questionnaire popup submission (requires seeded therapist + patient):

--- a/frontend/e2e/therapist-wearables-sync.spec.ts
+++ b/frontend/e2e/therapist-wearables-sync.spec.ts
@@ -1,0 +1,174 @@
+import { expect, test } from '@playwright/test';
+
+import { loginAsTherapist } from './helpers/auth';
+
+function envs() {
+  return {
+    therapistLogin: process.env.E2E_THERAPIST_LOGIN,
+    therapistPassword: process.env.E2E_THERAPIST_PASSWORD,
+    emailDir: process.env.E2E_EMAIL_DIR,
+  };
+}
+
+function skipUnlessSeeded(t: typeof test) {
+  const { therapistLogin, therapistPassword, emailDir } = envs();
+  t.skip(
+    !therapistLogin || !therapistPassword || !emailDir,
+    'Missing E2E_THERAPIST_LOGIN / E2E_THERAPIST_PASSWORD / E2E_EMAIL_DIR — skipping seeded E2E tests'
+  );
+}
+
+async function mockPatientPopupPrereqs(page: Parameters<Parameters<typeof test>[1]>[0]) {
+  await page.route('**/users/*/profile', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        _id: '680000000000000000000001',
+        first_name: 'E2E',
+        name: 'Patient',
+        patient_code: 'P-E2E-001',
+        redcap_project: 'COMPASS',
+        redcap_identifier: 'P-E2E-001',
+      }),
+    });
+  });
+
+  await page.route('**/redcap/patient/**', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        matches: [
+          {
+            project: 'COMPASS',
+            rows: [{ record_id: '99', pat_id: 'P-E2E-001' }],
+          },
+        ],
+      }),
+    });
+  });
+
+  await page.route('**/patients/*/thresholds/', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        thresholds: {
+          steps_goal: 10000,
+          active_minutes_green: 30,
+          active_minutes_yellow: 20,
+          sleep_green_min: 420,
+          sleep_yellow_min: 360,
+          bp_sys_green_max: 129,
+          bp_sys_yellow_max: 139,
+          bp_dia_green_max: 84,
+          bp_dia_yellow_max: 89,
+        },
+        thresholds_history: [],
+      }),
+    });
+  });
+}
+
+async function openPatientPopup(page: Parameters<Parameters<typeof test>[1]>[0]) {
+  await page.goto('/therapist');
+
+  const infoBtn = page.getByRole('button', { name: /info/i }).first();
+  await expect(infoBtn).toBeVisible({ timeout: 15000 });
+  await infoBtn.click();
+
+  await expect(page.getByRole('button', { name: /sync wearables/i })).toBeVisible({
+    timeout: 10000,
+  });
+}
+
+test.describe('Therapist patient popup wearables sync', () => {
+  test.beforeEach(async ({ page }) => {
+    skipUnlessSeeded(test);
+    await loginAsTherapist(page);
+    await mockPatientPopupPrereqs(page);
+  });
+
+  test('shows per-period sync results and payload details when sync succeeds', async ({ page }) => {
+    skipUnlessSeeded(test);
+
+    await page.route('**/wearables/sync-to-redcap/*/', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          ok: true,
+          results: {
+            baseline: 'ok',
+            followup: 'skipped',
+          },
+          sent_payloads: {
+            baseline: {
+              status: 'sent',
+              record: {
+                record_id: '99',
+                monitoring_start: '03-01-2024',
+                monitoring_end: '09-01-2024',
+                monitoring_days: '7',
+                fitbit_steps: '6843',
+                redcap_event_name: 'visit_baseline_arm_1',
+                wearables_complete: '1',
+              },
+            },
+            followup: {
+              status: 'skipped',
+              reason: 'no_fitbit_data_in_period',
+            },
+          },
+        }),
+      });
+    });
+
+    await openPatientPopup(page);
+
+    const syncReq = page.waitForRequest(
+      (req) => req.method() === 'POST' && req.url().includes('/wearables/sync-to-redcap/')
+    );
+
+    await page.getByRole('button', { name: /sync wearables/i }).click();
+
+    await syncReq;
+
+    const successAlert = page
+      .locator('.alert-success')
+      .filter({ hasText: /wearables synced to redcap/i });
+    await expect(successAlert).toBeVisible({ timeout: 10000 });
+    await expect(successAlert.getByText(/baseline/i)).toBeVisible();
+    await expect(successAlert.getByText(/followup/i)).toBeVisible();
+    await expect(successAlert.getByText(/no_fitbit_data_in_period/i)).toBeVisible();
+
+    await expect(successAlert.getByText('record_id')).toBeVisible();
+    await expect(successAlert.getByText('99')).toBeVisible();
+    await expect(successAlert.getByText('redcap_event_name')).toBeVisible();
+    await expect(successAlert.getByText('visit_baseline_arm_1')).toBeVisible();
+    await expect(successAlert.getByText('wearables_complete')).toBeVisible();
+  });
+
+  test('shows backend error reason when sync fails', async ({ page }) => {
+    skipUnlessSeeded(test);
+
+    await page.route('**/wearables/sync-to-redcap/*/', async (route) => {
+      await route.fulfill({
+        status: 400,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          error: 'No REDCap record found for patient_code=P-E2E-001 in project=COMPASS',
+        }),
+      });
+    });
+
+    await openPatientPopup(page);
+
+    await page.getByRole('button', { name: /sync wearables/i }).click();
+
+    const errorAlert = page.locator('.alert').filter({ hasText: /no redcap record found/i });
+    await expect(errorAlert).toBeVisible({ timeout: 10000 });
+    await expect(errorAlert).toContainText('project=COMPASS');
+  });
+});

--- a/frontend/src/components/TherapistPatientPage/PatientPopup.tsx
+++ b/frontend/src/components/TherapistPatientPage/PatientPopup.tsx
@@ -347,13 +347,65 @@ const PatientPopup: React.FC<PatientPopupProps> = observer(({ patient_id, show, 
                   {Object.entries(store.wearablesSyncResult).map(([period, status]) => (
                     <li key={period}>
                       {t(period)}: <code>{status}</code>
+                      {store.wearablesSyncPayloads?.[period]?.reason && (
+                        <span className="ms-2 text-muted">
+                          ({store.wearablesSyncPayloads[period].reason})
+                        </span>
+                      )}
                     </li>
                   ))}
                 </ul>
+                {store.wearablesSyncPayloads && (
+                  <div className="mt-2">
+                    <div className="small text-muted mb-1">
+                      {t('Payload sent to REDCap (by period)')}
+                    </div>
+                    {Object.entries(store.wearablesSyncPayloads).map(([period, payload]) => {
+                      const details = (payload as any) || {};
+                      const record = details.record || {};
+                      return (
+                        <div key={period} className="mb-2 p-2 bg-light border rounded">
+                          <div className="fw-semibold mb-1">{t(period)}</div>
+                          <Table size="sm" bordered className="mb-0">
+                            <tbody>
+                              <tr>
+                                <td style={{ width: '35%' }}>{t('status')}</td>
+                                <td>
+                                  <code>{String(details.status ?? 'unknown')}</code>
+                                </td>
+                              </tr>
+                              {details.reason && (
+                                <tr>
+                                  <td>{t('reason')}</td>
+                                  <td>{String(details.reason)}</td>
+                                </tr>
+                              )}
+                              {details.error && (
+                                <tr>
+                                  <td>{t('Error')}</td>
+                                  <td>{String(details.error)}</td>
+                                </tr>
+                              )}
+                              {Object.entries(record).map(([field, value]) => (
+                                <tr key={`${period}-${field}`}>
+                                  <td>{field}</td>
+                                  <td>{String(value)}</td>
+                                </tr>
+                              ))}
+                            </tbody>
+                          </Table>
+                        </div>
+                      );
+                    })}
+                  </div>
+                )}
                 <button
                   type="button"
                   className="btn-close"
-                  onClick={() => (store.wearablesSyncResult = null)}
+                  onClick={() => {
+                    store.wearablesSyncResult = null;
+                    store.wearablesSyncPayloads = null;
+                  }}
                   aria-label={t('Close')}
                 />
               </div>

--- a/frontend/src/stores/patientPopupStore.ts
+++ b/frontend/src/stores/patientPopupStore.ts
@@ -749,6 +749,7 @@ export class PatientPopupStore {
   // -------------------------
   wearablesSyncing = false;
   wearablesSyncResult: Record<string, string> | null = null;
+  wearablesSyncPayloads: Record<string, any> | null = null;
   wearablesSyncError: string | null = null;
 
   async syncWearablesToRedcap(
@@ -758,6 +759,7 @@ export class PatientPopupStore {
   ) {
     this.wearablesSyncing = true;
     this.wearablesSyncResult = null;
+    this.wearablesSyncPayloads = null;
     this.wearablesSyncError = null;
     try {
       const body: Record<string, string> = {};
@@ -766,6 +768,7 @@ export class PatientPopupStore {
       const res = await apiClient.post(`/wearables/sync-to-redcap/${this.patientId}/`, body);
       runInAction(() => {
         this.wearablesSyncResult = (res.data as any)?.results ?? {};
+        this.wearablesSyncPayloads = (res.data as any)?.sent_payloads ?? null;
       });
     } catch (err: any) {
       const api = err?.response?.data;


### PR DESCRIPTION
# Description

This PR improves Fitbit and REDCap wearables sync visibility so therapists can distinguish between:
- OAuth connection success, and
- actual wearable data availability/sync results.

Motivation and context:
- A patient could appear “Fitbit connected” while no wearable payload had been stored yet.
- Sync flows needed clearer backend/FE feedback about what was sent, skipped, or failed.

What changed:

Backend
- `backend/core/views/fitbit_view.py`
  - Improved `/api/fitbit/status/<id>/` resolution to accept both `Patient.id` and `User.id`.
  - Response now includes:
    - `connected`
    - `has_data`
    - `last_data`
  - Unresolved identifiers return safe false/null values.
- `backend/core/views/fitbit_sync.py`
  - Avoids writing empty Fitbit rows when no wearable payload is returned.
  - Adds logging for “no payload returned” cases.
- `backend/core/services/wearables_redcap_service.py`
  - Added `return_payloads` support in `export_wearables_to_redcap(...)`.
  - Returns period-level payload metadata (`sent` / `skipped` / `error`) including skip reason (`no_fitbit_data_in_period`) and prepared record details.
- `backend/core/views/wearables_redcap_view.py`
  - Sync endpoint now returns `sent_payloads` in response alongside `results` and `summary`.

Frontend
- `frontend/src/stores/patientPopupStore.ts`
  - Stores `sent_payloads` response in `wearablesSyncPayloads`.
- `frontend/src/components/TherapistPatientPage/PatientPopup.tsx`
  - Displays per-period sync status plus payload details table.
  - Shows skip reasons and per-period error details.
  - Clears both result and payload state when dismissed.
- Added E2E test:
  - `frontend/e2e/therapist-wearables-sync.spec.ts`
  - Covers successful sync rendering (`ok`/`skipped`, payload table) and backend error visibility.

Docs and test docs
- Updated:
  - `docs/09-API_DOCUMENTATION.md`
  - `docs/wearables_redcap_sync.md`
  - `FRONTEND_E2E_TEST_DOCUMENTATION.md`
  - `frontend/e2e/TESTING.md`
  - `backend/tests/fitbit_sync/TESTING.md`
  - `backend/tests/fitbit_views/TESTING.md`

Dependencies:
- No new runtime dependencies.

## Related Issue
[#152](https://github.com/ARTORG-GERONTECHNOLOGY/Bearny-RehaAdvisor/issues/152)

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Documentation update
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] A new research paper code implementation
- [ ] Other (Specify)

## Tests

Backend tests added/updated:
- `backend/tests/fitbit_sync/test_fitbit_sync.py`
  - Added coverage for “no wearable payload => no row written”.
- `backend/tests/fitbit_views/test_fitbit_views.py`
  - Added Fitbit status coverage for `Patient.id` resolution and unresolved identifiers.
- `backend/tests/wearables_redcap/test_wearables_redcap_service.py`
  - Added coverage for `return_payloads=True` with sent/skipped details.
- `backend/tests/wearables_redcap/test_wearables_redcap_view.py`
  - Updated to validate `sent_payloads` in API response and `return_payloads=True` passthrough.

Frontend E2E:
- `frontend/e2e/therapist-wearables-sync.spec.ts`
  - Verifies success status rendering, payload detail rendering, skip reason visibility, and backend error messaging.

Suggested commands to reproduce:
```bash
pytest -q backend/tests/fitbit_sync/test_fitbit_sync.py
pytest -q backend/tests/fitbit_views/test_fitbit_views.py
pytest -q backend/tests/wearables_redcap/test_wearables_redcap_service.py
pytest -q backend/tests/wearables_redcap/test_wearables_redcap_view.py
cd frontend && npm run test:e2e -- e2e/therapist-wearables-sync.spec.ts
```

Execution note:
- Not executed in this shell environment as part of this PR write-up.

**Test Configuration**:
- Backend: Django + MongoEngine test suite
- Frontend: Playwright E2E (seeded therapist env vars required)

## Checklist

- [X] I have read the [guidelines for contributing](https://github.com/fastmachinelearning/hls4ml/blob/main/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [X] I have installed and run `pre-commit` on the files I edited or added.
- [x] I have added tests that prove my fix is effective or that my feature works.