### PR TITLE
Potential fix for code scanning alert no. 79: Incomplete URL substring sanitization

### DIFF
--- a/backend/utils/interventions.py
+++ b/backend/utils/interventions.py
@@ -477,14 +477,25 @@ def youtube_embed(url: str) -> Optional[str]:
 
 
 def _guess_provider(url: str) -> Optional[str]:
-    u = (url or "").lower()
-    if "spotify.com" in u:
+    raw = (url or "").strip()
+    if not raw:
+        return "website"
+
+    parsed = urlparse(raw)
+    host = (parsed.hostname or "").lower()
+
+    # Fallback for URLs without scheme (for example: "youtube.com/watch?v=...")
+    if not host:
+        parsed = urlparse(f"https://{raw}")
+        host = (parsed.hostname or "").lower()
+
+    if host == "spotify.com" or host.endswith(".spotify.com"):
         return "spotify"
-    if "youtube.com" in u or "youtu.be" in u:
+    if host == "youtube.com" or host.endswith(".youtube.com") or host == "youtu.be":
         return "youtube"
-    if "soundcloud.com" in u:
+    if host == "soundcloud.com" or host.endswith(".soundcloud.com"):
         return "soundcloud"
-    if "vimeo.com" in u:
+    if host == "vimeo.com" or host.endswith(".vimeo.com"):
         return "vimeo"
     return "website"
 


### PR DESCRIPTION
Potential fix for [https://github.com/ARTORG-GERONTECHNOLOGY/Bearny-RehaAdvisor/security/code-scanning/79](https://github.com/ARTORG-GERONTECHNOLOGY/Bearny-RehaAdvisor/security/code-scanning/79)

Use `urllib.parse.urlparse` (already imported) to parse the URL and inspect `hostname` only. Then compare host with exact domain or proper subdomain match (`host == "vimeo.com"` or `host.endswith(".vimeo.com")`), similarly for Spotify/SoundCloud/YouTube (`youtube.com` and `youtu.be`). Keep behavior the same otherwise by returning `"website"` when parsing fails or no known host matches.

Best single fix in `backend/utils/interventions.py`:
- Edit `_guess_provider` (lines 479–489 region).
- Replace substring checks over full URL string with hostname-based checks.
- Add safe fallback for inputs without scheme by retrying parse with `https://` prefix so existing loose inputs like `youtube.com/watch?v=...` still classify.

No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
