### PR TITLE
bug text input in characteristics section does not accept spaces

### DIFF
--- a/FRONTEND_E2E_TEST_DOCUMENTATION.md
+++ b/FRONTEND_E2E_TEST_DOCUMENTATION.md
@@ -20,6 +20,7 @@ frontend/
     home-register-therapist.spec.ts
     patient-page.spec.ts
     therapist-feedback-chips.spec.ts
+    therapist-characteristics-space-input.spec.ts
     therapist-interventions-templates.spec.ts
     TESTING.md
   playwright.config.ts
@@ -118,6 +119,14 @@ Validates therapist patient-list feedback traffic lights on `/therapist` using c
   - Feedback tooltip includes average-score text for recent answered days
   - Health chip is hidden for ongoing (active) patients
 
+### `therapist-characteristics-space-input.spec.ts`
+
+Validates therapist patient-popup Characteristics input behavior:
+- Opens `/therapist` and opens a patient popup via the `Info` button
+- Switches to the Characteristics tab in edit mode
+- Types multi-word comma-separated values (containing spaces)
+- Verifies the profile save payload keeps internal spaces while normalizing by comma split
+
 ---
 
 ## Prerequisites
@@ -175,6 +184,17 @@ E2E_EMAIL_DIR=<shared-email-dir> \
 npm run test:e2e -- e2e/therapist-feedback-chips.spec.ts'
 ```
 
+Run therapist characteristics space-input regression:
+
+```bash
+docker exec react sh -lc 'cd /app && \
+E2E_API_URL=http://django:8000/api \
+E2E_THERAPIST_LOGIN=<therapist-login> \
+E2E_THERAPIST_PASSWORD=<therapist-password> \
+E2E_EMAIL_DIR=<email-dir-shared-with-django> \
+npm run test:e2e -- e2e/therapist-characteristics-space-input.spec.ts'
+```
+
 ### Direct host run (without Docker)
 
 From `frontend/`:
@@ -214,6 +234,7 @@ The `frontend-e2e` job:
 - Runs therapist 2FA E2E test when `E2E_THERAPIST_LOGIN` and `E2E_THERAPIST_PASSWORD` are configured
 - Runs named-template E2E tests (`e2e/therapist-interventions-templates.spec.ts`) when `E2E_THERAPIST_LOGIN` and `E2E_THERAPIST_PASSWORD` are configured
 - Runs therapist feedback-chip E2E test (`e2e/therapist-feedback-chips.spec.ts`) when therapist creds are configured
+- Runs therapist characteristics space-input E2E test (`e2e/therapist-characteristics-space-input.spec.ts`) when therapist creds and `E2E_EMAIL_DIR` are configured
 
 Required GitHub secrets for seeded redirect tests:
 - `E2E_PATIENT_LOGIN`

--- a/backend/tests/user_views/TESTING.md
+++ b/backend/tests/user_views/TESTING.md
@@ -10,13 +10,13 @@ under `/api/users/` and `/api/admin/`.
 
 | Endpoint | HTTP verbs | View function | Tests |
 |---|---|---|---|
-| `/api/users/<user_id>/profile/` | GET, PUT, DELETE | `user_profile_view` | 16 |
+| `/api/users/<user_id>/profile/` | GET, PUT, DELETE | `user_profile_view` | 17 |
 | `/api/admin/pending-users/` | GET | `get_pending_users` | 4 |
 | `/api/admin/accept-user/` | POST | `accept_user` | 5 |
 | `/api/admin/decline-user/` | POST | `decline_user` | 5 |
 | `/api/users/<user_id>/change-password/` | PUT | `change_password` | 5 |
 
-**Total: 35 tests**
+**Total: 36 tests**
 
 ---
 
@@ -112,6 +112,7 @@ check_password(old) ──Fail──► 403 "Old password incorrect"
 | `test_user_profile_view_update_password_missing_new` | Only `oldPassword` sent | 400, 'New password required' |
 | `test_user_profile_view_update_therapist_fields` | Valid `first_name`, `name` | 200, updated keys in response |
 | `test_user_profile_view_update_patient_reha_end_date` | Valid `reha_end_date` string | 200, `reha_end_date` in updated |
+| `test_user_profile_view_update_patient_characteristics_preserves_internal_spaces` | Multi-word patient characteristics values (lists + restrictions) | 200; persisted values keep internal spaces |
 | `test_user_profile_view_update_invalid_date_format` | `reha_end_date = "not-a-date"` | 400, 'Invalid date format' |
 | `test_user_profile_view_update_invalid_email` | `email = "not-valid"` | 400, 'Invalid email' |
 | `test_user_profile_view_update_invalid_phone` | `phone = "not-a-phone"` | 400, 'Invalid phone' |

--- a/backend/tests/user_views/test_user_views.py
+++ b/backend/tests/user_views/test_user_views.py
@@ -455,6 +455,34 @@ def test_user_profile_view_update_patient_reha_end_date():
     assert "reha_end_date" in resp.json().get("updated", {})
 
 
+def test_user_profile_view_update_patient_characteristics_preserves_internal_spaces():
+    """
+    PUT patient characteristic fields with multi-word values should preserve
+    internal spaces in persisted data (regression for FE characteristics input).
+    """
+    user, patient = create_patient()
+    payload = {
+        "lifestyle": ["Very active person", "Morning walk group"],
+        "personal_goals": ["Improve walking endurance"],
+        "social_support": ["Family support network"],
+        "restrictions": "Needs support during long walks",
+    }
+
+    resp = client.put(
+        f"/api/users/{user.id}/profile/",
+        data=json.dumps(payload),
+        content_type="application/json",
+        HTTP_AUTHORIZATION="Bearer test",
+    )
+
+    assert resp.status_code == 200
+    patient.reload()
+    assert patient.lifestyle == ["Very active person", "Morning walk group"]
+    assert patient.personal_goals == ["Improve walking endurance"]
+    assert patient.social_support == ["Family support network"]
+    assert patient.restrictions == "Needs support during long walks"
+
+
 def test_user_profile_view_update_invalid_date_format():
     """
     PUT an unparseable ``reha_end_date`` returns 400 with

--- a/frontend/e2e/TESTING.md
+++ b/frontend/e2e/TESTING.md
@@ -24,6 +24,7 @@ Current scope starts with the home/login journey.
 | `therapist-rehabtable-questionnaires.spec.ts`       | Therapist RehabTable questionnaire tab: endpoint fetches, schedule modal open, questionnaire-content visibility, and answered-results rendering for assigned questionnaires. Requires `E2E_THERAPIST_LOGIN` / `E2E_THERAPIST_PASSWORD` / `E2E_PATIENT_ID`.                                                                                                    |
 | `therapist-health-export-questionnaire-csv.spec.ts` | Therapist Health page export regression: CSV questionnaire section includes question text, multi-answer keys/texts, comments, and media URLs. Requires `E2E_THERAPIST_LOGIN` / `E2E_THERAPIST_PASSWORD` / `E2E_PATIENT_ID`.                                                                                                                                   |
 | `therapist-feedback-chips.spec.ts`                  | Therapist patient-list feedback chip logic: uses mocked `/api/therapists/<id>/patients` response to verify intervention-feedback-based chip level and tooltip text, and that Health chip remains hidden for ongoing patients. Requires seeded therapist login.                                                                                                |
+| `therapist-characteristics-space-input.spec.ts`     | Therapist patient-popup characteristics regression: verifies multi-word values can be typed in comma-separated fields and that save payload preserves spaces within words (normalizing by comma). Requires `E2E_THERAPIST_LOGIN` / `E2E_THERAPIST_PASSWORD` / `E2E_EMAIL_DIR`.                                                                                |
 | `patient-health-questionnaire-ui.spec.ts`           | Patient UI questionnaire flow: therapist assigns questionnaire (API setup), patient logs in, answers popup questions, and submits to `/patients/feedback/questionaire/`. Requires seeded therapist + patient credentials.                                                                                                                                     |
 
 ---
@@ -107,6 +108,10 @@ Current scope starts with the home/login journey.
   - Verifies `Feedback good` for recent/high-average intervention feedback and tooltip average text
   - Verifies `Feedback bad` when trend is lower
   - Verifies Health chip is hidden for ongoing (active) patient rows
+- Therapist characteristics space-input regression (`therapist-characteristics-space-input.spec.ts`, seeded therapist required):
+  - Opens patient popup from `/therapist`
+  - Enters multi-word comma-separated text in Characteristics input
+  - Confirms saved profile payload keeps internal spaces while normalizing by commas
 - Patient questionnaire UI submission (`patient-health-questionnaire-ui.spec.ts`, seeded therapist + patient required):
   - Setup assigns a due Healthstatus questionnaire for the patient
   - Patient login opens the questionnaire popup
@@ -244,6 +249,16 @@ E2E_THERAPIST_LOGIN=<seeded-therapist-email> \
 E2E_THERAPIST_PASSWORD=<seeded-therapist-password> \
 E2E_EMAIL_DIR=<shared-email-dir-for-2fa> \
 npm run test:e2e -- e2e/therapist-feedback-chips.spec.ts
+```
+
+Therapist characteristics space-input regression (requires seeded therapist + OTP email directory):
+
+```bash
+E2E_API_URL=http://localhost:8001/api \
+E2E_THERAPIST_LOGIN=<seeded-therapist-email> \
+E2E_THERAPIST_PASSWORD=<seeded-therapist-password> \
+E2E_EMAIL_DIR=<shared-email-dir> \
+npm run test:e2e -- e2e/therapist-characteristics-space-input.spec.ts
 ```
 
 Patient questionnaire popup submission (requires seeded therapist + patient):

