### PR TITLE
Add CLAUDE.md and fill documentation gaps for LibreTranslate and mult…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,168 @@
+# RehaAdvisor — Developer Reference for Claude Code
+
+## Stack at a glance
+
+| Layer | Technology |
+|---|---|
+| Backend | Django 5 + MongoEngine (MongoDB), REST API, JWT auth |
+| Frontend | React + TypeScript + MobX stores |
+| Task queue | Celery + Redis |
+| Translation | LibreTranslate (self-hosted) |
+| Containers | Docker Compose — `django`, `react`, `celery`, `celery-beat`, `nginx`, `libretranslate`, `redis`, `db` |
+
+## Running the project
+
+```bash
+# Development
+docker compose -f docker-compose.dev.yml up -d
+
+# Local-prod (staging-like, uses built images)
+docker compose -f docker-compose.local-prod.yml up -d
+
+# Production (separate clone at /home/ubuntu/repos/telerehabapp-prod)
+docker compose -f docker-compose.prod.reha-advisor.yml up -d
+```
+
+## Running tests
+
+Tests run inside the `django` container (Python env is Miniconda inside Docker, not on host):
+
+```bash
+# All tests
+docker exec django pytest tests/ -v
+
+# Single module
+docker exec django pytest tests/template_views/ -v
+
+# With coverage
+docker exec django pytest tests/ --cov=. --cov-report=term-missing
+```
+
+The test suite uses `mongomock` for in-memory MongoDB — no real DB needed. All test files follow the pattern:
+
+```python
+@pytest.fixture(autouse=True, scope="function")
+def mongo_mock():
+    from mongoengine import connect, disconnect
+    from mongoengine.connection import _connections
+    alias = "default"
+    if alias in _connections:
+        disconnect(alias)
+    conn = connect("mongoenginetest", alias=alias, host="mongodb://localhost",
+                   mongo_client_class=mongomock.MongoClient)
+    yield conn
+    disconnect(alias)
+```
+
+DRF views use `APIRequestFactory` + `force_authenticate`, not Django's `Client`.
+
+## Key file locations
+
+| What | Where |
+|---|---|
+| Backend views | `backend/core/views/` (one file per domain) |
+| Models | `backend/core/models.py` |
+| URL routing | `backend/core/urls.py` |
+| Tests | `backend/tests/<module>/` |
+| Clinic/project config | `backend/config.json` |
+| Config loader | `backend/utils/config.py` → `from utils.config import config` |
+| Frontend stores (MobX) | `frontend/src/stores/` |
+| Frontend components | `frontend/src/components/` |
+
+## config.json — runtime configuration
+
+`backend/config.json` is the **single source of truth** for clinic, project, and specialization choices. It is never committed with secrets — only structural data.
+
+### `therapistInfo` section
+
+```json
+"therapistInfo": {
+  "specializations": ["Cardiology", "Neurology", ...],
+  "projects": ["COPAIN", "COMPASS"],
+  "clinic_projects": {
+    "Inselspital": ["COPAIN", "COMPASS"],
+    "Berner Reha Centrum": ["COPAIN"],
+    ...
+  },
+  "clinic_dag": {
+    "Inselspital": "inselspital",
+    "Berner Reha Centrum": "brc",
+    ...
+  }
+}
+```
+
+- `projects` — master list of valid project choices for `Therapist.projects` (MongoEngine `choices=`).
+- `clinic_projects` — maps each clinic to the REDCap projects accessible from it. **Used by `get_allowed_redcap_projects_for_therapist`** to derive access rights.
+- `clinic_dag` — maps clinic name to REDCap Data Access Group identifier used during patient import.
+- Adding a clinic or project: update both this file and the relevant `REDCAP_TOKEN_<PROJECT>` env var.
+
+### `RedCap_Characteristics`
+
+List of REDCap field names fetched when retrieving a patient record live (used by `export_record_by_pat_id`).
+
+## MongoEngine patterns
+
+**Do not** use Django ORM patterns — there are no migrations. Models inherit from `mongoengine.Document`.
+
+ReferenceField dereference — always wrap in try/except because MongoEngine raises `DoesNotExist` on broken references:
+
+```python
+value = None
+try:
+    ref = doc.some_ref_field   # triggers dereference
+    if ref is not None:
+        value = ref.name
+except Exception:
+    logger.warning("Could not resolve some_ref_field for %s", doc.id)
+```
+
+## Authentication
+
+JWT via `djangorestframework-simplejwt`. `request.user` on a DRF `@api_view` is a MongoEngine `User` document (not a Django auth user). `request.user.id` is the MongoEngine ObjectId string.
+
+`@permission_classes([IsAuthenticated])` only works when paired with `@api_view`. Without `@api_view` it is a no-op.
+
+## Environment files
+
+| File | Used by |
+|---|---|
+| `.env.dev` | `docker-compose.dev.yml` |
+| `.env.local-prod` | `docker-compose.local-prod.yml` |
+| `.env.prod` (on server) | `docker-compose.prod.reha-advisor.yml` |
+
+Key env vars (see `docs/07-ENVIRONMENT_CONFIG.md` for the full reference):
+
+```
+REDCAP_API_URL          # https://redcap.unibe.ch/api/
+REDCAP_TOKEN_COPAIN     # per-project API tokens
+REDCAP_TOKEN_COMPASS
+SENTRY_DSN              # backend error tracking
+VITE_SENTRY_DSN         # frontend error tracking
+```
+
+## LibreTranslate
+
+The `libretranslate` container provides self-hosted machine translation for intervention content. Required env vars:
+
+```
+LT_LOAD_ONLY=en,fr,de,it,nl,pt
+LT_UPDATE_MODELS=true
+LT_PACKAGES_ROOT=/app/packages
+```
+
+The `libretranslate_packages` named volume must exist — without it the language models are re-downloaded on every restart and the service is unavailable during that window.
+
+## Three-environment setup
+
+| Stack | Compose file | Purpose |
+|---|---|---|
+| `dev` | `docker-compose.dev.yml` | Active development, hot-reload, code mounted as volume |
+| `local-prod` | `docker-compose.local-prod.yml` | Staging on the same server, built images, prod-like settings |
+| `prod` | `docker-compose.prod.reha-advisor.yml` (in `/home/ubuntu/repos/telerehabapp-prod`) | Live production, pulls from GHCR |
+
+A gateway nginx (`docker-compose.gateway.yml`) routes incoming traffic between the local-prod and prod stacks on the same host. Both stacks sit on different Docker networks (`telereha` / `telereha-prod`).
+
+## Deployment
+
+Triggered automatically by publishing a GitHub Release. The workflow builds backend and frontend images, pushes to GHCR, then SSH-deploys to the production server. See `docs/PRODUCTION_DEPLOY_RUNBOOK.md` for step-by-step procedures and rollback.

