### PR TITLE
187 improve template assignment errors

### DIFF
--- a/backend/core/views/template_views.py
+++ b/backend/core/views/template_views.py
@@ -815,8 +815,7 @@ def apply_named_template(request, template_id):
     if patient_errors:
         response["partial_errors"] = patient_errors
         response["warning"] = (
-            f"Applied to {patients_affected} patient(s). "
-            f"{len(patient_errors)} patient(s) could not be updated."
+            f"Applied to {patients_affected} patient(s). " f"{len(patient_errors)} patient(s) could not be updated."
         )
     return JsonResponse(response, status=200)
 

--- a/backend/core/views/template_views.py
+++ b/backend/core/views/template_views.py
@@ -19,6 +19,7 @@ from bson import ObjectId
 from django.http import JsonResponse
 from django.utils import timezone
 from django.utils.timezone import is_naive, make_aware
+from mongoengine.errors import ValidationError as MongoValidationError
 from mongoengine.queryset.visitor import Q
 from rest_framework.decorators import api_view, permission_classes
 from rest_framework.permissions import IsAuthenticated
@@ -61,6 +62,24 @@ def _get_therapist(request) -> Therapist | None:
         return Therapist.objects.get(userId=str(request.user.id))
     except Exception:
         return None
+
+
+_FIELD_MESSAGES = {
+    "endDate": "Patient has no rehabilitation end date. Set a rehab or study end date on the patient profile before applying a template.",
+    "startDate": "Patient has no start date. Ensure the patient profile has a valid start date.",
+    "patientId": "Patient reference is invalid or missing.",
+    "therapistId": "Therapist reference is invalid or missing.",
+}
+
+
+def _describe_validation_error(e: MongoValidationError) -> str:
+    errors = getattr(e, "errors", {}) or {}
+    if not errors:
+        return str(e)
+    parts = []
+    for field, detail in errors.items():
+        parts.append(_FIELD_MESSAGES.get(field) or f"'{field}' is required or invalid ({detail}).")
+    return " ".join(parts)
 
 
 def _serialize_template(tmpl: InterventionTemplate, detail: bool = False) -> dict:
@@ -750,8 +769,10 @@ def apply_named_template(request, template_id):
     total_applied = 0
     total_sessions = 0
     patients_affected = 0
+    patient_errors: List[Dict] = []
 
     for patient in patients:
