### PR TITLE
Potential fix for code scanning alert no. 93: Clear-text logging of sensitive information

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,6 +21,9 @@
 
 name: Tests
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main, dev]

--- a/backend/core/views/patient_views.py
+++ b/backend/core/views/patient_views.py
@@ -2633,9 +2633,7 @@ def get_patient_plan_for_therapist(request, patient_id):
         return JsonResponse(plan_data, safe=False, status=200)
 
     except Patient.DoesNotExist:
-        logger.warning(
-            "[get_patient_plan_for_therapist] Patient.DoesNotExist for requested patient."
-        )
+        logger.warning("[get_patient_plan_for_therapist] Patient.DoesNotExist for requested patient.")
         return JsonResponse(
             {
                 "success": False,

--- a/backend/core/views/patient_views.py
+++ b/backend/core/views/patient_views.py
@@ -2634,8 +2634,7 @@ def get_patient_plan_for_therapist(request, patient_id):
 
     except Patient.DoesNotExist:
         logger.warning(
-            "[get_patient_plan_for_therapist] Patient.DoesNotExist for id: %s",
-            patient_id,
+            "[get_patient_plan_for_therapist] Patient.DoesNotExist for requested patient."
         )
         return JsonResponse(
             {


### PR DESCRIPTION
Potential fix for [https://github.com/ARTORG-GERONTECHNOLOGY/Bearny-RehaAdvisor/security/code-scanning/93](https://github.com/ARTORG-GERONTECHNOLOGY/Bearny-RehaAdvisor/security/code-scanning/93)

To fix this without changing endpoint behavior, remove the sensitive value from logs (or replace it with a non-sensitive placeholder) while keeping the warning message useful for troubleshooting.

Best single fix in `backend/core/views/patient_views.py`:
- In `get_patient_plan_for_therapist`, update the `except Patient.DoesNotExist` logger call so it no longer interpolates `patient_id`.
- Keep response payload unchanged (no functional API change).
- No new imports or dependencies are required.

Concretely, replace the warning message at the block around lines 2636–2639 with a static message that does not include the identifier.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
