### PR TITLE
191 backup scripts

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -319,6 +319,21 @@ jobs:
             # Clean up old images to free disk space
             docker image prune -f
 
+      - name: Run backup script tests on prod server
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.PROD_HOST }}
+          username: ${{ secrets.PROD_USERNAME }}
+          key: ${{ secrets.PROD_SSH_KEY }}
+          script: |
+            set -euo pipefail
+            PROD_DIR=/home/ubuntu/repos/telerehabapp-prod
+            cd "$PROD_DIR"
+            command -v bats >/dev/null 2>&1 || sudo apt-get install -y bats
+            echo "Running backup script tests..."
+            bats scripts/tests/
+            echo "✅ All script tests passed"
+
       - name: Production health check
         run: |
           max_attempts=60

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,338 +1,194 @@
 # RehaAdvisor Production Scripts
 
-This directory contains utility scripts for managing the RehaAdvisor production environment at reha-advisor.ch.
-
-## Available Scripts
-
-### 1. `backup.sh` - Database Backup
-Creates compressed backups of the MongoDB database with optional cloud upload.
-
-**Usage:**
-```bash
-# Create local backup
-./scripts/backup.sh
-
-# Create backup and upload to S3
-./scripts/backup.sh --upload-s3 --s3-bucket my-backup-bucket
-```
-
-**Features:**
-- Automated gzip compression
-- Backup metadata tracking
-- Automatic cleanup of old backups (30 days retention)
-- Optional AWS S3 upload
-- Detailed logging
-
-**Cron Setup:**
-```bash
-# Daily backup at 2 AM
-0 2 * * * cd /opt/reha-advisor && ./scripts/backup.sh
-
-# Daily backup at 2 AM with S3 upload
-0 2 * * * cd /opt/reha-advisor && ./scripts/backup.sh --upload-s3 --s3-bucket reha-advisor-backups
-```
-
-**Output:**
-```
-=== RehaAdvisor Database Backup ===
-Timestamp: 2024-02-17T14:30:45+00:00
-Backup File: /opt/reha-advisor/backups/mongodb_20240217_143045.archive
-✓ Backup created successfully
-  Size: 125M
-```
+Utility scripts for managing the RehaAdvisor production environment.
 
 ---
 
-### 2. `restore.sh` - Database Restore
-Restores a backup created by backup.sh with confirmation prompts.
+## Backup system
 
-**Usage:**
+Three data stores are backed up:
+
+| Store | What | Where it lives |
+|---|---|---|
+| **MongoDB** | All patient/therapist data | `db-prod` Docker container |
+| **SQLite** | Celery-beat task schedules | `./data/db.sqlite3` bind-mount on host |
+| **Media** | Uploaded videos, PDFs, images | `/srv/app/media` inside `django-prod` container |
+
+Backups land in `./backups/` (gitignored, 30-day retention).
+
+---
+
+## Scripts
+
+### `backup.sh` — create a backup
+
 ```bash
-# Interactive restore (shows available backups)
+./scripts/backup.sh
+```
+
+Backs up all three stores and exits 1 if MongoDB fails (MongoDB is the only critical store — missing SQLite or media is logged and skipped).
+
+**Options:**
+
+| Flag | Description |
+|---|---|
+| `--upload-s3 --s3-bucket <bucket>` | Upload all backup files to S3 after creating them |
+
+**Output files per run:**
+
+| File | Contents |
+|---|---|
+| `backups/mongodb_YYYYMMDD_HHMMSS.archive` | Compressed MongoDB dump (gzip archive) |
+| `backups/sqlite_YYYYMMDD_HHMMSS.db` | Copy of Celery-beat SQLite database |
+| `backups/media_YYYYMMDD_HHMMSS.tar.gz` | Tarball of the media volume |
+| `backups/backup_YYYYMMDD_HHMMSS.log` | Stderr from mongodump/tar |
+| `backups/backup_YYYYMMDD_HHMMSS.meta` | JSON manifest (paths, sizes, timestamp) |
+
+**MongoDB credentials** are read automatically from `.env.prod` if present (`MONGO_INITDB_ROOT_USERNAME` / `MONGO_INITDB_ROOT_PASSWORD`).
+
+---
+
+### `restore.sh` — restore from a backup
+
+```bash
+# Interactive (lists available backups, prompts for selection and confirmation)
 ./scripts/restore.sh
 
-# Restore specific backup
-./scripts/restore.sh /opt/reha-advisor/backups/mongodb_20240217_143045.archive
+# Non-interactive (pass the archive file directly)
+./scripts/restore.sh backups/mongodb_20260101_030000.archive
 ```
 
-**Features:**
-- List available backups
-- Interactive selection
-- Confirmation prompt for safety
-- Restore verification
-- Collection and document count reporting
+Only MongoDB is restored. Uses `--drop` to atomically replace each collection before restoring. The script verifies the restore by counting collections and reporting document counts per collection.
 
-**Example Output:**
+**Safety:** A confirmation prompt (`Type 'yes' to confirm`) must be answered before any data is overwritten.
+
+---
+
+### `setup-cron.sh` — install the daily cron job
+
+```bash
+./scripts/setup-cron.sh                        # daily at 03:00 (default)
+./scripts/setup-cron.sh --hour 2 --minute 30   # daily at 02:30
 ```
-=== RehaAdvisor Database Restore ===
-Available backups:
-1	/opt/reha-advisor/backups/mongodb_20240217_143045.archive
-2	/opt/reha-advisor/backups/mongodb_20240217_020045.archive
 
-Enter backup file name or number: 1
-⚠️  WARNING: This will overwrite the current database!
-Are you sure you want to restore from this backup? Type 'yes' to confirm: yes
+Idempotent — safe to run multiple times. If the backup cron entry already exists it prints "already installed" and exits without modifying anything.
 
-✓ Restore completed successfully
-Collections in restored database:
-[ "users", "patients", "sessions", "assessments", "feedback" ]
+The installed entry looks like:
+```
+0 3 * * * /path/to/scripts/backup.sh >> /path/to/backups/cron.log 2>&1
+```
 
-Document counts:
-users: 42
-patients: 156
-sessions: 1203
+03:00 is chosen to run after the 02:30 Fitbit sync Celery task finishes.
+
+---
+
+## Other scripts
+
+| Script | Purpose |
+|---|---|
+| `health-check.sh` | Check all container and endpoint health |
+| `init-db.sh` | Initialise MongoDB schema on first deployment |
+| `install-git-hooks.sh` | Install pre-push style hooks for contributors |
+
+---
+
+## First-time setup
+
+```bash
+cd /home/ubuntu/repos/telerehabapp-prod
+
+# 1. Run a manual backup to verify it works before scheduling
+bash scripts/backup.sh
+ls -lh backups/
+
+# 2. Schedule the daily cron job
+bash scripts/setup-cron.sh
+
+# 3. Confirm the entry was installed
+crontab -l | grep backup
 ```
 
 ---
 
-### 3. `init-db.sh` - Database Initialization
-Initializes MongoDB with schema validation, collections, and indexes after first deployment.
+## Verifying a backup archive
 