+        patient_code = getattr(patient, "patient_code", str(patient.pk))
         try:
             a, s = _apply_template_to_single_patient(
                 tmpl, patient, therapist, eff_dt, diagnosis_filter, notes, force_video, overwrite
@@ -760,23 +781,44 @@ def apply_named_template(request, template_id):
             total_sessions += s
             if a > 0:
                 patients_affected += 1
-        except Exception as e:
+        except MongoValidationError as e:
+            reason = _describe_validation_error(e)
             logger.error(
                 "apply_named_template: error applying to patient %s: %s",
-                getattr(patient, "patient_code", str(patient.pk)),
+                patient_code,
                 str(e),
                 exc_info=True,
             )
+            patient_errors.append({"patient": patient_code, "reason": reason})
+        except Exception as e:
+            logger.error(
+                "apply_named_template: error applying to patient %s: %s",
+                patient_code,
+                str(e),
+                exc_info=True,
+            )
+            patient_errors.append({"patient": patient_code, "reason": "Unexpected error. Check server logs."})
 
-    return JsonResponse(
-        {
-            "success": True,
-            "applied": total_applied,
-            "sessions_created": total_sessions,
-            "patients_affected": patients_affected,
-        },
-        status=200,
-    )
+    if patient_errors and not total_applied:
+        return bad(
+            "Template could not be applied to any patient.",
+            non_field_errors=[f"{e['patient']}: {e['reason']}" for e in patient_errors],
+            status=400,
+        )
+
+    response: Dict = {
+        "success": True,
+        "applied": total_applied,
+        "sessions_created": total_sessions,
+        "patients_affected": patients_affected,
+    }
+    if patient_errors:
+        response["partial_errors"] = patient_errors
+        response["warning"] = (
+            f"Applied to {patients_affected} patient(s). "
+            f"{len(patient_errors)} patient(s) could not be updated."
+        )
+    return JsonResponse(response, status=200)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/template_views/test_template_views.py
+++ b/backend/tests/template_views/test_template_views.py
@@ -1713,3 +1713,120 @@ def test_remove_diagnosis_block_persisted(mongo_mock):
     da_after = recs_after[0]["diagnosis_assignments"]
     assert "MS" not in da_after, "MS block must be removed from DB (dirty-tracking bug regression)"
     assert "Stroke" in da_after, "Stroke block must be untouched"
+
+
+# ===========================================================================
+# apply_named_template — error surfacing (bug #187)
+# ===========================================================================
+
+
+def _make_patient_no_end_date(therapist):
+    """Create a patient with no reha_end_date or study_end_date."""
+    p_user = User(
+        username=f"patient_{str(ObjectId())[-6:]}",
+        email=f"p_{str(ObjectId())[-6:]}@example.com",
+        phone="456",
+        createdAt=datetime.now(),
+        isActive=True,
+    ).save()
+    patient = Patient(
+        userId=p_user,
+        patient_code=f"PAT-NOEND-{str(ObjectId())[-6:]}",
+        name="Noend",
+        first_name="Pat",
+        access_word="word",
+        age="40",
+        therapist=therapist,
+        clinic="Inselspital",
+        sex="Female",
+        diagnosis=["Stroke"],
+        function=["Cardiology"],
+        level_of_education="High School",
+        professional_status="Employed Full-Time",
+        marital_status="Single",
+        lifestyle=[],
+        personal_goals=[],
+        # reha_end_date and study_end_date deliberately omitted
+    ).save()
+    return p_user, patient
+
+
+def test_apply_template_total_failure_returns_400_with_reason(mongo_mock):
+    """
+    Bug #187 regression: when every patient fails with a ValidationError
+    (e.g. missing endDate), the response must be 400, not a silent 200.
+    The error body must contain a human-readable reason.
+    """
+    _, therapist = _make_therapist()
+    _, patient = _make_patient_no_end_date(therapist)
+    tmpl = _make_template(therapist, with_intervention=True)
+
+    tomorrow = (datetime.now() + timedelta(days=1)).strftime("%Y-%m-%d")
+    resp = _post_json(
+        APPLY_URL.format(id=tmpl.id),
+        {"patientIds": [str(patient.id)], "effectiveFrom": tomorrow},
+        therapist,
+    )
+
+    assert resp.status_code == 400, resp.content.decode()
+    body = resp.json()
+    assert body.get("success") is False
+    errors = body.get("non_field_errors", [])
+    assert errors, "non_field_errors must be populated"
+    # The error for missing endDate must be human-readable, not a raw MongoEngine string
+    combined = " ".join(errors)
+    assert "end date" in combined.lower(), f"Expected 'end date' in error message, got: {combined}"
+
+
+def test_apply_template_partial_failure_returns_200_with_partial_errors(mongo_mock):
+    """
+    Bug #187 regression: when some patients succeed and one fails, the response
+    must be 200 with success=True, include the successful counts, AND include
+    a partial_errors list with a human-readable reason for the failing patient.
+    """
+    _, therapist = _make_therapist()
+    _, good_patient = _make_patient(therapist)
+    _, bad_patient = _make_patient_no_end_date(therapist)
+    tmpl = _make_template(therapist, with_intervention=True)
+
+    tomorrow = (datetime.now() + timedelta(days=1)).strftime("%Y-%m-%d")
+    resp = _post_json(
+        APPLY_URL.format(id=tmpl.id),
+        {"patientIds": [str(good_patient.id), str(bad_patient.id)], "effectiveFrom": tomorrow},
+        therapist,
+    )
+
+    assert resp.status_code == 200, resp.content.decode()
+    body = resp.json()
+    assert body.get("success") is True
+    assert body.get("applied", 0) >= 1, "at least one patient must have been applied"
+    assert body.get("patients_affected", 0) >= 1
+
+    partial = body.get("partial_errors", [])
+    assert len(partial) == 1, f"expected 1 partial error, got {partial}"
+    assert bad_patient.patient_code in partial[0]["patient"]
+    assert "end date" in partial[0]["reason"].lower()
+
+    assert "warning" in body, "response must include a 'warning' summary string"
+
+
+def test_apply_template_success_has_no_partial_errors_key(mongo_mock):
+    """
+    When all patients succeed, partial_errors must not appear in the response
+    (keeps the happy-path payload clean).
+    """
+    _, therapist = _make_therapist()
+    _, patient = _make_patient(therapist)
+    tmpl = _make_template(therapist, with_intervention=True)
+
+    tomorrow = (datetime.now() + timedelta(days=1)).strftime("%Y-%m-%d")
+    resp = _post_json(
+        APPLY_URL.format(id=tmpl.id),
+        {"patientIds": [str(patient.id)], "effectiveFrom": tomorrow},
+        therapist,
+    )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "partial_errors" not in body
+    assert "warning" not in body

--- a/frontend/src/components/TherapistInterventionPage/ApplyTemplateModal.tsx
+++ b/frontend/src/components/TherapistInterventionPage/ApplyTemplateModal.tsx
@@ -22,6 +22,8 @@ type Props = {
     applied: number;
     sessions_created: number;
     patients_affected?: number;
+    partial_errors?: { patient: string; reason: string }[];
+    warning?: string;
   }) => void;
   templateId?: string;
 };
