### PR TITLE
Potential fix for code scanning alert no. 116: Clear text storage of sensitive information

### DIFF
--- a/frontend/src/pages/eva2.tsx
+++ b/frontend/src/pages/eva2.tsx
@@ -365,9 +365,12 @@ export default function HealthSlider() {
     } catch {}
   }, [isPracticeMode, questionIndex]);
 
-  /** --- sync URL-provided patient ID to localStorage --- */
+  /** --- sync URL-provided patient ID to in-memory state (avoid persistent cleartext storage) --- */
   useEffect(() => {
-    if (urlPatientId) localStorage.setItem('patient_id', urlPatientId);
+    if (urlPatientId) {
+      setPatientId(urlPatientId);
+      setPatientIdError('');
+    }
   }, [urlPatientId]);
 
   const submitPatientId = () => {


### PR DESCRIPTION
Potential fix for [https://github.com/ARTORG-GERONTECHNOLOGY/Bearny-RehaAdvisor/security/code-scanning/116](https://github.com/ARTORG-GERONTECHNOLOGY/Bearny-RehaAdvisor/security/code-scanning/116)

Best fix: **do not store URL-derived `patient_id` in `localStorage`**. Keep it in component state only (already done via `setPatientId`) so functionality remains (prefill/use during current session) without writing sensitive data to durable client storage.

In `frontend/src/pages/eva2.tsx`, update the effect at lines 368–371:

- Replace `localStorage.setItem('patient_id', urlPatientId)` with `setPatientId(urlPatientId)`.
- Optionally clear existing validation error when URL ID is accepted.

This is the least invasive change, avoids new dependencies, and preserves behavior needed by the page while removing the cleartext-at-rest sink flagged by CodeQL.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