-**Usage:**
 ```bash
-./scripts/init-db.sh
-```
-
-**Features:**
-- Creates required collections with schema validation
-- Sets up performance indexes
-- Creates admin user
-- Validates MongoDB connectivity
-- Detailed initialization logging
-
-**Collections Created:**
-- `users` - User accounts and profiles
-- `patients` - Patient records
-- `sessions` - Therapy sessions
-- `therapies` - Available therapies
-- `assessments` - Patient assessments
-- `feedback` - User feedback
-
-**Indexes Created:**
-- Unique email index on users
-- Foreign key indexes (therapist_id, patient_id, user_id)
-- Query optimization indexes (status, created_at, etc.)
-
-**Example Output:**
-```
-=== RehaAdvisor MongoDB Initialization ===
-Waiting for MongoDB to be ready...
-✓ MongoDB is ready
-Creating collections...
-✓ users collection created
-✓ patients collection created
-✓ sessions collection created
-✓ assessments collection created
-✓ feedback collection created
-
-Creating indexes...
-✓ users indexes created
-✓ patients indexes created
-✓ sessions indexes created
-✓ assessments indexes created
-✓ feedback indexes created
-
-=== Database initialization complete ===
+docker exec db-prod mongorestore --archive --gzip --dryRun \
+    -u "$MONGO_USER" -p "$MONGO_PASSWORD" \
+    --authenticationDatabase admin \
+    < backups/mongodb_YYYYMMDD_HHMMSS.archive
 ```
 
 ---
 
-### 4. `health-check.sh` - Service Health Monitor
-Comprehensive health check for all services with optional Slack notifications.
+## Restoring in an emergency
 
-**Usage:**
 ```bash
-# Basic health check
-./scripts/health-check.sh
+cd /home/ubuntu/repos/telerehabapp-prod
 
-# Detailed check with resource usage
-./scripts/health-check.sh --detailed
+# Interactive — lists available backups, prompts for selection and confirmation
+bash scripts/restore.sh
 
-# Health check with Slack notifications
-./scripts/health-check.sh --slack-webhook https://hooks.slack.com/services/YOUR/WEBHOOK/URL
-```
-
-**Features:**
-- Container status verification
-- HTTP/HTTPS endpoint testing
-- Resource usage monitoring (with --detailed)
-- Slack notifications
-- Detailed logging
-- Exit codes for monitoring systems
-
-**Services Checked:**
-- Docker daemon
-- LibreTranslate
-- MongoDB
-- Redis
-- Django Backend
-- Celery Worker
-- Celery Beat
-- React Frontend
-- NGINX Proxy
-- HTTPS/HTTP endpoints
-
-**Cron Setup:**
-```bash
-# Health check every 5 minutes
-*/5 * * * * cd /opt/reha-advisor && ./scripts/health-check.sh --slack-webhook https://hooks.slack.com/services/YOUR/WEBHOOK/URL
-```
-
-**Example Output:**
-```
-=== RehaAdvisor Health Check ===
-Domain: reha-advisor.ch
-Timestamp: 2024-02-17T14:35:22+00:00
-
-Docker Status:
-✓ Docker daemon is running
-
-Container Status:
-✓ LibreTranslate: Running
-✓ MongoDB: Healthy
-✓ Redis: Healthy
-✓ Django Backend: Healthy
-✓ Celery Worker: Running
-✓ Celery Beat: Running
-✓ React Frontend: Running
-✓ NGINX: Running
-
-HTTP/HTTPS Endpoints:
-✓ HTTPS Health: OK
-✓ API Health: OK
-✓ Frontend: OK
-
-=== Summary ===
-Services OK: 12
-
-Status: HEALTHY
+# Or restore a specific archive directly
+bash scripts/restore.sh backups/mongodb_20260101_030000.archive
 ```
 
 ---
 
-## Integration with Makefile
+## Running the tests
 
