### PR TITLE
Improve DB activity log: new action types, correct field semantics, add index

### DIFF
--- a/backend/core/models.py
+++ b/backend/core/models.py
@@ -159,7 +159,16 @@ class FitbitData(Document):
 
 
 class Logs(Document):
-    meta = {"collection": "logs"}  # MongoDB collection
+    meta = {
+        "collection": "logs",
+        "indexes": [
+            # Fast lookup by user + action ordered by time (used by last-login queries)
+            {"fields": ["userId", "action", "-timestamp"]},
+            # General time-range queries
+            {"fields": ["-timestamp"]},
+        ],
+    }
+
     userId = ReferenceField(User, required=True)
     action = StringField(
         choices=[
@@ -167,7 +176,6 @@ class Logs(Document):
             "LOGOUT",
             "UPDATE_PROFILE",
             "DELETE_ACCOUNT",
-            "OTHER",
             "REHATABLE",
             "HEALTH_PAGE",
             "VITALS_SUBMIT",
@@ -177,15 +185,22 @@ class Logs(Document):
             "UPDATE_PLAN",
             "REDCAP_IMPORT",
             "INTERVENTION_VIEW",
+            "INTERVENTION_COMPLETE",
+            "INTERVENTION_UNCOMPLETE",
+            "TEMPLATE_APPLY",
+            "PATIENT_REGISTER",
         ],
-        default="Therapist",
         required=True,
     )
     timestamp = DateTimeField(default=timezone.now)
-    ended = DateTimeField(required=False, null=True)  # Optional end time for actions like "REHATABLE"
-    started = DateTimeField(required=False, null=True)  # Optional start time for actions like "REHATABLE"
-    userAgent = StringField(max_length=20, required=True)
-    patient = ReferenceField("Patient", required=False, null=True)  # Optional, for actions related to patients
+    ended = DateTimeField(required=False, null=True)
+    started = DateTimeField(required=False, null=True)
+    # Stores the user's role ("Patient", "Therapist", "Admin") — not the browser UA.
+    # db_field keeps the MongoDB key unchanged so existing documents stay readable.
+    actor_role = StringField(max_length=50, required=True, db_field="userAgent")
+    # Optional browser User-Agent string (populated when the event originates from a web request)
+    user_agent = StringField(max_length=300, required=False, null=True)
+    patient = ReferenceField("Patient", required=False, null=True)
     details = StringField(max_length=1000)
 
     def __str__(self):

--- a/backend/core/views/auth_views.py
+++ b/backend/core/views/auth_views.py
@@ -383,7 +383,7 @@ def login_view(request):
             )
 
         # Others: issue JWT immediately
-        Logs.objects.create(userId=user, action="LOGIN", userAgent=user.role)
+        Logs.objects.create(userId=user, action="LOGIN", actor_role=user.role)
 
         refresh = RefreshToken()
         refresh["user_id"] = user_id_str
@@ -425,7 +425,7 @@ def logout_view(request):
 
         user = User.objects.get(pk=ObjectId(user_id))
 
-        Logs.objects.create(userId=user, action="LOGOUT", userAgent=user.role)
+        Logs.objects.create(userId=user, action="LOGOUT", actor_role=user.role)
 
         return JsonResponse({"message": "Logout successful"}, status=200)
 
@@ -814,6 +814,17 @@ def register_view(request):
                 rollback()
                 return _err("Rehabilitation plan creation failed.", status=500)
 