--- a/frontend/e2e/therapist-characteristics-space-input.spec.ts
+++ b/frontend/e2e/therapist-characteristics-space-input.spec.ts
@@ -1,0 +1,138 @@
+import { expect, test } from '@playwright/test';
+
+import { loginAsTherapist } from './helpers/auth';
+
+function envs() {
+  return {
+    therapistLogin: process.env.E2E_THERAPIST_LOGIN,
+    therapistPassword: process.env.E2E_THERAPIST_PASSWORD,
+    emailDir: process.env.E2E_EMAIL_DIR,
+  };
+}
+
+function skipUnlessSeeded(t: typeof test) {
+  const { therapistLogin, therapistPassword, emailDir } = envs();
+  t.skip(
+    !therapistLogin || !therapistPassword || !emailDir,
+    'Missing E2E_THERAPIST_LOGIN / E2E_THERAPIST_PASSWORD / E2E_EMAIL_DIR — skipping seeded E2E tests'
+  );
+}
+
+test.describe('Therapist patient popup characteristics input', () => {
+  test.beforeEach(async ({ page }) => {
+    skipUnlessSeeded(test);
+    await loginAsTherapist(page);
+  });
+
+  test('allows multi-word characteristics input and saves normalized comma-separated values', async ({
+    page,
+  }) => {
+    skipUnlessSeeded(test);
+
+    const patientId = '680000000000000000000001';
+    const mockedPatients = [
+      {
+        _id: patientId,
+        first_name: 'E2E',
+        name: 'Patient',
+        diagnosis: ['Stroke'],
+        sex: 'Male',
+        duration: 30,
+        created_at: '2026-01-10T00:00:00.000Z',
+      },
+    ];
+
+    let profile = {
+      _id: patientId,
+      first_name: 'E2E',
+      name: 'Patient',
+      email: 'e2e.patient@example.com',
+      phone: '+41790000000',
+      function: ['Cardiology'],
+      diagnosis: ['Stroke'],
+      lifestyle: [],
+      personal_goals: [],
+      social_support: [],
+      restrictions: '',
+    };
+
+    await page.route('**/therapists/*/patients', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(mockedPatients),
+      });
+    });
+
+    await page.route(`**/users/${patientId}/profile*`, async (route) => {
+      const req = route.request();
+      if (req.method() === 'GET') {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(profile),
+        });
+        return;
+      }
+
+      if (req.method() === 'PUT') {
+        const body = JSON.parse(req.postData() || '{}');
+        profile = { ...profile, ...body };
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ message: 'Profile updated', updated: body }),
+        });
+        return;
+      }
+
+      await route.fulfill({ status: 405, body: 'Method not allowed' });
+    });
+
+    await page.route(`**/patients/${patientId}/thresholds/`, async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          thresholds: {
+            steps_goal: 10000,
+            active_minutes_green: 30,
+            active_minutes_yellow: 20,
+            sleep_green_min: 420,
+            sleep_yellow_min: 360,
+            bp_sys_green_max: 129,
+            bp_sys_yellow_max: 139,
+            bp_dia_green_max: 84,
+            bp_dia_yellow_max: 89,
+          },
+          thresholds_history: [],
+        }),
+      });
+    });
+
+    await page.goto('/therapist');
+
+    const infoButton = page.getByRole('button', { name: /info/i }).first();
+    await expect(infoButton).toBeVisible({ timeout: 15000 });
+    await infoButton.click();
+
+    await page.getByRole('button', { name: /edit/i }).click();
+    await page.getByRole('tab', { name: /characteristics/i }).click();
+
+    const lifestyleInput = page.locator('#lifestyle');
+    await expect(lifestyleInput).toBeVisible();
+    await lifestyleInput.fill('Very active person, Morning walk group');
+
+    const saveRequest = page.waitForRequest(
+      (req) => req.method() === 'PUT' && req.url().includes(`/users/${patientId}/profile`)
+    );
+
+    await page.getByRole('button', { name: /save changes/i }).click();
+
+    const req = await saveRequest;
+    const payload = JSON.parse(req.postData() || '{}');
+    expect(payload.lifestyle).toEqual(['Very active person', 'Morning walk group']);
+
+    await expect(page.getByRole('button', { name: /edit/i })).toBeVisible({ timeout: 10000 });
+  });
+});