-All scripts can be run via the Makefile:
+The test suite requires [bats](https://github.com/bats-core/bats-core):
 
 ```bash
-# Production commands
-make prod_backup              # Run backup script
-make prod_migrate             # Initialize database
-make prod_health              # Run health check
-make prod_logs                # View all logs
-make prod_logs_django         # View Django logs
-make prod_shell_django        # Access Django shell
+sudo apt install bats
 ```
 
----
+```bash
+# All 26 tests
+bats scripts/tests/
 
-## Production Deployment Workflow
+# Individual suites
+bats scripts/tests/test_backup.bats
+bats scripts/tests/test_restore.bats
+bats scripts/tests/test_setup_cron.bats
+```
 
-1. **Initial Setup:**
-   ```bash
-   make build_prod
-   make prod_up
-   make prod_migrate
-   ```
+Tests run against copies of the scripts in a temporary directory. `docker`, `crontab`, and `aws` are replaced with lightweight mocks — no real Docker or cloud access is needed.
 
-2. **Database Initialization:**
-   ```bash
-   ./scripts/init-db.sh
-   make prod_superuser
-   ```
-
-3. **Verify Health:**
-   ```bash
-   ./scripts/health-check.sh --detailed
-   ```
-
-4. **Schedule Backups:**
-   ```bash
-   # Add cron jobs for backup and health checks
-   (crontab -l 2>/dev/null; echo "0 2 * * * cd /opt/reha-advisor && ./scripts/backup.sh") | crontab -
-   (crontab -l 2>/dev/null; echo "*/5 * * * * cd /opt/reha-advisor && ./scripts/health-check.sh") | crontab -
-   ```
+| Test file | Tests | Covers |
+|---|---|---|
+| `test_backup.bats` | 11 | Arg parsing, MongoDB/SQLite/media backup paths, credential reading, meta file |
+| `test_restore.bats` | 9 | File resolution, interactive mode, confirmation prompt, restore flow, credentials |
+| `test_setup_cron.bats` | 6 | Default timing, custom timing, idempotency, correct paths |
 
 ---
 
 ## Troubleshooting
 
-### Backup script fails
+**Backup exits 1 immediately**
 ```bash
-# Check if MongoDB is running
-docker ps | grep db-prod
-
-# Check MongoDB logs
-docker logs db-prod
-
-# Verify disk space
-df -h /opt/reha-advisor
+docker ps | grep db-prod   # MongoDB container must be running
 ```
 
-### Restore fails
+**Backup log shows auth failure**
 ```bash
-# Check if backup file exists
-ls -lh /opt/reha-advisor/backups/
-
-# Verify MongoDB connectivity
-docker exec db-prod mongosh --eval 'db.adminCommand("ping")'
-
-# Check MongoDB logs
-docker logs db-prod
+grep MONGO_INITDB_ROOT /home/ubuntu/repos/telerehabapp-prod/.env.prod
 ```
 
-### Health check reports failures
+**Cron job not running**
 ```bash
-# Check individual service logs
-make prod_logs_django
-make prod_logs_nginx
-
-# Check Docker resources
-docker stats
-
-# Run detailed health check
-./scripts/health-check.sh --detailed
+crontab -l              # confirm entry exists
+cat backups/cron.log    # check last run output
 ```
 
----
+**Restore fails at collection verification**
+```bash
+# Check archive is non-empty
+ls -lh backups/mongodb_*.archive
 
-## Best Practices
-
-1. **Backups:**
-   - Run daily backups at low-traffic hours
-   - Test restores monthly
-   - Store backups off-site
-   - Monitor backup size trends
-
-2. **Health Checks:**
-   - Run every 5 minutes in production
-   - Enable Slack notifications
-   - Monitor check logs
-   - Alert on consecutive failures
-
-3. **Database:**
-   - Keep indexes optimized
-   - Monitor collection sizes
-   - Archive old data regularly
-   - Validate data integrity monthly
-
-4. **Monitoring:**
-   - Track response times
-   - Monitor error rates
-   - Review security logs
-   - Track resource usage
-
----
-
-## Support
-
-For issues or questions:
-1. Review [PRODUCTION_DEPLOYMENT.md](../docs/deployment/PRODUCTION_DEPLOYMENT.md)
-2. Check [Troubleshooting Guide](../docs/08-TROUBLESHOOTING.md)
-3. Review script logs in `/opt/reha-advisor/logs/`
-4. Contact support team
-
----
-
-**Last Updated:** February 17, 2024
-**Version:** 1.0
+# Dry run to validate the archive
+docker exec db-prod mongorestore --archive --gzip --dryRun \
+    -u "$MONGO_USER" -p "$MONGO_PASSWORD" \
+    --authenticationDatabase admin \
+    < backups/mongodb_*.archive
+```

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -1,15 +1,19 @@
 #!/bin/bash
 
-# Backup script for RehaAdvisor MongoDB database
-# Creates compressed backups and optionally uploads to cloud storage
+# Backup script for RehaAdvisor
+# Backs up: MongoDB (main DB), SQLite (celery-beat schedules), media volume (uploads)
 # Usage: ./backup.sh [--upload-s3] [--s3-bucket bucket-name]
 
 set -e
 
+# Resolve repo root relative to this script so it works from any working directory
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+REPO_DIR=$(cd "$SCRIPT_DIR/.." && pwd)
+
 # Configuration
-BACKUP_DIR="/opt/reha-advisor/backups"
+BACKUP_DIR="$REPO_DIR/backups"
 RETENTION_DAYS=30
-COMPOSE_FILE="/opt/reha-advisor/docker-compose.prod.reha-advisor.yml"
+COMPOSE_FILE="$REPO_DIR/docker-compose.prod.reha-advisor.yml"
 
 # Colors for output
 RED='\033[0;31m'
@@ -40,116 +44,167 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
+# Read MongoDB credentials from .env.prod if present
+MONGO_USER=""
+MONGO_PASSWORD=""
+ENV_FILE="$REPO_DIR/.env.prod"
+if [ -f "$ENV_FILE" ]; then
+    MONGO_USER=$(grep -E '^MONGO_INITDB_ROOT_USERNAME=' "$ENV_FILE" | head -1 | cut -d= -f2 | tr -d '"'"'" | xargs)
+    MONGO_PASSWORD=$(grep -E '^MONGO_INITDB_ROOT_PASSWORD=' "$ENV_FILE" | head -1 | cut -d= -f2 | tr -d '"'"'" | xargs)
+fi
+
+# Build auth args for mongodump/mongorestore
+MONGO_AUTH_ARGS=""
+if [ -n "$MONGO_USER" ] && [ -n "$MONGO_PASSWORD" ]; then
+    MONGO_AUTH_ARGS="-u $MONGO_USER -p $MONGO_PASSWORD --authenticationDatabase admin"
+fi
+
 # Create backup directory
 mkdir -p "$BACKUP_DIR"
 
 # Generate timestamp
 TIMESTAMP=$(date +%Y%m%d_%H%M%S)
-BACKUP_FILE="$BACKUP_DIR/mongodb_$TIMESTAMP.archive"
-BACKUP_LOG="$BACKUP_DIR/backup_$TIMESTAMP.log"
+MONGODB_BACKUP="$BACKUP_DIR/mongodb_${TIMESTAMP}.archive"
+SQLITE_BACKUP="$BACKUP_DIR/sqlite_${TIMESTAMP}.db"
+MEDIA_BACKUP="$BACKUP_DIR/media_${TIMESTAMP}.tar.gz"
+BACKUP_LOG="$BACKUP_DIR/backup_${TIMESTAMP}.log"
 
 echo -e "${BLUE}=== RehaAdvisor Database Backup ===${NC}"
 echo -e "${BLUE}Timestamp: $(date)${NC}"
-echo -e "${BLUE}Backup File: $BACKUP_FILE${NC}"
+echo -e "${BLUE}Backup dir: $BACKUP_DIR${NC}"
 echo ""
 
-# Check if MongoDB container is running
+MONGODB_OK=false
+SQLITE_OK=false
+MEDIA_OK=false
+
+# ---------------------------------------------------------------------------
+# 1. MongoDB
+# ---------------------------------------------------------------------------
+echo -e "${YELLOW}[1/3] MongoDB backup...${NC}"
+
 if ! docker ps --format '{{.Names}}' | grep -q "^db-prod$"; then
-    echo -e "${RED}✗ MongoDB container (db-prod) is not running${NC}"
+    echo -e "${RED}✗ MongoDB container (db-prod) is not running — skipping${NC}" | tee -a "$BACKUP_LOG"
+else
+    # Pipe mongodump stdout to a host file — the only correct way with --archive
+    # shellcheck disable=SC2086
+    if docker exec db-prod mongodump \
+            --archive --gzip \
+            $MONGO_AUTH_ARGS \
+            2>>"$BACKUP_LOG" > "$MONGODB_BACKUP"; then
+        MONGO_SIZE=$(du -h "$MONGODB_BACKUP" | cut -f1)
+        echo -e "${GREEN}✓ MongoDB backup: $MONGODB_BACKUP ($MONGO_SIZE)${NC}"
+        MONGODB_OK=true
+    else
+        echo -e "${RED}✗ MongoDB backup failed — check $BACKUP_LOG${NC}"
+        rm -f "$MONGODB_BACKUP"
+    fi
+fi
+
+# ---------------------------------------------------------------------------
+# 2. SQLite (celery-beat schedule DB — bind mount at ./data/db.sqlite3)
+# ---------------------------------------------------------------------------
+echo -e "${YELLOW}[2/3] SQLite backup...${NC}"
+
+SQLITE_SRC="$REPO_DIR/data/db.sqlite3"
+if [ -f "$SQLITE_SRC" ]; then
+    if cp "$SQLITE_SRC" "$SQLITE_BACKUP"; then
+        SQLITE_SIZE=$(du -h "$SQLITE_BACKUP" | cut -f1)
+        echo -e "${GREEN}✓ SQLite backup: $SQLITE_BACKUP ($SQLITE_SIZE)${NC}"
+        SQLITE_OK=true
+    else
+        echo -e "${RED}✗ SQLite backup failed${NC}"
+        rm -f "$SQLITE_BACKUP"
+    fi
+else
+    echo -e "${YELLOW}  SQLite file not found at $SQLITE_SRC — skipping${NC}"
+fi
+
+# ---------------------------------------------------------------------------
+# 3. Media volume (uploaded files: videos, PDFs, images)
+# ---------------------------------------------------------------------------
+echo -e "${YELLOW}[3/3] Media backup...${NC}"
+
+if ! docker ps --format '{{.Names}}' | grep -q "^django-prod$"; then
+    echo -e "${YELLOW}  django-prod not running — skipping media backup${NC}"
+else
+    if docker exec django-prod tar -czf - /srv/app/media 2>>"$BACKUP_LOG" > "$MEDIA_BACKUP"; then
+        MEDIA_SIZE=$(du -h "$MEDIA_BACKUP" | cut -f1)
+        echo -e "${GREEN}✓ Media backup: $MEDIA_BACKUP ($MEDIA_SIZE)${NC}"
+        MEDIA_OK=true
+    else
+        echo -e "${RED}✗ Media backup failed — check $BACKUP_LOG${NC}"
+        rm -f "$MEDIA_BACKUP"
+    fi
+fi
+
+# ---------------------------------------------------------------------------
+# Fail if MongoDB backup (the critical one) did not succeed
+# ---------------------------------------------------------------------------
+if [ "$MONGODB_OK" = false ]; then
+    echo -e "${RED}✗ MongoDB backup failed — aborting${NC}"
     exit 1
 fi
 
-# Create backup
-echo -e "${YELLOW}Starting MongoDB backup...${NC}"
-{
-    docker exec db-prod mongodump \
-        --archive="$BACKUP_FILE" \
-        --gzip \
-        --out="/backups/$TIMESTAMP" \
-        2>&1 || true
-} | tee -a "$BACKUP_LOG"
-
-# Check if backup was successful
-if [ -f "$BACKUP_FILE" ]; then
-    BACKUP_SIZE=$(du -h "$BACKUP_FILE" | cut -f1)
-    echo -e "${GREEN}✓ Backup created successfully${NC}"
-    echo -e "${GREEN}  Size: $BACKUP_SIZE${NC}"
-    
-    # Create backup metadata
-    cat > "$BACKUP_DIR/backup_$TIMESTAMP.meta" << EOF
+# ---------------------------------------------------------------------------
+# Metadata
+# ---------------------------------------------------------------------------
+cat > "$BACKUP_DIR/backup_${TIMESTAMP}.meta" << EOF
 {
   "timestamp": "$(date -Iseconds)",
-  "size_bytes": $(stat -f%z "$BACKUP_FILE" 2>/dev/null || stat -c%s "$BACKUP_FILE"),
-  "size_human": "$BACKUP_SIZE",
-  "database": "reha_advisor",
-  "backup_type": "full",
-  "compress": "gzip",
+  "mongodb": $([ "$MONGODB_OK" = true ] && echo '"'$MONGODB_BACKUP'"' || echo 'null'),
+  "sqlite":  $([ "$SQLITE_OK"  = true ] && echo '"'$SQLITE_BACKUP'"'  || echo 'null'),
+  "media":   $([ "$MEDIA_OK"   = true ] && echo '"'$MEDIA_BACKUP'"'   || echo 'null'),
   "retention_days": $RETENTION_DAYS
 }
 EOF
-    
-else
-    echo -e "${RED}✗ Backup failed${NC}"
-    exit 1
-fi
 
-# Upload to S3 if requested
+# ---------------------------------------------------------------------------
+# S3 upload (optional)
+# ---------------------------------------------------------------------------
 if [ "$UPLOAD_S3" = true ]; then
     if [ -z "$S3_BUCKET" ]; then
         echo -e "${RED}✗ S3 bucket not specified. Use --s3-bucket bucket-name${NC}"
         exit 1
     fi
-    
+    if ! command -v aws &>/dev/null; then
+        echo -e "${RED}✗ AWS CLI not installed${NC}"
+        exit 1
+    fi
     echo ""
-    echo -e "${YELLOW}Uploading backup to S3...${NC}"
-    
-    # Check if AWS CLI is installed
-    if ! command -v aws &> /dev/null; then
-        echo -e "${RED}✗ AWS CLI is not installed${NC}"
-        echo "Install with: pip install awscli or brew install awscli"
-        exit 1
-    fi
-    
-    # Upload backup and metadata
-    if aws s3 cp "$BACKUP_FILE" "s3://$S3_BUCKET/reha-advisor/backups/$(basename $BACKUP_FILE)" 2>&1 | tee -a "$BACKUP_LOG"; then
-        echo -e "${GREEN}✓ Backup uploaded to S3: s3://$S3_BUCKET/reha-advisor/backups/${BACKUP_FILE##*/}${NC}"
-        
-        # Upload metadata
-        aws s3 cp "$BACKUP_DIR/backup_$TIMESTAMP.meta" "s3://$S3_BUCKET/reha-advisor/backups/backup_$TIMESTAMP.meta"
-        echo -e "${GREEN}✓ Backup metadata uploaded${NC}"
-    else
-        echo -e "${RED}✗ Upload to S3 failed${NC}"
-        exit 1
-    fi
+    echo -e "${YELLOW}Uploading to S3: s3://$S3_BUCKET/reha-advisor/backups/${NC}"
+    for f in "$MONGODB_BACKUP" "$SQLITE_BACKUP" "$MEDIA_BACKUP"; do
+        [ -f "$f" ] && aws s3 cp "$f" "s3://$S3_BUCKET/reha-advisor/backups/$(basename "$f")" 2>>"$BACKUP_LOG" \
+            && echo -e "${GREEN}✓ Uploaded $(basename "$f")${NC}"
+    done
 fi
 
-# Clean up old backups
+# ---------------------------------------------------------------------------
+# Retention cleanup
+# ---------------------------------------------------------------------------
 echo ""
-echo -e "${YELLOW}Cleaning up old backups (older than $RETENTION_DAYS days)...${NC}"
+echo -e "${YELLOW}Cleaning up backups older than $RETENTION_DAYS days...${NC}"
+find "$BACKUP_DIR" -name "mongodb_*.archive" -type f -mtime +"$RETENTION_DAYS" -delete 2>/dev/null
+find "$BACKUP_DIR" -name "sqlite_*.db"       -type f -mtime +"$RETENTION_DAYS" -delete 2>/dev/null
+find "$BACKUP_DIR" -name "media_*.tar.gz"    -type f -mtime +"$RETENTION_DAYS" -delete 2>/dev/null
+find "$BACKUP_DIR" -name "backup_*.log"      -type f -mtime +"$RETENTION_DAYS" -delete 2>/dev/null
+find "$BACKUP_DIR" -name "backup_*.meta"     -type f -mtime +"$RETENTION_DAYS" -delete 2>/dev/null
+echo -e "${GREEN}✓ Cleanup done${NC}"
 
-find "$BACKUP_DIR" -name "mongodb_*.archive" -type f -mtime +$RETENTION_DAYS -exec rm -f {} \; 2>/dev/null
-find "$BACKUP_DIR" -name "backup_*.meta" -type f -mtime +$RETENTION_DAYS -exec rm -f {} \; 2>/dev/null
-find "$BACKUP_DIR" -name "backup_*.log" -type f -mtime +$RETENTION_DAYS -exec rm -f {} \; 2>/dev/null
-
-DELETED_COUNT=$(find "$BACKUP_DIR" -name "mongodb_*.archive" -type f -mtime +$RETENTION_DAYS 2>/dev/null | wc -l)
-if [ $DELETED_COUNT -gt 0 ]; then
-    echo -e "${GREEN}✓ Deleted $DELETED_COUNT old backup(s)${NC}"
-else
-    echo -e "${GREEN}✓ No old backups to delete${NC}"
-fi
-
-# Display backup summary
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
 echo ""
 echo -e "${BLUE}=== Backup Summary ===${NC}"
-echo -e "Backup location: ${GREEN}$BACKUP_FILE${NC}"
-echo -e "Backup size: ${GREEN}$BACKUP_SIZE${NC}"
-echo -e "Retention: ${GREEN}$RETENTION_DAYS days${NC}"
-echo -e "Log file: ${GREEN}$BACKUP_LOG${NC}"
-
-# List recent backups
+[ "$MONGODB_OK" = true ] && echo -e "  MongoDB : ${GREEN}$(du -h "$MONGODB_BACKUP" | cut -f1)${NC}  $MONGODB_BACKUP"
+[ "$SQLITE_OK"  = true ] && echo -e "  SQLite  : ${GREEN}$(du -h "$SQLITE_BACKUP"  | cut -f1)${NC}  $SQLITE_BACKUP"
+[ "$MEDIA_OK"   = true ] && echo -e "  Media   : ${GREEN}$(du -h "$MEDIA_BACKUP"   | cut -f1)${NC}  $MEDIA_BACKUP"
+echo -e "  Log     : $BACKUP_LOG"
+echo -e "  Retention: $RETENTION_DAYS days"
 echo ""
-echo -e "${BLUE}=== Recent Backups ===${NC}"
-ls -lh "$BACKUP_DIR"/mongodb_*.archive 2>/dev/null | awk '{printf "%-30s %8s\n", $9, $5}' | tail -5
+
+echo -e "${BLUE}Recent backups:${NC}"
+ls -lh "$BACKUP_DIR"/mongodb_*.archive 2>/dev/null | awk '{printf "  %-45s %s\n", $NF, $5}' | tail -5
 
 echo ""
-echo -e "${GREEN}✓ Backup process completed${NC}"
+echo -e "${GREEN}✓ Backup complete${NC}"

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -2,13 +2,17 @@
 
 # Restore script for RehaAdvisor MongoDB database
 # Restores a backup created by backup.sh
-# Usage: ./restore.sh [backup-file]
+# Usage: ./restore.sh [mongodb-backup-file]
 
 set -e
 
+# Resolve repo root relative to this script
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+REPO_DIR=$(cd "$SCRIPT_DIR/.." && pwd)
+
 # Configuration
-BACKUP_DIR="/opt/reha-advisor/backups"
-COMPOSE_FILE="/opt/reha-advisor/docker-compose.prod.reha-advisor.yml"
+BACKUP_DIR="$REPO_DIR/backups"
+COMPOSE_FILE="$REPO_DIR/docker-compose.prod.reha-advisor.yml"
 
 # Colors for output
 RED='\033[0;31m'
@@ -17,11 +21,25 @@ YELLOW='\033[1;33m'
 BLUE='\033[0;34m'
 NC='\033[0m'
 
+# Read MongoDB credentials from .env.prod if present
+MONGO_USER=""
+MONGO_PASSWORD=""
+ENV_FILE="$REPO_DIR/.env.prod"
+if [ -f "$ENV_FILE" ]; then
+    MONGO_USER=$(grep -E '^MONGO_INITDB_ROOT_USERNAME=' "$ENV_FILE" | head -1 | cut -d= -f2 | tr -d '"'"'" | xargs)
+    MONGO_PASSWORD=$(grep -E '^MONGO_INITDB_ROOT_PASSWORD=' "$ENV_FILE" | head -1 | cut -d= -f2 | tr -d '"'"'" | xargs)
+fi
+
+MONGO_AUTH_ARGS=""
+if [ -n "$MONGO_USER" ] && [ -n "$MONGO_PASSWORD" ]; then
+    MONGO_AUTH_ARGS="-u $MONGO_USER -p $MONGO_PASSWORD --authenticationDatabase admin"
+fi
+
 # Function to list available backups
 list_backups() {
-    echo -e "${BLUE}Available backups:${NC}"
+    echo -e "${BLUE}Available MongoDB backups:${NC}"
     echo ""
-    ls -1 "$BACKUP_DIR"/mongodb_*.archive 2>/dev/null | nl || echo "No backups found"
+    ls -1 "$BACKUP_DIR"/mongodb_*.archive 2>/dev/null | nl -ba || echo "  No backups found in $BACKUP_DIR"
     echo ""
 }
 
@@ -30,13 +48,17 @@ BACKUP_FILE="${1:-}"
 
 if [ -z "$BACKUP_FILE" ]; then
     list_backups
-    read -p "Enter backup file name or number: " BACKUP_INPUT
-    
-    # Check if input is a number
+    read -rp "Enter backup file name or number: " BACKUP_INPUT
+
     if [[ "$BACKUP_INPUT" =~ ^[0-9]+$ ]]; then
         BACKUP_FILE=$(ls -1 "$BACKUP_DIR"/mongodb_*.archive 2>/dev/null | sed -n "${BACKUP_INPUT}p")
     else
-        BACKUP_FILE="$BACKUP_DIR/$BACKUP_INPUT"
+        # Accept bare filename (no path) or full path
+        if [ -f "$BACKUP_INPUT" ]; then
+            BACKUP_FILE="$BACKUP_INPUT"
+        else
+            BACKUP_FILE="$BACKUP_DIR/$BACKUP_INPUT"
+        fi
     fi
 fi
 
@@ -48,14 +70,14 @@ if [ ! -f "$BACKUP_FILE" ]; then
 fi
 
 echo -e "${BLUE}=== RehaAdvisor Database Restore ===${NC}"
-echo -e "${BLUE}Backup file: $(basename $BACKUP_FILE)${NC}"
-echo -e "${BLUE}Backup size: $(du -h "$BACKUP_FILE" | cut -f1)${NC}"
-echo -e "${BLUE}Timestamp: $(date)${NC}"
+echo -e "${BLUE}Backup file : $(basename "$BACKUP_FILE")${NC}"
+echo -e "${BLUE}Backup size : $(du -h "$BACKUP_FILE" | cut -f1)${NC}"
+echo -e "${BLUE}Timestamp   : $(date)${NC}"
 echo ""
 
 # Confirm restore
-echo -e "${YELLOW}⚠️  WARNING: This will overwrite the current database!${NC}"
-read -p "Are you sure you want to restore from this backup? Type 'yes' to confirm: " CONFIRM
+echo -e "${YELLOW}⚠️  WARNING: This will OVERWRITE the current database!${NC}"
+read -rp "Type 'yes' to confirm: " CONFIRM
 
 if [ "$CONFIRM" != "yes" ]; then
     echo -e "${YELLOW}Restore cancelled${NC}"
@@ -75,7 +97,7 @@ max_attempts=30
 attempt=0
 
 while [ $attempt -lt $max_attempts ]; do
-    if docker exec db-prod mongosh --eval 'db.adminCommand("ping")' > /dev/null 2>&1; then
+    if docker exec db-prod mongosh --eval 'db.adminCommand("ping")' >/dev/null 2>&1; then
         echo -e "${GREEN}✓ MongoDB is ready${NC}"
         break
     fi
@@ -84,46 +106,42 @@ while [ $attempt -lt $max_attempts ]; do
 done
 
 if [ $attempt -eq $max_attempts ]; then
-    echo -e "${RED}✗ MongoDB failed to become ready${NC}"
+    echo -e "${RED}✗ MongoDB failed to become ready after $((max_attempts * 2))s${NC}"
     exit 1
 fi
 
-# Drop existing database (confirmation already received above)
+# Restore — --drop removes each collection before restoring it (atomic, no manual dropDatabase needed)
 echo ""
-echo -e "${YELLOW}Dropping current database...${NC}"
-docker exec db-prod mongosh reha_advisor --eval 'db.dropDatabase()' > /dev/null 2>&1
-
-# Restore backup
 echo -e "${YELLOW}Restoring backup...${NC}"
-docker exec -i db-prod mongorestore --archive --gzip < "$BACKUP_FILE"
+# shellcheck disable=SC2086
+docker exec -i db-prod mongorestore \
+    --archive --gzip \
+    --drop \
+    $MONGO_AUTH_ARGS \
+    < "$BACKUP_FILE"
 
 # Verify restore
 echo ""
 echo -e "${YELLOW}Verifying restore...${NC}"
-COLLECTION_COUNT=$(docker exec db-prod mongosh reha_advisor --eval 'db.getCollectionNames().length' 2>/dev/null | tail -1)
+COLLECTION_COUNT=$(docker exec db-prod mongosh reha_advisor \
+    --eval 'db.getCollectionNames().length' \
+    --quiet 2>/dev/null | tail -1)
 
-if [ "$COLLECTION_COUNT" -gt 0 ]; then
-    echo -e "${GREEN}✓ Restore completed successfully${NC}"
-    
-    # Show collections
+if [ "${COLLECTION_COUNT:-0}" -gt 0 ]; then
+    echo -e "${GREEN}✓ Restore verified — $COLLECTION_COUNT collections found${NC}"
+
     echo ""
-    echo -e "${BLUE}Collections in restored database:${NC}"
-    docker exec db-prod mongosh reha_advisor --eval 'db.getCollectionNames()' 2>/dev/null | tail -1
-    
-    # Show document counts
-    echo ""
-    echo -e "${BLUE}Document counts:${NC}"
-    docker exec db-prod mongosh reha_advisor << 'EOF'
+    echo -e "${BLUE}Document counts per collection:${NC}"
+    docker exec db-prod mongosh reha_advisor --quiet << 'EOF'
 db.getCollectionNames().forEach(function(name) {
-    var count = db[name].countDocuments({});
-    print(name + ': ' + count);
+    print("  " + name + ": " + db[name].countDocuments({}));
 });
 EOF
-    
+
 else
-    echo -e "${RED}✗ Restore failed - no collections found${NC}"
+    echo -e "${RED}✗ Restore failed — no collections found${NC}"
     exit 1
 fi
 
 echo ""
-echo -e "${GREEN}✓ Database restore process completed${NC}"
+echo -e "${GREEN}✓ Database restore complete${NC}"

--- a/scripts/setup-cron.sh
+++ b/scripts/setup-cron.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# Installs a daily backup cron job for RehaAdvisor.
+# Idempotent — safe to run multiple times; will not duplicate the entry.
+# Usage: ./setup-cron.sh [--hour H] [--minute M]
+# Default: runs daily at 03:00.
+
+set -e
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+REPO_DIR=$(cd "$SCRIPT_DIR/.." && pwd)
+
+CRON_HOUR=3
+CRON_MINUTE=0
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --hour)   CRON_HOUR="$2";   shift 2 ;;
+        --minute) CRON_MINUTE="$2"; shift 2 ;;
+        *) echo "Unknown option: $1"; echo "Usage: $0 [--hour H] [--minute M]"; exit 1 ;;
+    esac
+done
+
+BACKUP_SCRIPT="$REPO_DIR/scripts/backup.sh"
+CRON_LOG="$REPO_DIR/backups/cron.log"
+CRON_LINE="$CRON_MINUTE $CRON_HOUR * * * $BACKUP_SCRIPT >> $CRON_LOG 2>&1"
+
+if ! crontab -l 2>/dev/null | grep -qF "$BACKUP_SCRIPT"; then
+    (crontab -l 2>/dev/null; echo "$CRON_LINE") | crontab -
+    echo "Cron job installed: daily at $(printf '%02d:%02d' "$CRON_HOUR" "$CRON_MINUTE")"
+else
+    echo "Cron job already installed — no changes made"
+fi
+
+echo ""
+echo "Current backup cron entries:"
+crontab -l 2>/dev/null | grep backup || echo "  (none)"

