### PR TITLE
185 bug redcap retrieval problems

### DIFF
--- a/backend/core/services/redcap_access.py
+++ b/backend/core/services/redcap_access.py
@@ -46,7 +46,7 @@ def get_allowed_redcap_projects_for_therapist(therapist: Therapist) -> List[str]
     Clinic-based access control.
     Returns union of projects allowed for therapist's clinic(s).
     """
-    clinic_projects = config.get("clinic_projects", {}) or {}
+    clinic_projects = (config.get("therapistInfo") or {}).get("clinic_projects") or {}
     allowed = set()
 
     for clinic in therapist.clinics or []:

--- a/backend/core/views/redcap_patient_views.py
+++ b/backend/core/views/redcap_patient_views.py
@@ -3,8 +3,7 @@ import logging
 from typing import Any, Dict, List
 
 from django.http import JsonResponse
-from django.views.decorators.csrf import csrf_exempt
-from rest_framework.decorators import permission_classes
+from rest_framework.decorators import api_view, permission_classes
 from rest_framework.permissions import IsAuthenticated
 
 from core.services.redcap_access import (
@@ -17,7 +16,7 @@ from core.views.redcap_import_views import _norm, get_therapist_by_user_id
 logger = logging.getLogger(__name__)
 
 
-@csrf_exempt
+@api_view(["GET"])
 @permission_classes([IsAuthenticated])
 def redcap_patient(request):
     """
@@ -43,7 +42,7 @@ def redcap_patient(request):
     if not therapist:
         return JsonResponse({"ok": False, "error": "Therapist profile not found."}, status=404)
 