--- a/frontend/src/__tests__/components/TherapistPatient/PatientPopup.test.tsx
+++ b/frontend/src/__tests__/components/TherapistPatient/PatientPopup.test.tsx
@@ -90,6 +90,37 @@ describe('PatientPopup', () => {
     });
   });
 
+  it('preserves spaces in comma-separated characteristics input while sending normalized array on save', async () => {
+    (apiClient.put as jest.Mock).mockResolvedValue({ data: { message: 'Profile updated' } });
+
+    renderComponent();
+
+    const editButton = await screen.findByText('Edit');
+    fireEvent.click(editButton);
+
+    const characteristicsTab = await screen.findByRole('tab', { name: /characteristics/i });
+    fireEvent.click(characteristicsTab);
+
+    const lifestyleInput = document.getElementById('lifestyle') as HTMLInputElement;
+    expect(lifestyleInput).toBeTruthy();
+
+    fireEvent.change(lifestyleInput, {
+      target: { value: 'Very active person, Morning walk group' },
+    });
+
+    const saveButton = await screen.findByText('Save Changes');
+    fireEvent.click(saveButton);
+
+    await waitFor(() => {
+      expect(apiClient.put).toHaveBeenCalledWith(
+        '/users/abc123/profile/',
+        expect.objectContaining({
+          lifestyle: ['Very active person', 'Morning walk group'],
+        })
+      );
+    });
+  });
+
   // Implement client-side validation for email in PatientPopup component
   it.skip('shows validation error for invalid email', async () => {
     renderComponent();

--- a/frontend/src/stores/patientPopupStore.ts
+++ b/frontend/src/stores/patientPopupStore.ts
@@ -157,6 +157,8 @@ const stableJSON = (obj: any) => {
   }
 };
 
+const COMMA_SEPARATED_PROFILE_FIELDS = ['lifestyle', 'personal_goals', 'social_support'] as const;
+
 export class PatientPopupStore {
   patientId: string;
 
@@ -421,11 +423,9 @@ export class PatientPopupStore {
   }
 
   setCommaSeparated(key: string, v: string) {
-    const arr = (v || '')
-      .split(',')
-      .map((x) => x.trim())
-      .filter(Boolean);
-    this.formData = { ...(this.formData || {}), [key]: arr };
+    // Keep raw text while typing so spaces are not stripped between words.
+    // We normalize to array form right before persistence in save().
+    this.formData = { ...(this.formData || {}), [key]: v };
   }
 
   arrayToDisplay(v: any) {
@@ -680,8 +680,25 @@ export class PatientPopupStore {
     }
 
     try {
+      const payload = { ...(this.formData || {}) };
+      COMMA_SEPARATED_PROFILE_FIELDS.forEach((fieldKey) => {
+        const raw = payload[fieldKey];
+        if (Array.isArray(raw)) {
+          payload[fieldKey] = raw
+            .map((x: unknown) => String(x ?? '').trim())
+            .filter(Boolean);
+          return;
+        }
+        if (typeof raw === 'string') {
+          payload[fieldKey] = raw
+            .split(',')
+            .map((x) => x.trim())
+            .filter(Boolean);
+        }
+      });
+
       // ✅ match your existing GET (and trailing slash)
-      await apiClient.put(`/users/${this.patientId}/profile/`, this.formData);
+      await apiClient.put(`/users/${this.patientId}/profile/`, payload);
 
       // Re-fetch the full profile so the modal shows accurate server state
       const profileRes = await apiClient.get(`/users/${this.patientId}/profile`);

--- a/frontend/src/stores/patientPopupStore.ts
+++ b/frontend/src/stores/patientPopupStore.ts
@@ -684,9 +684,7 @@ export class PatientPopupStore {
       COMMA_SEPARATED_PROFILE_FIELDS.forEach((fieldKey) => {
         const raw = payload[fieldKey];
         if (Array.isArray(raw)) {
-          payload[fieldKey] = raw
-            .map((x: unknown) => String(x ?? '').trim())
-            .filter(Boolean);
+          payload[fieldKey] = raw.map((x: unknown) => String(x ?? '').trim()).filter(Boolean);
           return;
         }
         if (typeof raw === 'string') {


### PR DESCRIPTION
# Description

This PR fixes a regression in the therapist patient-popup **Characteristics** section where typing spaces in comma-separated text fields was effectively broken during input (multi-word entries were difficult/impossible to enter naturally).

Root cause:
- The frontend was normalizing comma-separated fields (`split + trim`) on every keystroke, which removed/altered spacing while the user was still typing.

Fix:
- Keep raw text in form state while typing.
- Normalize comma-separated fields only at save time before sending to backend.
- Preserve internal spaces in multi-word values (for example: `Very active person`).

Updated implementation:
- `frontend/src/stores/patientPopupStore.ts`
  - `setCommaSeparated(...)` now stores raw text input.
  - `save(...)` now normalizes `lifestyle`, `personal_goals`, and `social_support` just before API `PUT`.

Additional regression coverage added:
- FE unit test for popup save payload behavior.
- BE profile update test for preserving internal spaces in persisted characteristics values.
- E2E therapist flow test validating popup edit/save behavior for multi-word comma-separated input.
- Testing documentation updated to include new coverage and commands.

## Related Issue
[#145](https://github.com/ARTORG-GERONTECHNOLOGY/Bearny-RehaAdvisor/issues/145)

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Documentation update
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] A new research paper code implementation
- [ ] Other (Specify)

## Tests

Added tests:
- `frontend/src/__tests__/components/TherapistPatient/PatientPopup.test.tsx`
  - `preserves spaces in comma-separated characteristics input while sending normalized array on save`
- `backend/tests/user_views/test_user_views.py`
  - `test_user_profile_view_update_patient_characteristics_preserves_internal_spaces`
- `frontend/e2e/therapist-characteristics-space-input.spec.ts`
  - Therapist popup regression flow for characteristics multi-word comma-separated input + save payload assertion

Updated testing docs:
- `backend/tests/user_views/TESTING.md`
- `frontend/e2e/TESTING.md`
- `FRONTEND_E2E_TEST_DOCUMENTATION.md`

Suggested commands:
```bash
pytest -q backend/tests/user_views/test_user_views.py -k characteristics_preserves_internal_spaces
cd frontend && npm run test -- --runInBand src/__tests__/components/TherapistPatient/PatientPopup.test.tsx
cd frontend && npm run test:e2e -- e2e/therapist-characteristics-space-input.spec.ts
```

Execution note:
- Could not execute tests in this environment because `pytest` and `npm` are unavailable (`command not found`).

**Test Configuration**:
- Backend: Django/MongoEngine tests
- Frontend: Jest + React Testing Library
- E2E: Playwright (seeded therapist credentials + `E2E_EMAIL_DIR`)

## Checklist

- [x] I have read the [guidelines for contributing](https://github.com/fastmachinelearning/hls4ml/blob/main/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have installed and run `pre-commit` on the files I edited or added.
- [x] I have added tests that prove my fix is effective or that my feature works.