--- a/scripts/tests/helpers.bash
+++ b/scripts/tests/helpers.bash
@@ -1,0 +1,107 @@
+# Shared test helpers for backup/restore/cron script tests.
+# Loaded by each .bats file via: load 'helpers'
+
+setup_repo() {
+    export REPO_DIR
+    REPO_DIR=$(mktemp -d -t bats-backup-XXXXX)
+    mkdir -p "$REPO_DIR"/{scripts,backups,data,bin}
+
+    cp "${BATS_TEST_DIRNAME}/../backup.sh"     "$REPO_DIR/scripts/"
+    cp "${BATS_TEST_DIRNAME}/../restore.sh"    "$REPO_DIR/scripts/"
+    cp "${BATS_TEST_DIRNAME}/../setup-cron.sh" "$REPO_DIR/scripts/"
+
+    # Control variables read by mock docker at runtime
+    export MOCK_DOCKER_CONTAINERS=""   # space-separated running container names
+    export MOCK_MONGODUMP_FAIL="false"
+    export MOCK_MEDIA_FAIL="false"
+    export MOCK_MONGORESTORE_FAIL="false"
+    export DOCKER_CAPTURE_LOG=""       # if set, each docker call appends "$@" here
+
+    # Crontab mock stores state in a file
+    export MOCK_CRONTAB_FILE="$REPO_DIR/.crontab"
+
+    _write_mock_docker
+    _write_mock_crontab
+    _write_mock_aws
+
+    # Prepend temp bin dir so mocks take precedence over real commands
+    export PATH="$REPO_DIR/bin:$PATH"
+}
+
+teardown_repo() {
+    rm -rf "$REPO_DIR"
+}
+
+# ---------------------------------------------------------------------------
+# Mock writers
+# ---------------------------------------------------------------------------
+
+_write_mock_docker() {
+    # Single-quoted heredoc — variable expansions happen at mock runtime,
+    # so MOCK_* env vars are read from the test's exported environment.
+    cat > "$REPO_DIR/bin/docker" << 'DOCKER_EOF'
+#!/bin/bash
+# Optionally capture every call for assertion in tests
+[ -n "${DOCKER_CAPTURE_LOG:-}" ] && echo "$*" >> "$DOCKER_CAPTURE_LOG"
+
+case "$1" in
+    ps)
+        # Simulate "docker ps --format '{{.Names}}'" — print running containers
+        for name in ${MOCK_DOCKER_CONTAINERS:-}; do echo "$name"; done
+        ;;
+    exec)
+        shift
+        # Consume optional flags (-i, -t, ...)
+        while [[ "$1" == -* ]]; do shift; done
+        container="$1"; shift
+        cmd="$1";       shift
+
+        case "$container.$cmd" in
+            db-prod.mongodump)
+                [ "${MOCK_MONGODUMP_FAIL:-false}" = "true" ] && exit 1
+                printf 'archive-data'
+                ;;
+            db-prod.mongorestore)
+                cat > /dev/null          # consume stdin (the archive pipe)
+                [ "${MOCK_MONGORESTORE_FAIL:-false}" = "true" ] && exit 1
+                ;;
+            db-prod.mongosh)
+                all_args="$*"
+                if   echo "$all_args" | grep -q 'ping';   then echo '{ ok: 1 }'
+                elif echo "$all_args" | grep -q 'length'; then echo '3'
+                else cat > /dev/null     # consume heredoc stdin
+                fi
+                ;;
+            django-prod.tar)
+                [ "${MOCK_MEDIA_FAIL:-false}" = "true" ] && exit 1
+                printf 'tar-data'
+                ;;
+        esac
+        ;;
+esac
+exit 0
+DOCKER_EOF
+    chmod +x "$REPO_DIR/bin/docker"
+}
+
+_write_mock_crontab() {
+    # Unquoted heredoc so $MOCK_CRONTAB_FILE expands now (the path is fixed per test).
+    # \$1 stays literal so $1 is expanded when the mock runs.
+    cat > "$REPO_DIR/bin/crontab" << CRON_EOF
+#!/bin/bash
+case "\$1" in
+    -l) cat "${MOCK_CRONTAB_FILE}" 2>/dev/null || true ;;
+    -)  cat > "${MOCK_CRONTAB_FILE}" ;;
+esac
+CRON_EOF
+    chmod +x "$REPO_DIR/bin/crontab"
+}
+
+_write_mock_aws() {
+    cat > "$REPO_DIR/bin/aws" << 'AWS_EOF'
+#!/bin/bash
+[ "${MOCK_AWS_FAIL:-false}" = "true" ] && exit 1
+exit 0
+AWS_EOF
+    chmod +x "$REPO_DIR/bin/aws"
+}