+            try:
+                Logs(
+                    userId=pat_therapist.userId,
+                    action="PATIENT_REGISTER",
+                    actor_role="Therapist",
+                    patient=patient,
+                    details=f"patient_code={patient.patient_code} clinic={patient.clinic} project={patient.project}",
+                ).save()
+            except Exception:
+                pass
+
             return JsonResponse(
                 {
                     "success": True,
@@ -1008,7 +1019,7 @@ def verify_code_view(request):
         verification.delete()
 
         refresh = RefreshToken.for_user(user)
-        Logs.objects.create(userId=user, action="LOGIN", userAgent=user.role)
+        Logs.objects.create(userId=user, action="LOGIN", actor_role=user.role)
 
         return JsonResponse(
             {

--- a/backend/core/views/patient_views.py
+++ b/backend/core/views/patient_views.py
@@ -381,6 +381,17 @@ def submit_patient_feedback(request):
                 )
                 rating.save()
 
+        try:
+            Logs(
+                userId=patient.userId,
+                action="QUESTIONNAIRE_SUBMIT",
+                actor_role="Patient",
+                patient=patient,
+                details=f"intervention_id={intervention_id} date={target_day.isoformat()}",
+            ).save()
+        except Exception:
+            pass
+
         return JsonResponse({"message": "Feedback submitted successfully"}, status=200)
 
     except Exception as e:
@@ -511,9 +522,10 @@ def mark_intervention_completed(request):
 
             Logs(
                 userId=patient.userId,
-                action="OTHER",
-                userAgent="Patient",
-                details=f"Marked intervention {intervention.title} as done on {target_day.isoformat()}",
+                action="INTERVENTION_COMPLETE",
+                actor_role="Patient",
+                patient=patient,
+                details=f"intervention={intervention.title} date={target_day.isoformat()}",
             ).save()
 
             return JsonResponse({"message": "Marked as completed successfully"}, status=200)
@@ -532,9 +544,10 @@ def mark_intervention_completed(request):
 
         Logs(
             userId=patient.userId,
-            action="OTHER",
-            userAgent="Patient",
-            details=f"Marked intervention {intervention.title} as done on {target_day.isoformat()}",
+            action="INTERVENTION_COMPLETE",
+            actor_role="Patient",
+            patient=patient,
+            details=f"intervention={intervention.title} date={target_day.isoformat()}",
         ).save()
 
         return JsonResponse({"message": "Marked as completed successfully"}, status=200)
@@ -634,9 +647,10 @@ def unmark_intervention_completed(request):
 
         Logs(
             userId=patient.userId,
-            action="OTHER",
-            userAgent="Patient",
-            details=f"Unmarked intervention {intervention.title} as done on {target_day.isoformat()}",
+            action="INTERVENTION_UNCOMPLETE",
+            actor_role="Patient",
+            patient=patient,
+            details=f"intervention={intervention.title} date={target_day.isoformat()}",
         ).save()
 
         return JsonResponse({"message": "Unmarked successfully"}, status=200)
@@ -3422,7 +3436,8 @@ def add_manual_vitals(request, patient_id: str):
         Logs.objects.create(
             userId=patient.userId,
             action="VITALS_SUBMIT",
-            userAgent=(request.headers.get("User-Agent", "") or "")[:20],
+            actor_role="Patient",
+            user_agent=(request.headers.get("User-Agent", "") or "")[:300],
             patient=patient,
             details=", ".join(fields),
         )
@@ -3594,7 +3609,8 @@ def log_intervention_view(request, patient_id: str):
         Logs.objects.create(
             userId=patient.userId,
             action="INTERVENTION_VIEW",
-            userAgent=(request.headers.get("User-Agent", "") or "")[:20],
+            actor_role="Patient",
+            user_agent=(request.headers.get("User-Agent", "") or "")[:300],
             patient=patient,
             details=f"intervention_id={intervention_id} date={date} seconds={seconds_viewed}",
         )

--- a/backend/core/views/recomendation_views.py
+++ b/backend/core/views/recomendation_views.py
@@ -274,7 +274,8 @@ def apply_template_to_patient(request, therapist_id):
             Logs.objects.create(
                 userId=therapist.userId,
                 action="ASSIGN_INTERVENTION",
-                userAgent=(request.headers.get("User-Agent", "") or "")[:20],
+                actor_role="Therapist",
+                user_agent=(request.headers.get("User-Agent", "") or "")[:300],
                 patient=patient,
                 details=f"diagnosis={diagnosis} applied={applied} sessions={total_sessions}",
             )

--- a/backend/core/views/redcap_import_views.py
+++ b/backend/core/views/redcap_import_views.py
@@ -664,7 +664,8 @@ def import_patient_from_redcap(request):
             Logs.objects.create(
                 userId=therapist.userId,
                 action="REDCAP_IMPORT",
-                userAgent=(request.headers.get("User-Agent", "") or "")[:20],
+                actor_role="Therapist",
+                user_agent=(request.headers.get("User-Agent", "") or "")[:300],
                 patient=patient,
                 details=f"project={project} identifier={final_identifier} dag={dag}",
             )

--- a/backend/core/views/template_views.py
+++ b/backend/core/views/template_views.py
@@ -30,6 +30,7 @@ from core.models import (
     Intervention,
     InterventionAssignment,
     InterventionTemplate,
+    Logs,
     Patient,
     RehabilitationPlan,
     Therapist,
@@ -805,6 +806,20 @@ def apply_named_template(request, template_id):
             non_field_errors=[f"{e['patient']}: {e['reason']}" for e in patient_errors],
             status=400,
         )
+
+    try:
+        Logs(
+            userId=therapist.userId,
+            action="TEMPLATE_APPLY",
+            actor_role="Therapist",
+            details=(
+                f"template={tmpl.id} applied={total_applied} "
+                f"sessions={total_sessions} patients={patients_affected} "
+                f"errors={len(patient_errors)}"
+            ),
+        ).save()
+    except Exception:
+        pass
 
     response: Dict = {
         "success": True,

--- a/backend/core/views/therapist_access_views.py
+++ b/backend/core/views/therapist_access_views.py
@@ -155,7 +155,7 @@ def therapist_access(request, therapistId: str | None = None):
         Logs.objects.create(
             userId=th.userId,
             action="UPDATE_PROFILE",
-            userAgent="Admin",
+            actor_role="Admin",
             details=f"Updated therapist access therapist={str(th.id)} clinics {old_clinics}->{norm_clinics} projects {old_projects}->{norm_projects}",
         )
     except Exception:

--- a/backend/core/views/therapist_projects.py
+++ b/backend/core/views/therapist_projects.py
@@ -93,7 +93,7 @@ def therapist_projects(request):
         Logs.objects.create(
             userId=th.userId,
             action="UPDATE_PROFILE",
-            userAgent="Admin",
+            actor_role="Admin",
             details=f"Updated therapist.projects for therapist={str(th.id)} old={old_projects} new={normalized}",
         )
     except Exception:

--- a/backend/core/views/therapist_views.py
+++ b/backend/core/views/therapist_views.py
@@ -664,16 +664,6 @@ def list_therapist_patients(request, therapist_id):
                 }
             )
 
-        try:
-            Logs.objects.create(
-                userId=therapist.userId,
-                action="OPEN_PATIENT",
-                userAgent=(request.headers.get("User-Agent", "") or "")[:20],
-                details=f"patient_count={len(output_list)}",
-            )
-        except Exception:
-            pass
-
         # ✅ tests expect the response itself is a list
         return JsonResponse(output_list, safe=False, status=200)
 
@@ -720,10 +710,11 @@ def create_log(request):
             user = User.objects.get(id=ObjectId(user))
         log = Logs(
             userId=user,
-            action=data.get("action", "OTHER"),
+            action=data.get("action", "REHATABLE"),
             started=started,
             ended=ended,
-            userAgent=data.get("userAgent", ""),
+            actor_role=data.get("userAgent", data.get("actor_role", "Therapist")),
+            user_agent=(request.headers.get("User-Agent", "") or "")[:300],
             patient=patient,
             details=data.get("details", "")[:500],
         )

--- a/backend/core/views/user_views.py
+++ b/backend/core/views/user_views.py
@@ -213,7 +213,7 @@ def change_password(request, therapist_id):
     Logs.objects.create(
         userId=user,
         action="UPDATE_PROFILE",
-        userAgent="Therapist",
+        actor_role="Therapist",
         details="Password changed securely",
     )
 
@@ -234,7 +234,6 @@ def user_profile_view(request, user_id):
     """
 
     logger.info(f"[PROFILE] user_profile_view user_id={user_id}")
-    print(f"[PROFILE] user_profile_view user_id={user_id}")
 
     # ------------------------------------------------------------------
     # Resolve actual USER object (ID may be User ID OR Patient ID)
@@ -398,6 +397,22 @@ def user_profile_view(request, user_id):
                 except Exception:
                     logger.warning("Could not resolve therapist for patient %s", pt.id)
 
+                # Log therapist opening a patient profile
+                viewer = getattr(request, "user", None)
+                viewer_role = getattr(viewer, "role", "") if viewer else ""
+                if viewer_role == "Therapist":
+                    try:
+                        Logs(
+                            userId=viewer,
+                            action="OPEN_PATIENT",
+                            actor_role="Therapist",
+                            user_agent=(request.headers.get("User-Agent", "") or "")[:300],
+                            patient=pt,
+                            details=f"patient_code={pt.patient_code}",
+                        ).save()
+                    except Exception:
+                        pass
+
             return JsonResponse(obj, status=200)
 
         except Exception as e:
@@ -433,7 +448,7 @@ def user_profile_view(request, user_id):
                 Logs.objects.create(
                     userId=user,
                     action="UPDATE_PROFILE",
-                    userAgent="Patient",
+                    actor_role="Patient",
                     details="Password changed via profile endpoint",
                 )
 
@@ -556,7 +571,7 @@ def user_profile_view(request, user_id):
             Logs.objects.create(
                 userId=user,
                 action="UPDATE_PROFILE",
-                userAgent="Patient",
+                actor_role="Patient",
                 details=f"Updated: {updated} | old: {old}",
             )
 
@@ -575,7 +590,7 @@ def user_profile_view(request, user_id):
             Logs.objects.create(
                 userId=user,
                 action="DELETE_ACCOUNT",
-                userAgent="Patient",
+                actor_role="Patient",
                 details=f"Soft-deleted {user_id}",
             )
 
@@ -645,7 +660,7 @@ def reset_patient_password(request, patient_id):
     Logs.objects.create(
         userId=user,
         action="UPDATE_PROFILE",
-        userAgent="Therapist",
+        actor_role="Therapist",
         details=f"Password reset by therapist for patient {patient_id}",
     )
 

--- a/backend/core/views/user_views.py
+++ b/backend/core/views/user_views.py
@@ -100,7 +100,6 @@ from django.core.mail import send_mail
 from django.views.decorators.http import require_http_methods
 from mongoengine.queryset.visitor import Q
 
-
 # ----------------------------------------
 # Helpers
 # ----------------------------------------

--- a/backend/core/views/user_views.py
+++ b/backend/core/views/user_views.py
@@ -102,8 +102,34 @@ from mongoengine.queryset.visitor import Q
 
 
 # ----------------------------------------
-# Helper
+# Helpers
 # ----------------------------------------
+
+
+def _get_viewer_user(request):
+    """Return the User who made this request by decoding the JWT Bearer token.
+
+    Plain Django function views don't go through DRF's authentication pipeline,
+    so request.user is always AnonymousUser for JWT-authenticated calls.  This
+    helper decodes the Authorization header directly so we can identify the
+    caller for audit logging without restructuring the view.
+    Returns None when the token is absent, invalid, or the user is not in DB.
+    """
+    try:
+        auth_header = request.headers.get("Authorization", "") or ""
+        if not auth_header.startswith("Bearer "):
+            return None
+        from rest_framework_simplejwt.tokens import AccessToken
+
+        token = AccessToken(auth_header.split(" ", 1)[1])
+        user_id = token.get("user_id")
+        if not user_id:
+            return None
+        return User.objects.get(pk=str(user_id))
+    except Exception:
+        return None
+
+
 def valid_update_value(v):
     if v in ("", None, []):
         return False  # skip completely
@@ -398,7 +424,7 @@ def user_profile_view(request, user_id):
                     logger.warning("Could not resolve therapist for patient %s", pt.id)
 
                 # Log therapist opening a patient profile
-                viewer = getattr(request, "user", None)
+                viewer = _get_viewer_user(request)
                 viewer_role = getattr(viewer, "role", "") if viewer else ""
                 if viewer_role == "Therapist":
                     try:

--- a/backend/tests/activity_logs/TESTING.md
+++ b/backend/tests/activity_logs/TESTING.md
@@ -1,0 +1,134 @@
+# Activity Logs — Test Documentation
+
+Tests for the `Logs` MongoDB collection after the **190-improve-db-logs** refactor.
+Every test in [`test_activity_logs.py`](test_activity_logs.py) asserts that the
+correct `action`, `actor_role`, `userId`, `patient`, and `details` values are
+written to the collection by each view.
+
+---
+
+## What changed in the refactor
+
+| Before | After |
+|---|---|
+| `action="OTHER"` used for intervention complete/uncomplete | Dedicated `INTERVENTION_COMPLETE` / `INTERVENTION_UNCOMPLETE` actions |
+| No log on questionnaire submit | `QUESTIONNAIRE_SUBMIT` log added |
+| No log on patient registration | `PATIENT_REGISTER` log added |
+| `OPEN_PATIENT` fired on every patient-list load | `OPEN_PATIENT` fires only when a therapist opens a specific patient's profile |
+| `userAgent` field stored actor role (e.g. `"Patient"`) | `actor_role` field stores actor role; `user_agent` stores the HTTP User-Agent header |
+| `create_log` defaulted to `action="OTHER"` (now invalid) | Defaults to `action="REHATABLE"` |
+| No indexes on `Logs` collection | Composite index `(userId, action, -timestamp)` and time-range index `(-timestamp)` added |
+
+### Backward compatibility
+
+`actor_role` is stored in MongoDB under the key `userAgent` via MongoEngine's
+`db_field="userAgent"`.  Existing documents written before the refactor remain
+readable — the Python attribute name changed but the database field name did not.
+
+---
+
+## Endpoints covered
+
+| Endpoint | HTTP verb | Log action written |
+|---|---|---|
+| `/api/interventions/complete/` | POST | `INTERVENTION_COMPLETE` |
+| `/api/interventions/uncomplete/` | POST | `INTERVENTION_UNCOMPLETE` |
+| `/api/patients/feedback/questionaire/` | POST | `QUESTIONNAIRE_SUBMIT` |
+| `/api/auth/register/` (Patient path) | POST | `PATIENT_REGISTER` |
+| `/api/users/<id>/profile/` (Therapist viewer) | GET | `OPEN_PATIENT` |
+| `/api/analytics/log` | POST | `REHATABLE` / any valid action |
+
+---
+
+## Test cases
+
+### INTERVENTION_COMPLETE
+
+| Test | Scenario | Asserts |
+|---|---|---|
+| `test_mark_intervention_completed_writes_intervention_complete_log` | Patient marks an intervention done | `Logs(action="INTERVENTION_COMPLETE")` written; `userId=patient.userId`, `patient=patient`, `actor_role="Patient"`, intervention title in details |
+| `test_mark_intervention_completed_log_details_contain_date` | Same, today's date | Today's ISO date appears in `details` |
+
+### INTERVENTION_UNCOMPLETE
+
+| Test | Scenario | Asserts |
+|---|---|---|
+| `test_unmark_intervention_completed_writes_intervention_uncomplete_log` | Completion log exists; patient unmarks it | `Logs(action="INTERVENTION_UNCOMPLETE")` written; correct user/patient linkage |
+| `test_unmark_no_log_does_not_write_uncomplete_log` | No completion log for the requested day | Zero `INTERVENTION_UNCOMPLETE` logs (nothing changed → nothing to record) |
+
+### QUESTIONNAIRE_SUBMIT
+
+| Test | Scenario | Asserts |
+|---|---|---|
+| `test_submit_patient_feedback_writes_questionnaire_submit_log` | Patient submits questionnaire answers | `Logs(action="QUESTIONNAIRE_SUBMIT")` written; `userId=patient.userId`, `patient=patient`, `actor_role="Patient"` |
+
+### PATIENT_REGISTER
+
+| Test | Scenario | Asserts |
+|---|---|---|
+| `test_patient_registration_writes_patient_register_log` | Therapist registers a new patient | `Logs(action="PATIENT_REGISTER")` written; `userId=therapist.userId`, `actor_role="Therapist"`, patient_code and clinic in details |
+| `test_patient_registration_log_missing_on_failure` | Registration fails (missing `rehaEndDate`) | Zero `PATIENT_REGISTER` logs |
+
+### OPEN_PATIENT
+
+| Test | Scenario | Asserts |
+|---|---|---|
+| `test_open_patient_log_written_when_therapist_views_patient_profile` | Therapist GETs a patient's profile | `Logs(action="OPEN_PATIENT")` written; `userId=therapist.userId`, `patient=patient`, `actor_role="Therapist"`, patient_code in details |
+| `test_open_patient_log_not_written_when_patient_views_own_profile` | Patient GETs their own profile | Zero `OPEN_PATIENT` logs |
+
+### create_log  (`POST /api/analytics/log`)
+
+| Test | Scenario | Asserts |
+|---|---|---|
+| `test_create_log_defaults_to_rehatable_action` | Body omits `action` | Stored action is `REHATABLE` (not the old invalid `"OTHER"`) |
+| `test_create_log_accepts_legacy_useragent_key` | Body sends `userAgent: "Therapist"` | `actor_role == "Therapist"` |
+| `test_create_log_accepts_actor_role_key` | Body sends `actor_role: "Patient"` | `actor_role == "Patient"` |
+| `test_create_log_captures_http_user_agent_header` | HTTP `User-Agent` header set | `log.user_agent` contains the header value |
+| `test_create_log_truncates_details_to_500_chars` | `details` is 600 chars | Stored `details` has length 500 |
+| `test_create_log_returns_log_id_in_response` | Valid request | Response contains `log_id` matching the saved document |
+| `test_create_log_unknown_user_returns_500` | Non-existent user ObjectId | 500 (documented behaviour) |
+| `test_create_log_invalid_json_returns_500` | Malformed JSON body | 500 |
+
+### Logs model — field mapping
+
+| Test | Scenario | Asserts |
+|---|---|---|
+| `test_logs_actor_role_stored_in_useragent_db_field` | Save a `Logs` doc, inspect raw MongoDB doc | Raw document key is `userAgent`, not `actor_role` |
+| `test_logs_invalid_action_raises_validation_error` | Save with `action="OTHER"` (removed choice) | MongoEngine `ValidationError` raised |
+
+---
+
+## Running the tests
+
+```bash
+# From the backend/ directory (inside the django container)
+docker exec django pytest tests/activity_logs/ -v
+```
+
+---
+
+## Test infrastructure
+
+### `mongo_mock` fixture
+
+Function-scoped `autouse` fixture that:
+1. Disconnects any existing mongoengine default connection.
+2. Creates a fresh in-memory `mongomock.MongoClient` connection.
+3. Tears down after each test.
+
+Guarantees full test isolation — no state leaks between tests.
+
+### Factory helpers
+
+| Helper | Creates |
+|---|---|
+| `_make_therapist(suffix)` | `User` (Therapist role) + linked `Therapist` doc |
+| `_make_patient(therapist, suffix)` | `User` (Patient role) + `Patient` doc |
+| `_make_plan_with_intervention(patient, therapist)` | `Intervention` + `RehabilitationPlan` with one assignment |
+
+### Mocking
+
+- `core.views.auth_views.send_mail` — mocked in `PATIENT_REGISTER` tests to avoid SMTP calls.
+- `core.jwt_auth.MongoJWTAuthentication.authenticate` — mocked in `OPEN_PATIENT` tests to inject
+  a specific authenticated user, since the JWT middleware has no effect in plain Django test client
+  calls but `request.user` is read by the view to decide whether to write the log.

--- a/backend/tests/activity_logs/test_activity_logs.py
+++ b/backend/tests/activity_logs/test_activity_logs.py
@@ -1,0 +1,600 @@
+"""
+Activity Logs — integration tests
+==================================
+
+Covers every view that writes to the ``Logs`` collection after the
+190-improve-db-logs refactor.  Each test asserts that:
+
+  1. The correct ``action`` value is stored.
+  2. The ``actor_role`` field (stored in MongoDB as ``userAgent``) is correct.
+  3. The ``userId`` references the expected User document.
+  4. The ``patient`` reference is set when relevant.
+  5. Key tokens appear in ``details``.
+
+Also tests the ``create_log`` endpoint's backward-compatibility with the
+legacy ``userAgent`` body key and its new ``actor_role`` key.
+
+Endpoints under test
+---------------------
+``POST /api/interventions/complete/``           → INTERVENTION_COMPLETE
+``POST /api/interventions/uncomplete/``         → INTERVENTION_UNCOMPLETE
+``POST /api/patients/feedback/questionaire/``   → QUESTIONNAIRE_SUBMIT
+``POST /api/auth/register/``  (Patient path)    → PATIENT_REGISTER
+``GET  /api/users/<id>/profile/``  (Therapist)  → OPEN_PATIENT
+``POST /api/analytics/log``                     → REHATABLE / any action
+"""
+
+import json
+from datetime import datetime, timedelta
+from unittest import mock
+
+import mongomock
+import pytest
+from bson import ObjectId
+from django.contrib.auth.hashers import make_password
+from django.test import Client
+
+from core.models import (
+    Intervention,
+    Logs,
+    Patient,
+    PatientInterventionLogs,
+    RehabilitationPlan,
+    Therapist,
+    User,
+)
+
+client = Client()
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True, scope="function")
+def mongo_mock():
+    from mongoengine import connect, disconnect
+    from mongoengine.connection import _connections
+
+    alias = "default"
+    if alias in _connections:
+        disconnect(alias)
+    conn = connect(
+        "mongoenginetest",
+        alias=alias,
+        host="mongodb://localhost",
+        mongo_client_class=mongomock.MongoClient,
+    )
+    yield conn
+    disconnect(alias)
+
+
+# ---------------------------------------------------------------------------
+# Factory helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_therapist(suffix=""):
+    th_user = User(
+        username=f"therapist{suffix}",
+        email=f"therapist{suffix}@example.com",
+        phone="000",
+        role="Therapist",
+        createdAt=datetime.now(),
+        isActive=True,
+    ).save()
+    therapist = Therapist(
+        userId=th_user,
+        clinics=["Inselspital"],
+        projects=["COPAIN"],
+    ).save()
+    return th_user, therapist
+
+
+def _make_patient(therapist, suffix=""):
+    p_user = User(
+        username=f"patient{suffix}",
+        email=f"patient{suffix}@example.com",
+        phone="111",
+        role="Patient",
+        createdAt=datetime.now(),
+        isActive=True,
+    ).save()
+    patient = Patient(
+        userId=p_user,
+        patient_code=f"PAT{suffix}",
+        therapist=therapist,
+        access_word="pass",
+        clinic="Inselspital",
+        project="COPAIN",
+    ).save()
+    return p_user, patient
+
+
+def _make_plan_with_intervention(patient, therapist):
+    from core.models import InterventionAssignment
+
+    intervention = Intervention(
+        title="TestIntervention",
+        description="desc",
+        content_type="Video",
+        external_id="INT_ACT_001",
+        language="en",
+    ).save()
+    assignment = InterventionAssignment(
+        interventionId=intervention,
+        dates=[datetime.now()],
+        frequency="Daily",
+    )
+    plan = RehabilitationPlan(
+        patientId=patient,
+        therapistId=therapist,
+        startDate=datetime.now(),
+        endDate=datetime.now() + timedelta(days=30),
+        status="active",
+        interventions=[assignment],
+    ).save()
+    return intervention, plan
+
+
+# ---------------------------------------------------------------------------
+# INTERVENTION_COMPLETE
+# ---------------------------------------------------------------------------
+
+
+def test_mark_intervention_completed_writes_intervention_complete_log(mongo_mock):
+    """
+    ``mark_intervention_completed`` must write a ``Logs`` doc with
+    action=INTERVENTION_COMPLETE linked to the patient's User.
+    """
+    _, therapist = _make_therapist()
+    p_user, patient = _make_patient(therapist)
+    intervention, _ = _make_plan_with_intervention(patient, therapist)
+
+    resp = client.post(
+        "/api/interventions/complete/",
+        data=json.dumps(
+            {
+                "patient_id": str(p_user.id),  # view looks up Patient by userId
+                "intervention_id": str(intervention.id),
+            }
+        ),
+        content_type="application/json",
+    )
+    assert resp.status_code == 200
+
+    log = Logs.objects(action="INTERVENTION_COMPLETE").first()
+    assert log is not None, "Expected INTERVENTION_COMPLETE log"
+    assert log.userId.id == p_user.id
+    assert log.patient.id == patient.id
+    assert log.actor_role == "Patient"
+    assert "TestIntervention" in (log.details or "")
+
+
+def test_mark_intervention_completed_log_details_contain_date(mongo_mock):
+    """Details string must include the target ISO date."""
+    _, therapist = _make_therapist(suffix="2")
+    p_user, patient = _make_patient(therapist, suffix="2")
+    intervention, _ = _make_plan_with_intervention(patient, therapist)
+    today = datetime.now().date().isoformat()
+
+    client.post(
+        "/api/interventions/complete/",
+        data=json.dumps(
+            {
+                "patient_id": str(p_user.id),  # view looks up Patient by userId
+                "intervention_id": str(intervention.id),
+            }
+        ),
+        content_type="application/json",
+    )
+
+    log = Logs.objects(action="INTERVENTION_COMPLETE").first()
+    assert log is not None
+    assert today in (log.details or "")
+
+
+# ---------------------------------------------------------------------------
+# INTERVENTION_UNCOMPLETE
+# ---------------------------------------------------------------------------
+
+
+def test_unmark_intervention_completed_writes_intervention_uncomplete_log(mongo_mock):
+    """
+    ``unmark_intervention_completed`` must write a ``Logs`` doc with
+    action=INTERVENTION_UNCOMPLETE when there is a completion log to remove.
+    """
+    _, therapist = _make_therapist(suffix="u")
+    p_user, patient = _make_patient(therapist, suffix="u")
+    intervention, plan = _make_plan_with_intervention(patient, therapist)
+    today = datetime.now().date()
+
+    PatientInterventionLogs(
+        userId=patient,
+        interventionId=intervention,
+        rehabilitationPlanId=plan,
+        date=datetime.combine(today, datetime.min.time()),
+        status=["completed"],
+    ).save()
+
+    resp = client.post(
+        "/api/interventions/uncomplete/",
+        data=json.dumps(
+            {
+                "patient_id": str(p_user.id),  # view looks up Patient by userId
+                "intervention_id": str(intervention.id),
+                "date": today.isoformat(),
+            }
+        ),
+        content_type="application/json",
+    )
+    assert resp.status_code == 200
+
+    log = Logs.objects(action="INTERVENTION_UNCOMPLETE").first()
+    assert log is not None, "Expected INTERVENTION_UNCOMPLETE log"
+    assert log.userId.id == p_user.id
+    assert log.actor_role == "Patient"
+    assert "TestIntervention" in (log.details or "")
+
+
+def test_unmark_no_log_does_not_write_uncomplete_log(mongo_mock):
+    """
+    When there is no completion log for the requested day the view returns 200
+    'No completion log for this day' and must NOT write an INTERVENTION_UNCOMPLETE
+    log (nothing was actually changed).
+    """
+    _, therapist = _make_therapist(suffix="un2")
+    p_user, patient = _make_patient(therapist, suffix="un2")
+    intervention, _ = _make_plan_with_intervention(patient, therapist)
+
+    yesterday = (datetime.now() - timedelta(days=1)).date().isoformat()
+    client.post(
+        "/api/interventions/uncomplete/",
+        data=json.dumps(
+            {
+                "patient_id": str(p_user.id),  # view looks up Patient by userId
+                "intervention_id": str(intervention.id),
+                "date": yesterday,
+            }
+        ),
+        content_type="application/json",
+    )
+
+    assert Logs.objects(action="INTERVENTION_UNCOMPLETE").count() == 0
+
+
+# ---------------------------------------------------------------------------
+# QUESTIONNAIRE_SUBMIT
+# ---------------------------------------------------------------------------
+
+
+def test_submit_patient_feedback_writes_questionnaire_submit_log(mongo_mock):
+    """
+    ``submit_patient_feedback`` must write a QUESTIONNAIRE_SUBMIT log after
+    processing feedback, regardless of whether any FeedbackQuestion records
+    matched the submitted keys.
+    """
+    _, therapist = _make_therapist(suffix="q")
+    p_user, patient = _make_patient(therapist, suffix="q")
+
+    # The log is written at the end of the view regardless of question matches.
+    # We submit a non-empty answer map to get past the "No feedback responses"
+    # early-return guard.
+    resp = client.post(
+        "/api/patients/feedback/questionaire/",
+        data={
+            "userId": str(p_user.id),  # view looks up Patient by userId
+            "open_feedback": "Feeling well",
+        },
+        HTTP_AUTHORIZATION="Bearer test",
+    )
+    assert resp.status_code == 200
+
+    log = Logs.objects(action="QUESTIONNAIRE_SUBMIT").first()
+    assert log is not None, "Expected QUESTIONNAIRE_SUBMIT log"
+    assert log.userId.id == p_user.id
+    assert log.patient.id == patient.id
+    assert log.actor_role == "Patient"
+
+
+# ---------------------------------------------------------------------------
+# PATIENT_REGISTER
+# ---------------------------------------------------------------------------
+
+
+@mock.patch("core.views.auth_views.send_mail")
+def test_patient_registration_writes_patient_register_log(mock_mail, mongo_mock):
+    """
+    A successful patient registration via ``/api/auth/register/`` must write a
+    PATIENT_REGISTER log linked to the therapist's User document.
+    """
+    th_user, therapist = _make_therapist(suffix="pr")
+
+    payload = {
+        "userType": "Patient",
+        "email": "newpatient@example.com",
+        "password": "strongpass123",
+        "firstName": "New",
+        "lastName": "Patient",
+        "therapist": str(th_user.id),  # register_view looks up by User ID, not Therapist ID
+        "rehaEndDate": "2027-12-31",
+        "clinic": "Inselspital",
+        "project": "COPAIN",
+        "patient_code": "PAT_REG_01",
+    }
+
+    resp = client.post(
+        "/api/auth/register/",
+        data=json.dumps(payload),
+        content_type="application/json",
+    )
+    assert resp.status_code == 200, resp.json()
+
+    log = Logs.objects(action="PATIENT_REGISTER").first()
+    assert log is not None, "Expected PATIENT_REGISTER log"
+    assert log.userId.id == th_user.id
+    assert log.actor_role == "Therapist"
+    assert "PAT_REG_01" in (log.details or "")
+    assert "Inselspital" in (log.details or "")
+
+
+@mock.patch("core.views.auth_views.send_mail")
+def test_patient_registration_log_missing_on_failure(mock_mail, mongo_mock):
+    """
+    A failed registration (missing rehaEndDate) must NOT write a PATIENT_REGISTER log.
+    """
+    _make_therapist(suffix="prf")
+    _, therapist = _make_therapist(suffix="prf2")
+
+    payload = {
+        "userType": "Patient",
+        "email": "failpatient@example.com",
+        "password": "pw",
+        "firstName": "F",
+        "lastName": "P",
+        "therapist": str(therapist.id),
+        # rehaEndDate intentionally omitted
+    }
+
+    resp = client.post(
+        "/api/auth/register/",
+        data=json.dumps(payload),
+        content_type="application/json",
+    )
+    assert resp.status_code == 400
+    assert Logs.objects(action="PATIENT_REGISTER").count() == 0
+
+
+# ---------------------------------------------------------------------------
+# OPEN_PATIENT
+# ---------------------------------------------------------------------------
+
+
+def test_open_patient_log_written_when_therapist_views_patient_profile(mongo_mock):
+    """
+    ``GET /api/users/<patient_user_id>/profile/`` fires an OPEN_PATIENT log
+    when the viewer is identified as a Therapist.  The log must reference the
+    viewed patient document.
+
+    ``_get_viewer_user`` is patched to return the therapist user directly —
+    plain function views don't run DRF JWT auth so the real Bearer token
+    path can't be exercised without a live JWT signing key.
+    """
+    th_user, therapist = _make_therapist(suffix="op")
+    p_user, patient = _make_patient(therapist, suffix="op")
+
+    with mock.patch("core.views.user_views._get_viewer_user", return_value=th_user):
+        resp = client.get(f"/api/users/{str(p_user.id)}/profile/")
+
+    assert resp.status_code == 200
+
+    log = Logs.objects(action="OPEN_PATIENT").first()
+    assert log is not None, "Expected OPEN_PATIENT log"
+    assert log.userId.id == th_user.id
+    assert log.actor_role == "Therapist"
+    assert log.patient.id == patient.id
+    assert "PATop" in (log.details or "")
+
+
+def test_open_patient_log_not_written_when_patient_views_own_profile(mongo_mock):
+    """
+    When a Patient (not a Therapist) calls GET /api/users/<id>/profile/ no
+    OPEN_PATIENT log must be written.
+    """
+    _, therapist = _make_therapist(suffix="op2")
+    p_user, _ = _make_patient(therapist, suffix="op2")
+
+    with mock.patch("core.views.user_views._get_viewer_user", return_value=p_user):
+        client.get(f"/api/users/{str(p_user.id)}/profile/")
+
+    assert Logs.objects(action="OPEN_PATIENT").count() == 0
+
+
+# ---------------------------------------------------------------------------
+# create_log  —  POST /api/analytics/log
+# ---------------------------------------------------------------------------
+
+
+def test_create_log_defaults_to_rehatable_action(mongo_mock):
+    """
+    When the body omits the ``action`` key the endpoint must store
+    action=REHATABLE (not the old "OTHER" which is no longer a valid choice).
+    """
+    th_user, _ = _make_therapist(suffix="cl")
+
+    resp = client.post(
+        "/api/analytics/log",
+        data=json.dumps({"user": str(th_user.id), "details": "page load"}),
+        content_type="application/json",
+    )
+    assert resp.status_code == 201
+    log = Logs.objects.first()
+    assert log is not None
+    assert log.action == "REHATABLE"
+
+
+def test_create_log_accepts_legacy_useragent_key(mongo_mock):
+    """
+    The frontend still sends ``userAgent`` in the body.  The endpoint must
+    accept this key and store it in ``actor_role``.
+    """
+    th_user, _ = _make_therapist(suffix="cl2")
+
+    resp = client.post(
+        "/api/analytics/log",
+        data=json.dumps(
+            {
+                "user": str(th_user.id),
+                "action": "REHATABLE",
+                "userAgent": "Therapist",
+            }
+        ),
+        content_type="application/json",
+    )
+    assert resp.status_code == 201
+    log = Logs.objects.first()
+    assert log is not None
+    assert log.actor_role == "Therapist"
+
+
+def test_create_log_accepts_actor_role_key(mongo_mock):
+    """
+    The new ``actor_role`` key must also be accepted, so updated frontend
+    clients or other callers work correctly.
+    """
+    th_user, _ = _make_therapist(suffix="cl3")
+
+    resp = client.post(
+        "/api/analytics/log",
+        data=json.dumps(
+            {
+                "user": str(th_user.id),
+                "action": "HEALTH_PAGE",
+                "actor_role": "Patient",
+            }
+        ),
+        content_type="application/json",
+    )
+    assert resp.status_code == 201
+    log = Logs.objects.first()
+    assert log is not None
+    assert log.actor_role == "Patient"
+    assert log.action == "HEALTH_PAGE"
+
+
+def test_create_log_captures_http_user_agent_header(mongo_mock):
+    """
+    The real HTTP User-Agent header must be stored in the ``user_agent`` field
+    (separate from ``actor_role``).
+    """
+    th_user, _ = _make_therapist(suffix="cl4")
+
+    resp = client.post(
+        "/api/analytics/log",
+        data=json.dumps({"user": str(th_user.id), "action": "REHATABLE"}),
+        content_type="application/json",
+        HTTP_USER_AGENT="Mozilla/5.0 TestBrowser/1.0",
+    )
+    assert resp.status_code == 201
+    log = Logs.objects.first()
+    assert log is not None
+    assert "Mozilla" in (log.user_agent or "")
+
+
+def test_create_log_truncates_details_to_500_chars(mongo_mock):
+    """Details longer than 500 characters must be silently truncated."""
+    th_user, _ = _make_therapist(suffix="cl5")
+    long_details = "x" * 600
+
+    client.post(
+        "/api/analytics/log",
+        data=json.dumps(
+            {"user": str(th_user.id), "action": "REHATABLE", "details": long_details}
+        ),
+        content_type="application/json",
+    )
+    log = Logs.objects.first()
+    assert log is not None
+    assert len(log.details) == 500
+
+
+def test_create_log_returns_log_id_in_response(mongo_mock):
+    """The 201 response body must include ``log_id``."""
+    th_user, _ = _make_therapist(suffix="cl6")
+
+    resp = client.post(
+        "/api/analytics/log",
+        data=json.dumps({"user": str(th_user.id)}),
+        content_type="application/json",
+    )
+    assert resp.status_code == 201
+    body = resp.json()
+    assert "log_id" in body
+    assert body["log_id"] == str(Logs.objects.first().id)
+
+
+def test_create_log_unknown_user_returns_500(mongo_mock):
+    """A non-existent user ObjectId must return 500 (existing documented behaviour)."""
+    resp = client.post(
+        "/api/analytics/log",
+        data=json.dumps({"user": str(ObjectId()), "action": "REHATABLE"}),
+        content_type="application/json",
+    )
+    assert resp.status_code == 500
+
+
+def test_create_log_invalid_json_returns_500(mongo_mock):
+    """Malformed JSON body must return 500."""
+    resp = client.post(
+        "/api/analytics/log",
+        data="not-json",
+        content_type="application/json",
+    )
+    assert resp.status_code == 500
+
+
+# ---------------------------------------------------------------------------
+# Logs model — field mapping
+# ---------------------------------------------------------------------------
+
+
+def test_logs_actor_role_stored_in_useragent_db_field(mongo_mock):
+    """
+    The ``actor_role`` Python attribute must be stored under the key
+    ``userAgent`` in MongoDB (db_field backward-compat).  We verify this by
+    reading the raw pymongo document after saving a Logs entry.
+    """
+    th_user, _ = _make_therapist(suffix="dbf")
+
+    Logs(
+        userId=th_user,
+        action="LOGIN",
+        actor_role="Therapist",
+    ).save()
+
+    from mongoengine.connection import get_db
+
+    raw = get_db()["logs"].find_one({"action": "LOGIN"})
+    assert raw is not None
+    assert raw.get("userAgent") == "Therapist", (
+        "actor_role must be stored under the 'userAgent' MongoDB field for backward compat"
+    )
+    assert "actor_role" not in raw, "Python attribute name must NOT appear in the raw document"
+
+
+def test_logs_invalid_action_raises_validation_error(mongo_mock):
+    """
+    Saving a Logs doc with an action not in the choices list must raise a
+    mongoengine ValidationError, not silently save garbage.
+    """
+    from mongoengine import ValidationError
+
+    th_user, _ = _make_therapist(suffix="va")
+
+    with pytest.raises(ValidationError):
+        Logs(
+            userId=th_user,
+            action="OTHER",
+            actor_role="Therapist",
+        ).save()

--- a/backend/tests/activity_logs/test_activity_logs.py
+++ b/backend/tests/activity_logs/test_activity_logs.py
@@ -509,9 +509,7 @@ def test_create_log_truncates_details_to_500_chars(mongo_mock):
 
     client.post(
         "/api/analytics/log",
-        data=json.dumps(
-            {"user": str(th_user.id), "action": "REHATABLE", "details": long_details}
-        ),
+        data=json.dumps({"user": str(th_user.id), "action": "REHATABLE", "details": long_details}),
         content_type="application/json",
     )
     log = Logs.objects.first()
@@ -577,9 +575,9 @@ def test_logs_actor_role_stored_in_useragent_db_field(mongo_mock):
 
     raw = get_db()["logs"].find_one({"action": "LOGIN"})
     assert raw is not None
-    assert raw.get("userAgent") == "Therapist", (
-        "actor_role must be stored under the 'userAgent' MongoDB field for backward compat"
-    )
+    assert (
+        raw.get("userAgent") == "Therapist"
+    ), "actor_role must be stored under the 'userAgent' MongoDB field for backward compat"
     assert "actor_role" not in raw, "Python attribute name must NOT appear in the raw document"
 
 

--- a/backend/tests/patient_views/TESTING.md
+++ b/backend/tests/patient_views/TESTING.md
@@ -74,6 +74,8 @@ PatientICFRating            (Healthstatus history)
 
 Accepts `multipart/form-data`.  Required field: `userId`.  Optional: `interventionId`, `date` (YYYY-MM-DD), plus one key per `FeedbackQuestion.questionKey` containing the answer (JSON-encoded if a list).  File fields whose content type is `audio/*` or `video/*` are transcribed / stored.
 
+On success, a `Logs` document with `action="QUESTIONNAIRE_SUBMIT"` is written (see [`tests/activity_logs/`](../activity_logs/TESTING.md)).
+
 ### Tests (`test_patient_views.py`, `test_audio.py`)
 
 | Test | Scenario | Expected |
@@ -91,6 +93,8 @@ Accepts `multipart/form-data`.  Required field: `userId`.  Optional: `interventi
 ## `mark_intervention_completed`  —  `POST /api/interventions/complete/`
 
 JSON body: `{ patient_id, intervention_id, date? }`.  Ensures at most one log per (patient, plan, intervention, day).  Optional `date` (YYYY-MM-DD) defaults to today.
+
+On success, a `Logs` document with `action="INTERVENTION_COMPLETE"` is written (see [`tests/activity_logs/`](../activity_logs/TESTING.md)).
 
 ### Date storage behaviour
 
@@ -128,6 +132,8 @@ The fix stores:
 ## `unmark_intervention_completed`  —  `POST /api/interventions/uncomplete/`
 
 JSON body: `{ patient_id, intervention_id, date }` (all required).  Removes 'completed' status from the log for that day; deduplicates duplicate logs.
+
+On success, a `Logs` document with `action="INTERVENTION_UNCOMPLETE"` is written (see [`tests/activity_logs/`](../activity_logs/TESTING.md)).
 
 ### Tests (`test_uncomplete_and_modify.py`)
 

--- a/backend/tests/therapist_views/TESTING.md
+++ b/backend/tests/therapist_views/TESTING.md
@@ -119,10 +119,13 @@ Creates an analytics/audit log entry. Optional patient linkage is supported.
 
 ### Important behaviour covered
 
+- `action` defaults to `"REHATABLE"` when omitted (previously defaulted to the now-invalid `"OTHER"`).
+- The body key `userAgent` is accepted as a backward-compatible alias for `actor_role`.
+- The HTTP `User-Agent` request header is captured into the separate `user_agent` field.
 - `details` is truncated to 500 characters before save.
-- Unknown referenced `user` or malformed JSON currently returns HTTP 500.
+- Unknown referenced `user` or malformed JSON returns HTTP 500.
 
-### Tests
+### Tests (`test_therapist_views.py`)
 
 | Test | Scenario | Expected |
 |---|---|---|
@@ -130,6 +133,10 @@ Creates an analytics/audit log entry. Optional patient linkage is supported.
 | `test_create_log_with_patient_reference` | Valid user + valid patient reference | 201, saved log contains patient reference |
 | `test_create_log_invalid_json_returns_500` | Non-JSON payload with JSON content type | 500, `error: Failed to create log` |
 | `test_create_log_unknown_user_returns_500` | Non-existing user id in payload | 500, `error: Failed to create log` |
+
+> Additional `create_log` tests (default action, `userAgent`/`actor_role` key compat,
+> HTTP User-Agent capture, `log_id` in response) live in
+> [`tests/activity_logs/`](../activity_logs/TESTING.md).
 
 ---
 

--- a/backend/tests/therapist_views/TESTING.md
+++ b/backend/tests/therapist_views/TESTING.md
@@ -10,12 +10,12 @@ endpoints in `core/views/therapist_views.py`.
 
 | Endpoint | HTTP verb | View function | Tests |
 |---|---|---|---|
-| `/api/therapists/<therapist_id>/patients/` | GET | `list_therapist_patients` | 14 |
+| `/api/therapists/<therapist_id>/patients/` | GET | `list_therapist_patients` | 13 |
 | `/api/analytics/log` | POST | `create_log` | 4 |
 | Internal helpers (unit-level) | N/A | `_avg`, `_day_key`, `_sum_points_for_day`, `_adherence`, `_feedback_computing`, `_intervention_feedback_summary` | 9 |
 | Project-based access filter (unit-level) | N/A | `list_therapist_patients` queryset | 4 |
 
-**Total: 35 tests**
+**Total: 34 tests**
 
 ---
 

--- a/backend/tests/therapist_views/test_therapist_views.py
+++ b/backend/tests/therapist_views/test_therapist_views.py
@@ -780,7 +780,6 @@ def test_biomarker_sleep_falls_back_to_duration_when_no_minutes_asleep():
     assert row["biomarker"]["sleep_avg_h"] == pytest.approx(7.5, rel=1e-3)
 
 
-
 def test_list_therapist_patients_exposes_thresholds_and_non_questionnaire_feedback():
     therapist, patient = create_therapist_with_patient()
     user = patient.userId

--- a/backend/tests/therapist_views/test_therapist_views.py
+++ b/backend/tests/therapist_views/test_therapist_views.py
@@ -242,7 +242,7 @@ def test_list_therapist_patients_excludes_inactive_users():
 def test_list_therapist_patients_includes_login_and_biomarker_fields():
     therapist, patient = create_therapist_with_patient()
 
-    Logs(userId=patient.userId, action="LOGIN", userAgent="pytest").save()
+    Logs(userId=patient.userId, action="LOGIN", actor_role="pytest").save()
     FitbitData(
         user=patient.userId,
         date=datetime.now() - timedelta(days=1),
@@ -779,25 +779,6 @@ def test_biomarker_sleep_falls_back_to_duration_when_no_minutes_asleep():
     row = next(r for r in resp.json() if r["_id"] == str(patient.id))
     assert row["biomarker"]["sleep_avg_h"] == pytest.approx(7.5, rel=1e-3)
 
-
-def test_list_therapist_patients_creates_open_patient_log(mongo_mock):
-    """
-    GET /api/therapists/<id>/patients/ must write a ``Logs`` document with
-    ``action="OPEN_PATIENT"`` linked to the therapist User.
-    The details field records how many patients were returned.
-    """
-    therapist, _ = create_therapist_with_patient()
-
-    resp = client.get(
-        f"/api/therapists/{therapist.userId.id}/patients/",
-        HTTP_AUTHORIZATION="Bearer test",
-    )
-    assert resp.status_code == 200
-
-    log = Logs.objects(action="OPEN_PATIENT").first()
-    assert log is not None, "Expected an OPEN_PATIENT log entry"
-    assert log.userId.id == therapist.userId.id
-    assert "patient_count=" in (log.details or "")
 
 
 def test_list_therapist_patients_exposes_thresholds_and_non_questionnaire_feedback():


### PR DESCRIPTION

# Problem
The Logs MongoDB collection had several structural issues that made it unreliable for analytics:

1. Dead action choices — "OTHER" was used as a catch-all for unrelated events (intervention complete, uncomplete, questionnaire submit), hiding what actually happened.
2. Wrong field semantics — userAgent stored the actor role ("Patient", "Therapist") instead of the HTTP User-Agent string. The real browser User-Agent was never saved.
3. Missing action types — several meaningful events had no dedicated action: INTERVENTION_COMPLETE, INTERVENTION_UNCOMPLETE, QUESTIONNAIRE_SUBMIT, TEMPLATE_APPLY, PATIENT_REGISTER.
4. Misplaced OPEN_PATIENT log — fired on every patient list load (e.g. Apply Template modal) with details="patient_count=N" instead of when a therapist actually opened a patient's profile.
5. No indexes — the collection had no indexes; time-range and per-user queries would do full collection scans.
6. Wrong default in create_log — the /analytics/log endpoint defaulted to action="OTHER", which was removed from choices, causing every frontend-triggered log to fail validation.
## Changes
### backend/core/models.py

1. Added new action choices: INTERVENTION_COMPLETE, INTERVENTION_UNCOMPLETE, QUESTIONNAIRE_SUBMIT, TEMPLATE_APPLY, PATIENT_REGISTER
2. Renamed userAgent → actor_role (stores "Patient" / "Therapist" / "Admin"); kept db_field="userAgent" for backward compatibility with existing MongoDB documents
3. Added user_agent field (up to 300 chars) for the real HTTP User-Agent string
4. Added composite index (userId, action, -timestamp) and time-range index (-timestamp)

### View files

1. patient_views.py — OTHER → INTERVENTION_COMPLETE / INTERVENTION_UNCOMPLETE; added QUESTIONNAIRE_SUBMIT
2. template_views.py — added TEMPLATE_APPLY log after successful apply
3. auth_views.py — added PATIENT_REGISTER log on patient registration; fixed LOGIN/LOGOUT field names
4. therapist_views.py — moved OPEN_PATIENT out of list view; fixed create_log default to REHATABLE; capture real User-Agent header
5. user_views.py — OPEN_PATIENT now fires in user_profile_view when a therapist opens a specific patient's profile; removed debug print()
6. redcap_import_views.py, recomendation_views.py, therapist_access_views.py, therapist_projects.py — userAgent= → actor_role= across all log calls

### Notes

- All log writes are wrapped in try/except — a logging failure never breaks the main request.
- Existing MongoDB documents remain readable: db_field="userAgent" ensures the renamed Python field maps to the same MongoDB key.

## Related Issue
#193 

## Type of change

For a new feature, please create an issue first to discuss it with us before submitting a pull request.

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Tests

## Activity Logs — Test Cases (19 tests)

### INTERVENTION_COMPLETE
| Test | Scenario | Asserts |
|---|---|---|
| `test_mark_intervention_completed_writes_intervention_complete_log` | Patient marks an intervention done | `action="INTERVENTION_COMPLETE"`, `userId=patient.userId`, `patient=patient`, `actor_role="Patient"`, intervention title in details |
| `test_mark_intervention_completed_log_details_contain_date` | Same, no explicit date | Today's ISO date appears in `details` |

### INTERVENTION_UNCOMPLETE
| Test | Scenario | Asserts |
|---|---|---|
| `test_unmark_intervention_completed_writes_intervention_uncomplete_log` | Completion log exists; patient unmarks it | `action="INTERVENTION_UNCOMPLETE"` written; correct user/patient linkage |
| `test_unmark_no_log_does_not_write_uncomplete_log` | No completion log for the requested day | Zero `INTERVENTION_UNCOMPLETE` logs (nothing changed → nothing recorded) |

### QUESTIONNAIRE_SUBMIT
| Test | Scenario | Asserts |
|---|---|---|
| `test_submit_patient_feedback_writes_questionnaire_submit_log` | Patient submits questionnaire answers | `action="QUESTIONNAIRE_SUBMIT"`, `userId=patient.userId`, `patient=patient`, `actor_role="Patient"` |

### PATIENT_REGISTER
| Test | Scenario | Asserts |
|---|---|---|
| `test_patient_registration_writes_patient_register_log` | Therapist registers a new patient | `action="PATIENT_REGISTER"`, `userId=therapist.userId`, `actor_role="Therapist"`, patient_code and clinic in details |
| `test_patient_registration_log_missing_on_failure` | Registration fails (missing `rehaEndDate`) | Zero `PATIENT_REGISTER` logs |

### OPEN_PATIENT
| Test | Scenario | Asserts |
|---|---|---|
| `test_open_patient_log_written_when_therapist_views_patient_profile` | Therapist GETs a patient's profile | `action="OPEN_PATIENT"`, `userId=therapist.userId`, `patient=patient`, `actor_role="Therapist"`, patient_code in details |
| `test_open_patient_log_not_written_when_patient_views_own_profile` | Patient GETs their own profile | Zero `OPEN_PATIENT` logs |

### create_log (`POST /api/analytics/log`)
| Test | Scenario | Asserts |
|---|---|---|
| `test_create_log_defaults_to_rehatable_action` | Body omits `action` | Stored action is `REHATABLE` (not the old invalid `"OTHER"`) |
| `test_create_log_accepts_legacy_useragent_key` | Body sends `userAgent: "Therapist"` | `actor_role == "Therapist"` |
| `test_create_log_accepts_actor_role_key` | Body sends `actor_role: "Patient"` | `actor_role == "Patient"` |
| `test_create_log_captures_http_user_agent_header` | HTTP `User-Agent` header set | `log.user_agent` contains the header value |
| `test_create_log_truncates_details_to_500_chars` | `details` is 600 chars | Stored `details` has length 500 |
| `test_create_log_returns_log_id_in_response` | Valid request | Response contains `log_id` matching the saved document |
| `test_create_log_unknown_user_returns_500` | Non-existent user ObjectId | 500 (documented behaviour) |
| `test_create_log_invalid_json_returns_500` | Malformed JSON body | 500 |

### Logs model — field mapping
| Test | Scenario | Asserts |
|---|---|---|
| `test_logs_actor_role_stored_in_useragent_db_field` | Save a `Logs` doc, inspect raw MongoDB document | Raw document key is `userAgent`, not `actor_role` (backward compat) |
| `test_logs_invalid_action_raises_validation_error` | Save with `action="OTHER"` (removed choice) | MongoEngine `ValidationError` raised |


## Checklist

- [x] I have read the [contributing guidelines](/docs/12-CONTRIBUTING.md).
- [x] I have read the [code of conduct](/CODE_OF_CONDUCT.md).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
