### PR TITLE
Fix MEDIA_ROOT path mismatch causing uploaded files to 404 in production

### DIFF
--- a/backend/api/settings/prod.py
+++ b/backend/api/settings/prod.py
@@ -22,7 +22,8 @@ ALLOWED_HOSTS = [
 SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
 SECURE_SSL_REDIRECT = os.getenv("SECURE_SSL_REDIRECT", "false").lower() == "true"
 
-STATIC_ROOT = BASE_DIR / "static"
+STATIC_ROOT = "/srv/app/static"
+MEDIA_ROOT = "/srv/app/media"
 SESSION_COOKIE_SECURE = True
 CSRF_COOKIE_SECURE = True
 


### PR DESCRIPTION
Django wrote to /app/media (base.py MEDIA_ROOT) but the media-prod Docker volume mounts at /srv/app/media — the path nginx serves from. Files went outside the volume, invisible to nginx and lost on container restart. Also corrects STATIC_ROOT to the same absolute srv path.

## Related Issue
#190 

## Type of change

For a new feature, please create an issue first to discuss it with us before submitting a pull request.

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] I have read the [contributing guidelines](/docs/12-CONTRIBUTING.md).
- [x] I have read the [code of conduct](/CODE_OF_CONDUCT.md).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