--- a/scripts/tests/test_backup.bats
+++ b/scripts/tests/test_backup.bats
@@ -1,0 +1,145 @@
+#!/usr/bin/env bats
+# Tests for scripts/backup.sh
+# Run: bats scripts/tests/test_backup.bats
+
+load 'helpers'
+
+setup()    { setup_repo; }
+teardown() { teardown_repo; }
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+
+@test "unknown flag exits 1 and prints usage" {
+    run bash "$REPO_DIR/scripts/backup.sh" --bad-flag
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Unknown option"* ]]
+    [[ "$output" == *"Usage:"* ]]
+}
+
+@test "--upload-s3 without --s3-bucket exits 1 after successful backup" {
+    export MOCK_DOCKER_CONTAINERS="db-prod"
+    run bash "$REPO_DIR/scripts/backup.sh" --upload-s3
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"S3 bucket not specified"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# MongoDB backup
+# ---------------------------------------------------------------------------
+
+@test "mongodb container not running exits 1" {
+    # MOCK_DOCKER_CONTAINERS is empty — docker ps returns nothing
+    run bash "$REPO_DIR/scripts/backup.sh"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"not running"* ]]
+}
+
+@test "mongodb backup creates archive file with content" {
+    export MOCK_DOCKER_CONTAINERS="db-prod"
+    run bash "$REPO_DIR/scripts/backup.sh"
+    [ "$status" -eq 0 ]
+    local count
+    count=$(ls "$REPO_DIR/backups/mongodb_"*.archive 2>/dev/null | wc -l)
+    [ "$count" -eq 1 ]
+    # Archive must be non-empty (mock writes "archive-data")
+    local f
+    f=$(ls "$REPO_DIR/backups/mongodb_"*.archive)
+    [ -s "$f" ]
+}
+
+@test "mongodump failure exits 1 and removes partial archive" {
+    export MOCK_DOCKER_CONTAINERS="db-prod"
+    export MOCK_MONGODUMP_FAIL="true"
+    run bash "$REPO_DIR/scripts/backup.sh"
+    [ "$status" -eq 1 ]
+    local count
+    count=$(ls "$REPO_DIR/backups/mongodb_"*.archive 2>/dev/null | wc -l)
+    [ "$count" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# SQLite backup
+# ---------------------------------------------------------------------------
+
+@test "sqlite file absent skips without error and exits 0" {
+    export MOCK_DOCKER_CONTAINERS="db-prod"
+    # data/db.sqlite3 deliberately not created
+    run bash "$REPO_DIR/scripts/backup.sh"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"SQLite file not found"* ]]
+    local count
+    count=$(ls "$REPO_DIR/backups/sqlite_"*.db 2>/dev/null | wc -l)
+    [ "$count" -eq 0 ]
+}
+
+@test "sqlite file present creates backup" {
+    export MOCK_DOCKER_CONTAINERS="db-prod"
+    touch "$REPO_DIR/data/db.sqlite3"
+    run bash "$REPO_DIR/scripts/backup.sh"
+    [ "$status" -eq 0 ]
+    local count
+    count=$(ls "$REPO_DIR/backups/sqlite_"*.db 2>/dev/null | wc -l)
+    [ "$count" -eq 1 ]
+}
+
+# ---------------------------------------------------------------------------
+# Media backup
+# ---------------------------------------------------------------------------
+
+@test "django-prod not running skips media and exits 0" {
+    export MOCK_DOCKER_CONTAINERS="db-prod"  # no django-prod
+    run bash "$REPO_DIR/scripts/backup.sh"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"skipping media backup"* ]]
+    local count
+    count=$(ls "$REPO_DIR/backups/media_"*.tar.gz 2>/dev/null | wc -l)
+    [ "$count" -eq 0 ]
+}
+
+@test "full backup with all containers creates all three files" {
+    export MOCK_DOCKER_CONTAINERS="db-prod django-prod"
+    touch "$REPO_DIR/data/db.sqlite3"
+    run bash "$REPO_DIR/scripts/backup.sh"
+    [ "$status" -eq 0 ]
+    [ "$(ls "$REPO_DIR/backups/mongodb_"*.archive 2>/dev/null | wc -l)" -eq 1 ]
+    [ "$(ls "$REPO_DIR/backups/sqlite_"*.db 2>/dev/null | wc -l)" -eq 1 ]
+    [ "$(ls "$REPO_DIR/backups/media_"*.tar.gz 2>/dev/null | wc -l)" -eq 1 ]
+}
+
+# ---------------------------------------------------------------------------
+# Credentials and metadata
+# ---------------------------------------------------------------------------
+
+@test "reads mongodb credentials from .env.prod and passes to docker" {
+    cat > "$REPO_DIR/.env.prod" << 'ENV_EOF'
+MONGO_INITDB_ROOT_USERNAME=admin
+MONGO_INITDB_ROOT_PASSWORD=secret99
+ENV_EOF
+
+    export MOCK_DOCKER_CONTAINERS="db-prod"
+    export DOCKER_CAPTURE_LOG="$REPO_DIR/docker-calls.log"
+    run bash "$REPO_DIR/scripts/backup.sh"
+    [ "$status" -eq 0 ]
+
+    # Auth args must appear in the mongodump invocation
+    grep -q "\-u admin" "$DOCKER_CAPTURE_LOG"
+    grep -q "\-p secret99" "$DOCKER_CAPTURE_LOG"
+}
+
+@test "creates .meta file with correct json fields after backup" {
+    export MOCK_DOCKER_CONTAINERS="db-prod"
+    run bash "$REPO_DIR/scripts/backup.sh"
+    [ "$status" -eq 0 ]
+
+    local meta
+    meta=$(ls "$REPO_DIR/backups/backup_"*.meta 2>/dev/null | head -1)
+    [ -n "$meta" ]
+    # Required JSON keys must be present
+    grep -q '"timestamp"' "$meta"
+    grep -q '"mongodb"'   "$meta"
+    grep -q '"sqlite"'    "$meta"
+    grep -q '"media"'     "$meta"
+    grep -q '"retention_days"' "$meta"
+}

