### PR TITLE
fix(ci): pin production compose image tag to resolved release tag

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -270,6 +270,8 @@ jobs:
             fi
 
             DC="docker compose -f docker-compose.prod.reha-advisor.yml --env-file .env.prod"
+            export IMAGE_TAG="$TAG"
+            echo "Using IMAGE_TAG=$IMAGE_TAG for compose pull/up"
 
             # Ensure server-side data files exist (created once, persist across deploys)
             mkdir -p ./data ./mongo/tls
@@ -346,6 +348,7 @@ jobs:
             PREV_TAG=$(git describe --tags --abbrev=0 HEAD~1 2>/dev/null || echo "")
             if [ -n "$PREV_TAG" ]; then
               git checkout -f "$PREV_TAG"
+              export IMAGE_TAG="$PREV_TAG"
               docker compose -f docker-compose.prod.reha-advisor.yml pull || true
               docker compose -f docker-compose.prod.reha-advisor.yml up -d
               # Revert gateway routing back to local-prod


### PR DESCRIPTION
# Description

This fixes production deploys that could silently run old frontend/backend images when `.env.prod` did not set `IMAGE_TAG` (defaulting compose to `latest`).

We now explicitly pin `IMAGE_TAG` inside the deploy workflow:
- During deploy: `export IMAGE_TAG="$TAG"`
- During rollback: `export IMAGE_TAG="$PREV_TAG"`

This guarantees `docker compose pull/up` uses the intended release tag, not whatever `latest` currently points to.

## Related Issue
[Prod deploy may show stale frontend after successful run](https://github.com/ARTORG-GERONTECHNOLOGY/Bearny-RehaAdvisor/issues)

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Tests

- Validated current prod setup and confirmed containers were running `:latest`.
- Reviewed workflow execution path to confirm `TAG` was resolved but not injected into compose image selection.
- Updated workflow and verified diff only affects deploy/rollback tag pinning.

**Test Configuration**:
- GitHub Actions workflow: `.github/workflows/deploy-prod.yml`
- Production compose stack: `docker-compose.prod.reha-advisor.yml`

## Checklist

- [x] I have read the [guidelines for contributing](https://github.com/fastmachinelearning/hls4ml/blob/main/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have installed and run `pre-commit` on the files I edited or added.
- [ ] I have added tests that prove my fix is effective or that my feature works.