--- a/docs/07-ENVIRONMENT_CONFIG.md
+++ b/docs/07-ENVIRONMENT_CONFIG.md
@@ -533,7 +533,80 @@ validate_required_env_vars()
 
 ---
 
+## LibreTranslate Service
+
+RehaAdvisor bundles a self-hosted [LibreTranslate](https://github.com/LibreTranslate/LibreTranslate) container for machine translation of intervention content. It is **not optional** — the backend calls it whenever a therapist requests translation of an intervention.
+
+### Required environment variables (set inside `docker-compose.*.yml`)
+
+| Variable | Value | Description |
+|---|---|---|
+| `LT_LOAD_ONLY` | `en,fr,de,it,nl,pt` | Comma-separated list of language pairs to load. Reducing this list speeds up startup and saves disk. |
+| `LT_UPDATE_MODELS` | `true` | Re-downloads updated language models when the container image is updated. |
+| `LT_PACKAGES_ROOT` | `/app/packages` | Path inside the container where downloaded language model packages are stored. |
+
+### Named volume
+
+```yaml
+volumes:
+  libretranslate_packages:/app/packages
+```
+
+The `libretranslate_packages` named volume **must** be declared. Without it:
+
+- Language models are re-downloaded from the internet on every container restart.
+- The service is unavailable for several minutes after each restart.
+- Translations fail with "language pair not available" errors during the download window.
+
+If you see those errors, check that the volume exists:
+
+```bash
+docker volume ls | grep libretranslate
+```
+
+If it is missing, recreate it and restart the service:
+
+```bash
+docker volume create libretranslate_packages
+docker compose -f docker-compose.dev.yml restart libretranslate
+```
+
+---
+
+## Three-Environment Setup
+
+The project runs three distinct Docker Compose stacks on the same server host:
+
+| Stack | Compose file | `.env` file | Purpose |
+|---|---|---|---|
+| **dev** | `docker-compose.dev.yml` | `.env.dev` | Active development — code mounted as volumes, hot-reload enabled |
+| **local-prod** | `docker-compose.local-prod.yml` | `.env.local-prod` | Staging on the same host — built images, prod-like settings, accessible on port 8080 |
+| **prod** | `docker-compose.prod.reha-advisor.yml` (in `/home/ubuntu/repos/telerehabapp-prod`) | `.env.prod` | Live production — pulls images from GHCR, accessible on port 443 |
+
+### Gateway nginx
+
+A dedicated `docker-compose.gateway.yml` runs an nginx reverse proxy that routes incoming HTTPS traffic to either the local-prod or production stack depending on the hostname. Both stacks attach to separate Docker networks (`telereha` and `telereha-prod`); the gateway container joins both:
+
+```bash
+docker network connect telereha-prod gateway
+```
+
+When adding a new service to either stack that should be reachable through the gateway, update `docker-compose.gateway.yml` to proxy the relevant upstream.
+
+### Dev vs local-prod differences
+
+| Feature | dev | local-prod |
+|---|---|---|
+| Code mounting | `./backend:/app` volume | Image only (no bind mount) |
+| Settings module | `api.settings.dev` | `api.settings.local_prod` |
+| Debug | `True` | `False` |
+| Hot reload | Vite HMR active | Static build served by nginx |
+| Celery broker | `redis://redis:6379/0` | `redis://redis-localprod:6379/0` |
+
+---
+
 **Related Documentation**:
 - [Getting Started](./01-GETTING_STARTED.md)
 - [Deployment Guide](./06-DEPLOYMENT_GUIDE.md)
+- [Production Deploy Runbook](./PRODUCTION_DEPLOY_RUNBOOK.md)
 - [Troubleshooting](./08-TROUBLESHOOTING.md)

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -4,10 +4,11 @@ Complete technical documentation and guides for RehaAdvisor developers and users
 
 ## 📋 Complete File List
 
-### Core Documentation (15 files)
+### Core Documentation (16 files)
 
 | File | Purpose | Audience | Length |
 |------|---------|----------|--------|
+| [CLAUDE.md](../CLAUDE.md) | Quick-reference for AI-assisted development (Claude Code) | Developers | — |
 | [README.md](./README.md) | Main documentation hub with overview | Everyone | 4.4 KB |
 | [QUICK_REFERENCE.md](./QUICK_REFERENCE.md) | Fast lookup for common tasks | Everyone | Quick ref |
 | [01-GETTING_STARTED.md](./01-GETTING_STARTED.md) | Development setup and installation | Developers | 6.0 KB |


### PR DESCRIPTION
…i-env setup

Three gaps identified in the docs review:

1. CLAUDE.md (new) — quick-reference for AI-assisted development: stack, test commands (docker exec pattern + mongomock), key file paths, config.json schema, MongoEngine patterns, auth notes, env file mapping, LibreTranslate setup, three-environment and gateway overview, deploy summary.

2. docs/07-ENVIRONMENT_CONFIG.md — new sections:
   - LibreTranslate: required LT_* vars, named volume requirement, fix for "language pair not available" errors on restart.
   - Three-environment setup: dev / local-prod / prod stacks, compose files, gateway nginx, per-stack differences table.

3. docs/INDEX.md — add CLAUDE.md entry.

# Description

> :memo: Please include a summary of the change.
>
> * Please also include relevant motivation and context.
> * List any dependencies that are required for this change.

## Related Issue
[IssueName](IssueLink)

## Type of change

For a new feature, please create an issue first to discuss it with us before submitting a pull request.

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Documentation update
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (specify)

## Tests

> :memo: Please describe the tests that you ran to verify your changes.
>
> * Provide instructions so we can reproduce.
> * Please also list any relevant details for your test configuration.

**Test Configuration**:

## Checklist

- [ ] I have read the [contributing guidelines](/docs/12-CONTRIBUTING.md).
- [ ] I have read the [code of conduct](/CODE_OF_CONDUCT.md).
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