--- a/scripts/tests/test_restore.bats
+++ b/scripts/tests/test_restore.bats
@@ -1,0 +1,97 @@
+#!/usr/bin/env bats
+# Tests for scripts/restore.sh
+# Run: bats scripts/tests/test_restore.bats
+
+load 'helpers'
+
+setup() {
+    setup_repo
+    # Pre-create a fake backup archive so restore tests have something to work with
+    export FAKE_ARCHIVE="$REPO_DIR/backups/mongodb_20260101_030000.archive"
+    printf 'fake-archive-data' > "$FAKE_ARCHIVE"
+}
+teardown() { teardown_repo; }
+
+# ---------------------------------------------------------------------------
+# File resolution
+# ---------------------------------------------------------------------------
+
+@test "non-existent file argument exits 1 with not-found message" {
+    run bash "$REPO_DIR/scripts/restore.sh" "/no/such/file.archive"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"not found"* ]]
+}
+
+@test "interactive mode resolves bare filename to backups directory" {
+    # No positional arg → interactive. Two lines piped: filename then cancel.
+    run bash -c "printf 'mongodb_20260101_030000.archive\nno\n' | bash '$REPO_DIR/scripts/restore.sh'"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Restore cancelled"* ]]
+}
+
+@test "interactive mode accepts number to select backup" {
+    run bash -c "printf '1\nno\n' | bash '$REPO_DIR/scripts/restore.sh'"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Restore cancelled"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Confirmation prompt
+# ---------------------------------------------------------------------------
+
+@test "typing anything other than yes cancels restore" {
+    run bash "$REPO_DIR/scripts/restore.sh" "$FAKE_ARCHIVE" <<< "no"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Restore cancelled"* ]]
+}
+
+@test "empty confirmation cancels restore" {
+    run bash "$REPO_DIR/scripts/restore.sh" "$FAKE_ARCHIVE" <<< ""
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Restore cancelled"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Container checks
+# ---------------------------------------------------------------------------
+
+@test "mongodb container not running after confirmation exits 1" {
+    # MOCK_DOCKER_CONTAINERS is empty — db-prod not running
+    run bash "$REPO_DIR/scripts/restore.sh" "$FAKE_ARCHIVE" <<< "yes"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"not running"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Successful restore
+# ---------------------------------------------------------------------------
+
+@test "successful restore exits 0 and reports collection count" {
+    export MOCK_DOCKER_CONTAINERS="db-prod"
+    run bash "$REPO_DIR/scripts/restore.sh" "$FAKE_ARCHIVE" <<< "yes"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"3 collections found"* ]]
+    [[ "$output" == *"restore complete"* ]]
+}
+
+@test "restore reads mongodb credentials from .env.prod and passes to docker" {
+    cat > "$REPO_DIR/.env.prod" << 'ENV_EOF'
+MONGO_INITDB_ROOT_USERNAME=restoreuser
+MONGO_INITDB_ROOT_PASSWORD=restorepass
+ENV_EOF
+
+    export MOCK_DOCKER_CONTAINERS="db-prod"
+    export DOCKER_CAPTURE_LOG="$REPO_DIR/docker-calls.log"
+    run bash "$REPO_DIR/scripts/restore.sh" "$FAKE_ARCHIVE" <<< "yes"
+    [ "$status" -eq 0 ]
+
+    grep -q "\-u restoreuser" "$DOCKER_CAPTURE_LOG"
+    grep -q "\-p restorepass" "$DOCKER_CAPTURE_LOG"
+}
+
+@test "mongorestore failure exits 1" {
+    export MOCK_DOCKER_CONTAINERS="db-prod"
+    export MOCK_MONGORESTORE_FAIL="true"
+    run bash "$REPO_DIR/scripts/restore.sh" "$FAKE_ARCHIVE" <<< "yes"
+    [ "$status" -eq 1 ]
+}

--- a/scripts/tests/test_setup_cron.bats
+++ b/scripts/tests/test_setup_cron.bats
@@ -1,0 +1,71 @@
+#!/usr/bin/env bats
+# Tests for scripts/setup-cron.sh
+# Run: bats scripts/tests/test_setup_cron.bats
+
+load 'helpers'
+
+setup()    { setup_repo; }
+teardown() { teardown_repo; }
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+
+@test "unknown flag exits 1 and prints usage" {
+    run bash "$REPO_DIR/scripts/setup-cron.sh" --bad-flag
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Unknown option"* ]]
+    [[ "$output" == *"Usage:"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Installation
+# ---------------------------------------------------------------------------
+
+@test "default installs cron entry at 03:00" {
+    run bash "$REPO_DIR/scripts/setup-cron.sh"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"03:00"* ]]
+
+    # The crontab file should contain the correct time fields
+    grep -qE '^0 3 \* \* \*' "$MOCK_CRONTAB_FILE"
+}
+
+@test "--hour and --minute flags set custom timing" {
+    run bash "$REPO_DIR/scripts/setup-cron.sh" --hour 2 --minute 30
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"02:30"* ]]
+    grep -qE '^30 2 \* \* \*' "$MOCK_CRONTAB_FILE"
+}
+
+@test "cron entry points to backup.sh inside the repo" {
+    run bash "$REPO_DIR/scripts/setup-cron.sh"
+    [ "$status" -eq 0 ]
+
+    # The installed line must reference the backup.sh in the same repo
+    grep -q "$REPO_DIR/scripts/backup.sh" "$MOCK_CRONTAB_FILE"
+}
+
+@test "cron entry redirects output to cron.log inside backups dir" {
+    run bash "$REPO_DIR/scripts/setup-cron.sh"
+    [ "$status" -eq 0 ]
+    grep -q "$REPO_DIR/backups/cron.log" "$MOCK_CRONTAB_FILE"
+}
+
+# ---------------------------------------------------------------------------
+# Idempotency
+# ---------------------------------------------------------------------------
+
+@test "running twice does not duplicate the cron entry" {
+    run bash "$REPO_DIR/scripts/setup-cron.sh"
+    [ "$status" -eq 0 ]
+
+    run bash "$REPO_DIR/scripts/setup-cron.sh"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"already installed"* ]]
+
+    # Exactly one backup entry in the crontab file
+    local count
+    count=$(grep -c "backup.sh" "$MOCK_CRONTAB_FILE")
+    [ "$count" -eq 1 ]
+}


