### PR TITLE
Show Patient ID instead of Name (Rehabtable & Health Page)

### DIFF
--- a/frontend/src/pages/HealthPage.tsx
+++ b/frontend/src/pages/HealthPage.tsx
@@ -451,7 +451,7 @@ const HealthPage: React.FC = observer(() => {
             <Col xs={12} xxl={10}>
               {/* Patient name */}
               {store.patientName && (
-                <div className="text-center mb-3">
+                <div className="mb-3">
                   <h4 className="mb-0">{store.patientName}</h4>
                 </div>
               )}

--- a/frontend/src/pages/HealthPage.tsx
+++ b/frontend/src/pages/HealthPage.tsx
@@ -449,10 +449,11 @@ const HealthPage: React.FC = observer(() => {
         <Container fluid className="py-4 px-2 px-md-4">
           <Row className="justify-content-center">
             <Col xs={12} xxl={10}>
-              {/* Patient name */}
-              {store.patientName && (
+              {(localStorage.getItem('selectedPatientId') || store.patientName) && (
                 <div className="mb-3">
-                  <h4 className="mb-0">{store.patientName}</h4>
+                  <h4 className="mb-0">
+                    {localStorage.getItem('selectedPatientId') || store.patientName}
+                  </h4>
                 </div>
               )}
 

--- a/frontend/src/pages/RehabTable.tsx
+++ b/frontend/src/pages/RehabTable.tsx
@@ -249,11 +249,13 @@ const RehabTable: React.FC = observer(() => {
 
       <main className="rehaPage__content">
         <RehaPageLayout>
-          {store.patientName ? (
+          {(localStorage.getItem('selectedPatientId') || store.patientName) && (
             <div className="mb-3">
-              <h4 className="mb-0">{store.patientName}</h4>
+              <h4 className="mb-0">
+                {localStorage.getItem('selectedPatientId') || store.patientName}
+              </h4>
             </div>
-          ) : null}
+          )}
 
           {store.error ? (
             <Alert

--- a/frontend/src/pages/RehabTable.tsx
+++ b/frontend/src/pages/RehabTable.tsx
@@ -250,8 +250,8 @@ const RehabTable: React.FC = observer(() => {
       <main className="rehaPage__content">
         <RehaPageLayout>
           {store.patientName ? (
-            <div className="rehaPatientHeader">
-              <div className="rehaPatientHeader__name">{store.patientName}</div>
+            <div className="mb-3">
+              <h4 className="mb-0">{store.patientName}</h4>
             </div>
           ) : null}
 

--- a/frontend/src/pages/Therapist.tsx
+++ b/frontend/src/pages/Therapist.tsx
@@ -164,18 +164,20 @@ const Therapist: React.FC = observer(() => {
   }, [store, t]);
 
   const handleRehabButton = useCallback(
-    (id: string, name: string) => {
+    (id: string, name: string, pid: string) => {
       localStorage.setItem('selectedPatient', id);
       localStorage.setItem('selectedPatientName', name);
+      localStorage.setItem('selectedPatientId', pid);
       navigate('/rehabtable');
     },
     [navigate]
   );
 
   const handleProgressButton = useCallback(
-    (id: string, name: string) => {
+    (id: string, name: string, pid: string) => {
       localStorage.setItem('selectedPatient', id);
       localStorage.setItem('selectedPatientName', name);
+      localStorage.setItem('selectedPatientId', pid);
       navigate('/health');
     },
     [navigate]
@@ -854,14 +856,14 @@ const Therapist: React.FC = observer(() => {
                       <Button
                         size="sm"
                         variant="primary"
-                        onClick={() => handleRehabButton(mongoId, fullName)}
+                        onClick={() => handleRehabButton(mongoId, fullName, patientId)}
                       >
                         {String(t('Rehabilitation Plan'))}
                       </Button>
                       <Button
                         size="sm"
                         variant="outline-primary"
-                        onClick={() => handleProgressButton(mongoId, fullName)}
+                        onClick={() => handleProgressButton(mongoId, fullName, patientId)}
                       >
                         {String(t('Outcomes Dashboard'))}
                       </Button>
@@ -942,7 +944,7 @@ const Therapist: React.FC = observer(() => {
                           <Button
                             size="sm"
                             variant="outline-primary"
-                            onClick={() => handleProgressButton(mongoId, fullName)}
+                            onClick={() => handleProgressButton(mongoId, fullName, patientId)}
                           >
                             {String(t('Outcomes Dashboard'))}
                           </Button>


### PR DESCRIPTION
# Description
Show Patient ID instead of Patient Name on RehabTable and Health Page.

## Related Issue
https://github.com/ARTORG-GERONTECHNOLOGY/Bearny-RehaAdvisor/issues/128

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Tests

1. Log in as Therapist
2. Open Rehab Table of a Patient and make sure the Patient ID is displayed as site title.
3. Open Health Page of a Patient and make sure the Patient ID is displayed as site title.

## Checklist

- [x] I have read the [guidelines for contributing](https://github.com/fastmachinelearning/hls4ml/blob/main/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have installed and run `pre-commit` on the files I edited or added.
- [x] I have added tests that prove my fix is effective or that my feature works.
