### PR TITLE
Ensure star-rating question is included in feedback results as a fallback

### DIFF
--- a/backend/core/views/patient_views.py
+++ b/backend/core/views/patient_views.py
@@ -1444,6 +1444,16 @@ def get_feedback_questions(request, questionaire_type, patient_id, intervention_
         # 3) Build final list — type-specific (stars = Frage 1) first, then core (Frage 2 + open)
         result = _serialize_questions(type_q) + _serialize_questions(core_q)
 
+        # 3b) Guarantee a star-rating question is always present. When content_type
+        # is missing or doesn't match any applicable_types list, type_q is empty and
+        # no star question makes it into result. Fall back to rating_stars_education
+        # (the generic "How did you like the content?" question) in that case.
+        has_star = any(q.get("questionKey", "").startswith("rating_stars_") for q in result)
+        if not has_star:
+            fallback_star = FeedbackQuestion.objects(questionKey="rating_stars_education").first()
+            if fallback_star:
+                result = _serialize_questions([fallback_star]) + result
+
         # 4) Optional: require video feedback per assignment flag
         if assignment and getattr(assignment, "require_video_feedback", False):
             result.append(

--- a/backend/core/views/patient_views.py
+++ b/backend/core/views/patient_views.py
@@ -1444,12 +1444,13 @@ def get_feedback_questions(request, questionaire_type, patient_id, intervention_
         # 3) Build final list — type-specific (stars = Frage 1) first, then core (Frage 2 + open)
         result = _serialize_questions(type_q) + _serialize_questions(core_q)
 
-        # 3b) Guarantee a star-rating question is always present. When content_type
-        # is missing or doesn't match any applicable_types list, type_q is empty and
-        # no star question makes it into result. Fall back to rating_stars_education
-        # (the generic "How did you like the content?" question) in that case.
+        # 3b) Guarantee a star-rating question for intervention-specific requests.
+        # When content_type is missing or doesn't match any applicable_types list,
+        # type_q is empty and no star question makes it into result. Fall back to
+        # rating_stars_education (generic star question) only if an interventionId
+        # was provided. Without interventionId, return only core questions.
         has_star = any(q.get("questionKey", "").startswith("rating_stars_") for q in result)
-        if not has_star:
+        if intervention_id and not has_star:
             fallback_star = FeedbackQuestion.objects(questionKey="rating_stars_education").first()
             if fallback_star:
                 result = _serialize_questions([fallback_star]) + result

--- a/backend/tests/patient_views/test_patient_views.py
+++ b/backend/tests/patient_views/test_patient_views.py
@@ -1702,3 +1702,143 @@ def test_get_patient_plan_lang_param_ignored_for_intervention_without_external_i
     assert resp.status_code == 200
     data = resp.json()
     assert len(data) == 2  # both assignments returned without error
+
+
+# ---------------------------------------------------------------------------
+# get_feedback_questions — Intervention type, star-rating fallback
+# ---------------------------------------------------------------------------
+
+
+def _seed_star_questions():
+    """Create the two star rating FeedbackQuestions used by the endpoint."""
+    FeedbackQuestion(
+        questionSubject="Intervention",
+        questionKey="rating_stars_education",
+        answer_type="select",
+        applicable_types=["Education", "Instruction", "Text", "PDF", "Video", "Audio", "Website", "Apps"],
+        translations=[Translation(language="en", text="How did you like the content?")],
+        possibleAnswers=[
+            AnswerOption(key=str(i), translations=[Translation(language="en", text=f"{'★'*i}{'☆'*(5-i)} ({i}/5)")])
+            for i in range(1, 6)
+        ],
+    ).save()
+    FeedbackQuestion(
+        questionSubject="Intervention",
+        questionKey="rating_stars_exercise",
+        answer_type="select",
+        applicable_types=["Exercise", "Exercises", "Physiotherapy", "Training", "Movement"],
+        translations=[Translation(language="en", text="How did you like the exercise?")],
+        possibleAnswers=[
+            AnswerOption(key=str(i), translations=[Translation(language="en", text=f"{'★'*i}{'☆'*(5-i)} ({i}/5)")])
+            for i in range(1, 6)
+        ],
+    ).save()
+
+
+def _setup_patient_with_intervention(content_type):
+    """Patient + intervention with the given content_type, no rehab plan."""
+    t_user = User(username="tu2", email="tu2@example.com", phone="2", createdAt=datetime.now(), isActive=True).save()
+    therapist = Therapist(
+        userId=t_user, name="Doe", first_name="Jane", specializations=[], clinics=["Inselspital"]
+    ).save()
+    p_user = User(username="pu2", email="pu2@example.com", phone="3", createdAt=datetime.now(), isActive=True).save()
+    patient = Patient(
+        userId=p_user,
+        patient_code="PX",
+        name="Patient",
+        first_name="X",
+        access_word="pw",
+        age="40",
+        sex="Female",
+        therapist=therapist,
+        diagnosis=[],
+        function=[],
+        level_of_education="",
+        professional_status="",
+        marital_status="",
+        lifestyle=[],
+        personal_goals=[],
+    ).save()
+    iv = Intervention(
+        title="T",
+        description="",
+        content_type=content_type,
+        language="en",
+        external_id=f"TEST_{content_type or 'NONE'}",
+    ).save()
+    return patient, iv
+
+
+def test_get_intervention_feedback_questions_known_type_returns_matching_star(mongo_mock):
+    """
+    An intervention with content_type="Video" should return rating_stars_education
+    (which covers Video in its applicable_types), not the exercise star.
+    """
+    _seed_star_questions()
+    patient, iv = _setup_patient_with_intervention("Video")
+
+    resp = client.get(
+        f"/api/patients/get-questions/Intervention/{patient.userId.id}/",
+        {"interventionId": str(iv.id)},
+        HTTP_AUTHORIZATION="Bearer test",
+    )
+    assert resp.status_code == 200
+    keys = [q["questionKey"] for q in resp.json().get("questions", resp.json())]
+    assert "rating_stars_education" in keys
+    assert "rating_stars_exercise" not in keys
+
+
+def test_get_intervention_feedback_questions_exercise_type_returns_exercise_star(mongo_mock):
+    """
+    An intervention with content_type="Exercise" should return rating_stars_exercise.
+    """
+    _seed_star_questions()
+    patient, iv = _setup_patient_with_intervention("Exercise")
+
+    resp = client.get(
+        f"/api/patients/get-questions/Intervention/{patient.userId.id}/",
+        {"interventionId": str(iv.id)},
+        HTTP_AUTHORIZATION="Bearer test",
+    )
+    assert resp.status_code == 200
+    keys = [q["questionKey"] for q in resp.json().get("questions", resp.json())]
+    assert "rating_stars_exercise" in keys
+    assert "rating_stars_education" not in keys
+
+
+def test_get_intervention_feedback_questions_missing_content_type_gets_fallback_star(mongo_mock):
+    """
+    An intervention with no content_type should still receive a star rating
+    question (rating_stars_education as the fallback).
+    """
+    _seed_star_questions()
+    patient, iv = _setup_patient_with_intervention("")
+
+    resp = client.get(
+        f"/api/patients/get-questions/Intervention/{patient.userId.id}/",
+        {"interventionId": str(iv.id)},
+        HTTP_AUTHORIZATION="Bearer test",
+    )
+    assert resp.status_code == 200
+    keys = [q["questionKey"] for q in resp.json().get("questions", resp.json())]
+    assert any(k.startswith("rating_stars_") for k in keys), "Expected a star rating question but got: " + str(keys)
+
+
+def test_get_intervention_feedback_questions_unknown_content_type_gets_fallback_star(mongo_mock):
+    """
+    An intervention with an unrecognised content_type (not in any
+    applicable_types list) should still receive a star rating question.
+    """
+    _seed_star_questions()
+    patient, iv = _setup_patient_with_intervention("Quiz")
+
+    resp = client.get(
+        f"/api/patients/get-questions/Intervention/{patient.userId.id}/",
+        {"interventionId": str(iv.id)},
+        HTTP_AUTHORIZATION="Bearer test",
+    )
+    assert resp.status_code == 200
+    keys = [q["questionKey"] for q in resp.json().get("questions", resp.json())]
+    assert any(
+        k.startswith("rating_stars_") for k in keys
+    ), "Expected a star rating question for unknown type but got: " + str(keys)


### PR DESCRIPTION
# Description

Fix intervention feedback not showing a star-rating question when the intervention's `content_type` is missing, `None`, or unrecognised.

`get_feedback_questions` selects type-specific questions by matching the intervention's `content_type` against `FeedbackQuestion.applicable_types`. If `content_type` is empty or not present in any applicable list (e.g. `"Quiz"`, `""`), no `rating_stars_*` question was included — leaving the feedback form without its primary input.

The fix adds a fallback after the question list is built: if an `interventionId` was provided but no star-rating question was resolved, `rating_stars_education` is prepended as a generic fallback.

## Related Issue
[#171 - Bug: Intervention feedback not showing star rating](https://github.com/nooraangelva/telerehabapp/issues/171)

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Tests

Four new tests were added in `backend/tests/patient_views/test_patient_views.py`:

1. **Known education-type** (`content_type="Video"`) → `rating_stars_education` is returned, not `rating_stars_exercise`
2. **Known exercise-type** (`content_type="Exercise"`) → `rating_stars_exercise` is returned, not `rating_stars_education`
3. **Missing content type** (`content_type=""`) → fallback star question is present
4. **Unrecognised content type** (`content_type="Quiz"`) → fallback star question is present

**Test Configuration**:

docker exec django pytest tests/patient_views/test_patient_views.py -k "star" -v



## Checklist

- [x] I have read the guidelines for contributing.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have installed and run `pre-commit` on the files I edited or added.
- [x] I have added tests that prove my fix is effective or that my feature works.