@@ -201,10 +203,20 @@ const ApplyTemplateModal: React.FC<Props> = ({
         notes,
       });
 
-      onApplied?.(res.data);
-      resetLocalErrors();
-      setSubmitting(false);
-      onHide();
+      const data = res.data;
+      if (data.partial_errors?.length) {
+        applyErrors({
+          message: data.warning || t('Template was partially applied.'),
+          non_field_errors: data.partial_errors.map((e: { patient: string; reason: string }) => `${e.patient}: ${e.reason}`),
+        });
+        setSubmitting(false);
+        onApplied?.(data);
+      } else {
+        onApplied?.(data);
+        resetLocalErrors();
+        setSubmitting(false);
+        onHide();
+      }
     } catch (e: any) {
       console.error('apply_template error:', e?.response?.data || e);
       applyErrors(e?.response?.data || {});

--- a/frontend/src/components/TherapistInterventionPage/ApplyTemplateModal.tsx
+++ b/frontend/src/components/TherapistInterventionPage/ApplyTemplateModal.tsx
@@ -207,7 +207,9 @@ const ApplyTemplateModal: React.FC<Props> = ({
       if (data.partial_errors?.length) {
         applyErrors({
           message: data.warning || t('Template was partially applied.'),
-          non_field_errors: data.partial_errors.map((e: { patient: string; reason: string }) => `${e.patient}: ${e.reason}`),
+          non_field_errors: data.partial_errors.map(
+            (e: { patient: string; reason: string }) => `${e.patient}: ${e.reason}`
+          ),
         });
         setSubmitting(false);
         onApplied?.(data);

--- a/frontend/src/pages/TherapistInterventions.tsx
+++ b/frontend/src/pages/TherapistInterventions.tsx
@@ -1126,14 +1126,15 @@ const TherapistRecomendations: React.FC = observer(() => {
         defaultDiagnosis={templateDiag || undefined}
         templateId={activeTemplateId || undefined}
         onApplied={(res) => {
-          setShowApplyModal(false);
+          if (!res.partial_errors?.length) {
+            setShowApplyModal(false);
+          }
           setError('');
-          window.alert(
-            t('Template applied: {{applied}} interventions, {{sessions}} sessions', {
-              applied: res.applied,
-              sessions: res.sessions_created,
-            })
-          );
+          const summary = t('Template applied: {{applied}} interventions, {{sessions}} sessions', {
+            applied: res.applied,
+            sessions: res.sessions_created,
+          });
+          window.alert(res.warning ? `${summary}\n\n${res.warning}` : summary);
         }}
       />
 


### PR DESCRIPTION
## Summary

- Previously, `apply_named_template` swallowed per-patient exceptions — the
  response was always `200 success:true` even when every patient failed
- Patient 905-3 fails because it has no `reha_end_date`/`study_end_date`, so
  the new `RehabilitationPlan.endDate` is `None` → `ValidationError` on save
- Added `_describe_validation_error` to translate MongoEngine field errors to
  human-readable messages (known fields: `endDate`, `startDate`, `patientId`,
  `therapistId`)
- Total failure → 400 `bad()` with `non_field_errors` per patient
- Partial success → 200 with `partial_errors` list + `warning` string
- Frontend: modal stays open on partial failure; error alert shows each failing
  patient and reason

## Test plan

- [ ] `docker exec django pytest tests/template_views/ -v` — 80 tests, all green
- [ ] Manual: apply template to a patient with no end date → modal stays open,
  shows "Patient has no rehabilitation end date. Set a rehab or study end date…"
- [ ] Manual: apply to a mix of patients (one with end date, one without) →
  modal stays open, shows partial warning; window.alert shows counts + warning
- [ ] Manual: apply to a patient with end date → modal closes, alert shows counts only

Closes #187