### PR DESCRIPTION
# Description

Fixes the broken backup script and extends it to cover all three data stores (MongoDB, SQLite, and media). Before this change, no reliable automated backup existed: `backup.sh` was a complete no-op due to three bugs, SQLite and the media volume were never backed up, and no cron job was scheduled.

**What was broken in the old `backup.sh`:**
- `mongodump --archive=<host-path>` writes the archive inside the container to a path that has no volume mount — the file was silently discarded on every run
- `--archive` and `--out` are mutually exclusive flags; passing both caused an error
- No MongoDB credentials were passed, so auth-protected databases were rejected
- Paths were hardcoded to `/opt/reha-advisor/` which does not exist on this server

**What this PR adds:**
- Rewrites `backup.sh` with the correct `docker exec ... mongodump --archive --gzip > file` pipe pattern
- Reads MongoDB credentials from `.env.prod` at runtime
- Adds SQLite backup (`./data/db.sqlite3` bind-mount, used by celery-beat)
- Adds media volume backup (`/srv/app/media` inside `django-prod`)
- Rewrites `restore.sh`: same path/auth fixes, replaces manual `db.dropDatabase()` with the atomic `--drop` flag
- Adds `setup-cron.sh`: idempotent installer for a daily 03:00 backup cron job
- All scripts derive their paths from their own location — no hardcoded paths
- Rewrites `scripts/README.md` with accurate setup, usage, and troubleshooting docs
- Adds 26 bats tests covering all three scripts

