### PR TITLE
Potential fix for code scanning alert no. 92: Clear-text logging of sensitive information

### DIFF
--- a/backend/core/tasks.py
+++ b/backend/core/tasks.py
@@ -94,7 +94,7 @@ def sync_wearables_to_redcap_patient(patient_id: str):
 
     patient = Patient.objects(pk=patient_id).first()
     if not patient:
-        logger.warning("[sync_wearables] Patient not found: %s", patient_id)
+        logger.warning("[sync_wearables] Patient not found")
         return {"error": "Patient not found"}
 
     results = export_wearables_to_redcap(patient)

--- a/backend/core/views/patient_thresholds.py
+++ b/backend/core/views/patient_thresholds.py
@@ -430,7 +430,7 @@ def patient_thresholds_view(request, patient_id: str):
     POST /api/patients/<patient_id>/thresholds/
     """
     # ---- load patient ----
-    print("patient_thresholds_view called with patient_id:", patient_id)
+    logger.debug("patient_thresholds_view called")
     try:
         pat = Patient.objects.get(pk=patient_id)
     except Exception:

--- a/backend/core/views/patient_views.py
+++ b/backend/core/views/patient_views.py
@@ -2486,9 +2486,7 @@ def get_patient_plan_for_therapist(request, patient_id):
     try:
         patient = _resolve_patient_flexible(patient_id)
         if not patient:
-            logger.warning(
-                "[get_patient_plan_for_therapist] Could not resolve patient (identifier redacted)"
-            )
+            logger.warning("[get_patient_plan_for_therapist] Could not resolve patient (identifier redacted)")
             return JsonResponse(
                 {
                     "success": False,

--- a/backend/core/views/patient_views.py
+++ b/backend/core/views/patient_views.py
@@ -2487,8 +2487,7 @@ def get_patient_plan_for_therapist(request, patient_id):
         patient = _resolve_patient_flexible(patient_id)
         if not patient:
             logger.warning(
-                "[get_patient_plan_for_therapist] Could not resolve patient: %s",
-                patient_id,
+                "[get_patient_plan_for_therapist] Could not resolve patient (identifier redacted)"
             )
             return JsonResponse(
                 {
@@ -2503,8 +2502,7 @@ def get_patient_plan_for_therapist(request, patient_id):
             plan = RehabilitationPlan.objects.get(patientId=patient)
         except RehabilitationPlan.DoesNotExist:
             logger.info(
-                "[get_patient_plan_for_therapist] No rehab plan for patient: %s",
-                patient_id,
+                "[get_patient_plan_for_therapist] No rehab plan found for resolved patient (identifier redacted)"
             )
             return JsonResponse(
                 {
@@ -2633,7 +2631,7 @@ def get_patient_plan_for_therapist(request, patient_id):
         return JsonResponse(plan_data, safe=False, status=200)
 
     except Patient.DoesNotExist:
-        logger.warning("[get_patient_plan_for_therapist] Patient.DoesNotExist for requested patient.")
+        logger.warning("[get_patient_plan_for_therapist] Patient.DoesNotExist (identifier redacted)")
         return JsonResponse(
             {
                 "success": False,

--- a/backend/core/views/recomendation_views.py
+++ b/backend/core/views/recomendation_views.py
@@ -263,10 +263,13 @@ def apply_template_to_patient(request, therapist_id):
         plan.updatedAt = timezone.now()
         plan.save()
 
+        masked_patient_id = (
+            f"***{patient_id[-4:]}" if patient_id and len(patient_id) > 4 else "***"
+        )
         logger.info(
             "[ASSIGN_INTERVENTION] therapist=%s patient=%s diagnosis=%s applied=%d sessions=%d",
             therapist_id,
-            patient_id,
+            masked_patient_id,
             diagnosis,
             applied,
             total_sessions,

--- a/backend/core/views/recomendation_views.py
+++ b/backend/core/views/recomendation_views.py
@@ -263,13 +263,9 @@ def apply_template_to_patient(request, therapist_id):
         plan.updatedAt = timezone.now()
         plan.save()
 
-        masked_patient_id = (
-            f"***{patient_id[-4:]}" if patient_id and len(patient_id) > 4 else "***"
-        )
         logger.info(
-            "[ASSIGN_INTERVENTION] therapist=%s patient=%s diagnosis=%s applied=%d sessions=%d",
+            "[ASSIGN_INTERVENTION] therapist=%s diagnosis=%s applied=%d sessions=%d",
             therapist_id,
-            masked_patient_id,
             diagnosis,
             applied,
             total_sessions,


### PR DESCRIPTION
Potential fix for [https://github.com/ARTORG-GERONTECHNOLOGY/Bearny-RehaAdvisor/security/code-scanning/92](https://github.com/ARTORG-GERONTECHNOLOGY/Bearny-RehaAdvisor/security/code-scanning/92)

General fix: never log raw patient identifiers from request input. Replace `%s` arguments containing `patient_id` with a redacted value (or omit the identifier entirely). Keep message context so logs remain useful.

Best minimal fix in `backend/core/views/patient_views.py` (shown region): update the affected logger calls in `get_patient_plan_for_therapist` to avoid interpolating `patient_id`. This preserves endpoint behavior and responses, changes only logging content, and avoids adding new dependencies/imports.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