-    allowed = therapist.projects
+    allowed = get_allowed_redcap_projects_for_therapist(therapist)
     print("Allowed REDCap projects for therapist:", allowed)
     if not allowed:
         return JsonResponse(

--- a/backend/tests/redcap_access/test_redcap_access.py
+++ b/backend/tests/redcap_access/test_redcap_access.py
@@ -67,7 +67,7 @@ def test_get_allowed_projects_with_clinic_union_and_project_intersection(monkeyp
     monkeypatch.setattr(
         redcap_access,
         "config",
-        {"clinic_projects": {"ClinicA": ["PRJ1", "PRJ2"], "ClinicB": ["PRJ3", "PRJX"]}},
+        {"therapistInfo": {"clinic_projects": {"ClinicA": ["PRJ1", "PRJ2"], "ClinicB": ["PRJ3", "PRJX"]}}},
         raising=False,
     )
 
@@ -83,7 +83,7 @@ def test_assert_project_allowed_for_therapist(monkeypatch):
     monkeypatch.setattr(
         redcap_access,
         "config",
-        {"clinic_projects": {"ClinicA": ["PRJ1", "PRJ2"]}},
+        {"therapistInfo": {"clinic_projects": {"ClinicA": ["PRJ1", "PRJ2"]}}},
         raising=False,
     )
 

--- a/backend/tests/redcap_patient_views/test_redcap_patient_views.py
+++ b/backend/tests/redcap_patient_views/test_redcap_patient_views.py
@@ -1,0 +1,266 @@
+"""
+redcap_patient views tests
+==========================
+
+Covers core/views/redcap_patient_views.py  (GET /api/redcap/patient/).
+
+Key regressions guarded:
+  - Bug #185: therapist.projects was used instead of get_allowed_redcap_projects_for_therapist,
+    so therapists who only had clinics set got 403 even when the clinic mapped to REDCap projects.
+  - Auth bypass: @permission_classes without @api_view was a no-op.
+"""
+
+import json
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import mongomock
+import pytest
+from bson import ObjectId
+from rest_framework.test import APIRequestFactory, force_authenticate
+
+from core.models import Therapist, User
+from core.services.redcap_service import RedcapError
+from core.views.redcap_patient_views import redcap_patient
+
+URL = "/api/redcap/patient/"
+
+
+@pytest.fixture(autouse=True, scope="function")
+def mongo_mock():
+    from mongoengine import connect, disconnect
+    from mongoengine.connection import _connections
+
+    alias = "default"
+    if alias in _connections:
+        disconnect(alias)
+
+    conn = connect(
+        "mongoenginetest",
+        alias=alias,
+        host="mongodb://localhost",
+        mongo_client_class=mongomock.MongoClient,
+    )
+    yield conn
+    disconnect(alias)
+
+
+@pytest.fixture
+def arf():
+    return APIRequestFactory()
+
+
+class DummyUser(SimpleNamespace):
+    is_authenticated = True
+
+
+class DummyTherapist:
+    clinics = ["Inselspital"]
+    projects = []
+
+
+def _get(arf, params="", user=None):
+    req = arf.get(f"{URL}?{params}")
+    if user is not None:
+        force_authenticate(req, user=user)
+    return redcap_patient(req)
+
+
+# ---------------------------------------------------------------------------
+# Authentication
+# ---------------------------------------------------------------------------
+
+
+def test_unauthenticated_request_returns_401(arf):
+    req = arf.get(f"{URL}?patient_code=P1")
+    resp = redcap_patient(req)
+    assert resp.status_code == 401
+
+
+def test_method_not_allowed_returns_405(arf):
+    req = arf.post(URL, {})
+    force_authenticate(req, user=DummyUser())
+    resp = redcap_patient(req)
+    assert resp.status_code == 405
+
+
+# ---------------------------------------------------------------------------
+# Input validation
+# ---------------------------------------------------------------------------
+
+
+@patch("core.views.redcap_patient_views.get_therapist_for_user", return_value=DummyTherapist())
+def test_missing_patient_code_returns_400(mock_th, arf):
+    resp = _get(arf, params="", user=DummyUser())
+    assert resp.status_code == 400
+    assert "patient_code" in json.loads(resp.content)["error"]
+
+
+# ---------------------------------------------------------------------------
+# Therapist resolution
+# ---------------------------------------------------------------------------
+
+
+@patch("core.views.redcap_patient_views.get_therapist_for_user", return_value=None)
+def test_therapist_not_found_via_request_user_returns_404(mock_th, arf):
+    resp = _get(arf, params="patient_code=P1", user=DummyUser())
+    assert resp.status_code == 404
+    assert "Therapist" in json.loads(resp.content)["error"]
+
+
+@patch("core.views.redcap_patient_views.get_therapist_by_user_id", return_value=None)
+def test_therapist_not_found_via_query_param_returns_404(mock_th, arf):
+    user_id = str(ObjectId())
+    resp = _get(arf, params=f"patient_code=P1&therapistUserId={user_id}", user=DummyUser())
+    assert resp.status_code == 404
+    assert "Therapist" in json.loads(resp.content)["error"]
+
+
+# ---------------------------------------------------------------------------
+# Access control — project resolution
+# ---------------------------------------------------------------------------
+
+
+@patch("core.views.redcap_patient_views.get_allowed_redcap_projects_for_therapist", return_value=[])
+@patch("core.views.redcap_patient_views.get_therapist_for_user", return_value=DummyTherapist())
+def test_no_allowed_projects_returns_403(mock_th, mock_allowed, arf):
+    resp = _get(arf, params="patient_code=P1", user=DummyUser())
+    assert resp.status_code == 403
+    body = json.loads(resp.content)
+    assert "REDCap projects" in body["error"]
+
+
+@patch("core.views.redcap_patient_views.get_allowed_redcap_projects_for_therapist", return_value=["COPAIN"])
+@patch("core.views.redcap_patient_views.get_therapist_for_user", return_value=DummyTherapist())
+def test_project_param_not_in_allowed_returns_403(mock_th, mock_allowed, arf):
+    resp = _get(arf, params="patient_code=P1&project=COMPASS", user=DummyUser())
+    assert resp.status_code == 403
+    body = json.loads(resp.content)
+    assert "allowedProjects" in body
+
+
+@patch(
+    "core.views.redcap_patient_views.get_allowed_redcap_projects_for_therapist",
+    return_value=["COPAIN", "COMPASS"],
+)
+@patch("core.views.redcap_patient_views.get_therapist_for_user", return_value=DummyTherapist())
+@patch("core.views.redcap_patient_views.export_record_by_pat_id", return_value=[{"record_id": "P1"}])
+def test_project_param_restricts_search_to_that_project(mock_export, mock_th, mock_allowed, arf):
+    resp = _get(arf, params="patient_code=P1&project=COPAIN", user=DummyUser())
+    assert resp.status_code == 200
+    body = json.loads(resp.content)
+    assert body["searchedProjects"] == ["COPAIN"]
+    mock_export.assert_called_once_with("COPAIN", "P1")
+
+
+# ---------------------------------------------------------------------------
+# Bug #185 regression: clinic-only therapist previously got 403
+# ---------------------------------------------------------------------------
+
+
+def test_therapist_with_only_clinics_set_can_access_redcap(arf):
+    """
+    Therapist has clinics=["Inselspital"] but projects=[].
+    Before the fix: allowed = therapist.projects → [] → 403.
+    After the fix: get_allowed_redcap_projects_for_therapist derives
+    ["COPAIN", "COMPASS"] from clinic config → search proceeds.
+    """
+    u = User(
+        username=f"th-{ObjectId()}",
+        role="Therapist",
+        createdAt=datetime.now(),
+        isActive=True,
+    ).save()
+    th = Therapist(userId=u, clinics=["Inselspital"], projects=[]).save()
+
+    with patch("core.views.redcap_patient_views.get_therapist_for_user", return_value=th), patch(
+        "core.views.redcap_patient_views.export_record_by_pat_id", return_value=[]
+    ):
+        resp = _get(arf, params="patient_code=P_MISSING", user=DummyUser())
+
+    # Should reach REDCap lookup (404 = not found), NOT 403 = no projects
+    assert resp.status_code == 404
+    body = json.loads(resp.content)
+    assert body.get("code") == "redcap_not_found"
+    assert set(body["allowedProjects"]) == {"COPAIN", "COMPASS"}
+
+
+# ---------------------------------------------------------------------------
+# REDCap lookup outcomes
+# ---------------------------------------------------------------------------
+
+
+@patch(
+    "core.views.redcap_patient_views.get_allowed_redcap_projects_for_therapist",
+    return_value=["COPAIN"],
+)
+@patch("core.views.redcap_patient_views.get_therapist_for_user", return_value=DummyTherapist())
+@patch("core.views.redcap_patient_views.export_record_by_pat_id", return_value=[])
+def test_patient_not_found_in_redcap_returns_404(mock_export, mock_th, mock_allowed, arf):
+    resp = _get(arf, params="patient_code=UNKNOWN", user=DummyUser())
+    assert resp.status_code == 404
+    body = json.loads(resp.content)
+    assert body["code"] == "redcap_not_found"
+    assert body["patient_code"] == "UNKNOWN"
+
+
+@patch(
+    "core.views.redcap_patient_views.get_allowed_redcap_projects_for_therapist",
+    return_value=["COPAIN", "COMPASS"],
+)
+@patch("core.views.redcap_patient_views.get_therapist_for_user", return_value=DummyTherapist())
+@patch(
+    "core.views.redcap_patient_views.export_record_by_pat_id",
+    return_value=[{"record_id": "P17", "pat_id": "P17"}],
+)
+def test_patient_found_returns_200_with_matches(mock_export, mock_th, mock_allowed, arf):
+    resp = _get(arf, params="patient_code=P17", user=DummyUser())
+    assert resp.status_code == 200
+    body = json.loads(resp.content)
+    assert body["ok"] is True
+    assert body["patient_code"] == "P17"
+    assert len(body["matches"]) >= 1
+    assert body["matches"][0]["rows"][0]["record_id"] == "P17"
+
+
+@patch(
+    "core.views.redcap_patient_views.get_allowed_redcap_projects_for_therapist",
+    return_value=["COPAIN"],
+)
+@patch("core.views.redcap_patient_views.get_therapist_for_user", return_value=DummyTherapist())
+@patch(
+    "core.views.redcap_patient_views.export_record_by_pat_id",
+    side_effect=RedcapError("connection refused"),
+)
+def test_redcap_error_returns_502(mock_export, mock_th, mock_allowed, arf):
+    resp = _get(arf, params="patient_code=P1", user=DummyUser())
+    assert resp.status_code == 502
+    body = json.loads(resp.content)
+    assert body["code"] == "redcap_fetch_error"
+    assert len(body["errors"]) == 1
+
+
+@patch(
+    "core.views.redcap_patient_views.get_allowed_redcap_projects_for_therapist",
+    return_value=["COPAIN", "COMPASS"],
+)
+@patch("core.views.redcap_patient_views.get_therapist_for_user", return_value=DummyTherapist())
+def test_partial_error_still_returns_200_when_one_project_succeeds(mock_th, mock_allowed, arf):
+    """One project errors, another returns a match — overall 200 with errors in body."""
+
+    def side_effect(proj, pat_id):
+        if proj == "COPAIN":
+            raise RedcapError("timeout")
+        return [{"record_id": pat_id}]
+
+    with patch("core.views.redcap_patient_views.export_record_by_pat_id", side_effect=side_effect):
+        resp = _get(arf, params="patient_code=P1", user=DummyUser())
+
+    assert resp.status_code == 200
+    body = json.loads(resp.content)
+    assert body["ok"] is True
+    assert len(body["matches"]) == 1
+    assert body["matches"][0]["project"] == "COMPASS"
+    assert len(body["errors"]) == 1
+    assert body["errors"][0]["project"] == "COPAIN"

--- a/backend/tests/redcap_patient_views/test_redcap_patient_views.py
+++ b/backend/tests/redcap_patient_views/test_redcap_patient_views.py
@@ -174,8 +174,9 @@ def test_therapist_with_only_clinics_set_can_access_redcap(arf):
     ).save()
     th = Therapist(userId=u, clinics=["Inselspital"], projects=[]).save()
 
-    with patch("core.views.redcap_patient_views.get_therapist_for_user", return_value=th), patch(
-        "core.views.redcap_patient_views.export_record_by_pat_id", return_value=[]
+    with (
+        patch("core.views.redcap_patient_views.get_therapist_for_user", return_value=th),
+        patch("core.views.redcap_patient_views.export_record_by_pat_id", return_value=[]),
     ):
         resp = _get(arf, params="patient_code=P_MISSING", user=DummyUser())
 

--- a/backend/tests/redcap_views/test_redcap_views.py
+++ b/backend/tests/redcap_views/test_redcap_views.py
@@ -21,10 +21,22 @@ from unittest.mock import patch
 import mongomock
 import pytest
 from django.test import Client
+from rest_framework.test import APIClient
 
 from core.services.redcap_service import RedcapError
 
 client = Client()
+
+# redcap_patient uses @api_view + @permission_classes([IsAuthenticated]), so
+# it requires a properly authenticated DRF request. force_authenticate bypasses
+# JWT validation while still satisfying IsAuthenticated.
+_AUTH_USER = type("U", (), {"is_authenticated": True})()
+
+
+def _auth_client():
+    c = APIClient()
+    c.force_authenticate(user=_AUTH_USER)
+    return c
 
 
 @pytest.fixture(autouse=True, scope="function")
@@ -85,37 +97,42 @@ def test_redcap_projects_method_not_allowed():
 
 
 def test_redcap_patient_requires_patient_code():
-    resp = client.get("/api/redcap/patient/", HTTP_AUTHORIZATION="Bearer test")
+    resp = _auth_client().get("/api/redcap/patient/")
     assert resp.status_code == 400
     assert resp.json()["error"] == "patient_code is required"
 
 
 @patch("core.views.redcap_patient_views.get_therapist_for_user", return_value=None)
 def test_redcap_patient_therapist_not_found(mock_get_th):
-    resp = client.get("/api/redcap/patient/?patient_code=P17", HTTP_AUTHORIZATION="Bearer test")
+    resp = _auth_client().get("/api/redcap/patient/?patient_code=P17")
     assert resp.status_code == 404
     assert resp.json()["error"] == "Therapist profile not found."
 
 
 @patch(
+    "core.views.redcap_patient_views.get_allowed_redcap_projects_for_therapist",
+    return_value=[],
+)
+@patch(
     "core.views.redcap_patient_views.get_therapist_for_user",
     return_value=DummyTherapist(projects=[]),
 )
-def test_redcap_patient_no_allowed_projects(mock_get_th):
-    resp = client.get("/api/redcap/patient/?patient_code=P17", HTTP_AUTHORIZATION="Bearer test")
+def test_redcap_patient_no_allowed_projects(mock_get_th, mock_allowed):
+    resp = _auth_client().get("/api/redcap/patient/?patient_code=P17")
     assert resp.status_code == 403
     assert resp.json()["error"] == "No REDCap projects configured for your clinic."
 
 
 @patch(
+    "core.views.redcap_patient_views.get_allowed_redcap_projects_for_therapist",
+    return_value=["COPAIN"],
+)
+@patch(
     "core.views.redcap_patient_views.get_therapist_for_user",
     return_value=DummyTherapist(projects=["COPAIN"]),
 )
-def test_redcap_patient_forbidden_project(mock_get_th):
-    resp = client.get(
-        "/api/redcap/patient/?patient_code=P17&project=COMPASS",
-        HTTP_AUTHORIZATION="Bearer test",
-    )
+def test_redcap_patient_forbidden_project(mock_get_th, mock_allowed):
+    resp = _auth_client().get("/api/redcap/patient/?patient_code=P17&project=COMPASS")
     assert resp.status_code == 403
     body = resp.json()
     assert body["error"] == "Not allowed to access this REDCap project for your clinic."
@@ -124,14 +141,15 @@ def test_redcap_patient_forbidden_project(mock_get_th):
 
 @patch("core.views.redcap_patient_views.export_record_by_pat_id", return_value=[])
 @patch(
+    "core.views.redcap_patient_views.get_allowed_redcap_projects_for_therapist",
+    return_value=["COPAIN"],
+)
+@patch(
     "core.views.redcap_patient_views.get_therapist_for_user",
     return_value=DummyTherapist(projects=["COPAIN"]),
 )
-def test_redcap_patient_not_found_when_no_rows(mock_get_th, mock_export):
-    resp = client.get(
-        "/api/redcap/patient/?patient_code=P17&project=COPAIN",
-        HTTP_AUTHORIZATION="Bearer test",
-    )
+def test_redcap_patient_not_found_when_no_rows(mock_get_th, mock_allowed, mock_export):
+    resp = _auth_client().get("/api/redcap/patient/?patient_code=P17&project=COPAIN")
     assert resp.status_code == 404
     assert "No REDCap record found" in resp.json()["error"]
 
@@ -141,11 +159,15 @@ def test_redcap_patient_not_found_when_no_rows(mock_get_th, mock_export):
     side_effect=RedcapError("upstream error", detail="timeout"),
 )
 @patch(
+    "core.views.redcap_patient_views.get_allowed_redcap_projects_for_therapist",
+    return_value=["COPAIN"],
+)
+@patch(
     "core.views.redcap_patient_views.get_therapist_for_user",
     return_value=DummyTherapist(projects=["COPAIN"]),
 )
-def test_redcap_patient_returns_502_when_all_projects_error(mock_get_th, mock_export):
-    resp = client.get("/api/redcap/patient/?patient_code=P17", HTTP_AUTHORIZATION="Bearer test")
+def test_redcap_patient_returns_502_when_all_projects_error(mock_get_th, mock_allowed, mock_export):
+    resp = _auth_client().get("/api/redcap/patient/?patient_code=P17")
     assert resp.status_code == 502
     body = resp.json()
     assert "Failed to retrieve REDCap records" in body["error"]
@@ -153,11 +175,15 @@ def test_redcap_patient_returns_502_when_all_projects_error(mock_get_th, mock_ex
 
 
 @patch(
+    "core.views.redcap_patient_views.get_allowed_redcap_projects_for_therapist",
+    return_value=["COPAIN", "COMPASS"],
+)
+@patch(
     "core.views.redcap_patient_views.get_therapist_for_user",
     return_value=DummyTherapist(projects=["COPAIN", "COMPASS"]),
 )
 @patch("core.views.redcap_patient_views.export_record_by_pat_id")
-def test_redcap_patient_success_with_partial_errors(mock_export, mock_get_th):
+def test_redcap_patient_success_with_partial_errors(mock_export, mock_get_th, mock_allowed):
     def side_effect(project, _patient_code):
         if project == "COPAIN":
             return [{"record_id": "1", "pat_id": "P17"}]
@@ -165,7 +191,7 @@ def test_redcap_patient_success_with_partial_errors(mock_export, mock_get_th):
 
     mock_export.side_effect = side_effect
 
-    resp = client.get("/api/redcap/patient/?patient_code=P17", HTTP_AUTHORIZATION="Bearer test")
+    resp = _auth_client().get("/api/redcap/patient/?patient_code=P17")
     assert resp.status_code == 200
     body = resp.json()
     assert body["ok"] is True


### PR DESCRIPTION
# Description

## Summary

- `redcap_access.get_allowed_redcap_projects_for_therapist` read `config["clinic_projects"]` (top-level, doesn't exist) instead of `config["therapistInfo"]["clinic_projects"]` — always returned `[]`
- `redcap_patient_views` used `therapist.projects` (explicit list, defaults to `[]`) instead of calling the helper above — therapists with only `clinics` set got 403
- `@permission_classes([IsAuthenticated])` without `@api_view` was a no-op — endpoint accepted unauthenticated requests

## Related Issue
#185

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Tests

## Test plan
**Test Configuration**:
- [x] `docker exec django pytest tests/redcap_patient_views/ -v` — 13 tests, all green
- [x] `docker exec django pytest tests/redcap_access/ -v` — existing suite still passes
- [x] Manual: therapist with `clinics=["Inselspital"]` and `projects=[]` can now search REDCap without getting 403
- [x] Manual: unauthenticated request to `GET /api/redcap/patient/` now returns 401

## Checklist

- [x] I have read the [guidelines for contributing](https://github.com/fastmachinelearning/hls4ml/blob/main/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have installed and run `pre-commit` on the files I edited or added.
- [x] I have added tests that prove my fix is effective or that my feature works.