## Related Issue
[#191 Fix and automate database backups](https://github.com/ARTORG-GERONTECHNOLOGY/Bearny-RehaAdvisor/issues/191)

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Documentation update
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (specify)

## Tests
Manual smoke test on prod (run after merging and deploying):
```bash
cd /home/ubuntu/repos/telerehabapp-prod
bash scripts/backup.sh
ls -lh backups/
# Expect: mongodb_*.archive (non-zero), sqlite_*.db, media_*.tar.gz

bash scripts/setup-cron.sh
crontab -l | grep backup
# Expect: 0 3 * * * .../scripts/backup.sh >> .../backups/cron.log 2>&1

```
## Checklist

- [x]  I have read the [contributing guidelines](vscode-webview://01s0e8cn5tnjldvcuuc83jqd8doji1p4aqm55jv1cnaq876q8qmk/docs/12-CONTRIBUTING.md).
- [x]  I have read the [code of conduct](vscode-webview://01s0e8cn5tnjldvcuuc83jqd8doji1p4aqm55jv1cnaq876q8qmk/CODE_OF_CONDUCT.md).
- [x]  I have commented my code, particularly in hard-to-understand areas.
- [x]  I have made corresponding changes to the documentation.
- [x]  My changes generate no new warnings.
- [x]  I have added tests that prove my fix is effective or that my feature works.