### PR TITLE
Fix TypeError when sorting thresholds history with mixed naive/aware datetimes

### DIFF
--- a/backend/core/views/patient_thresholds.py
+++ b/backend/core/views/patient_thresholds.py
@@ -121,6 +121,15 @@ def _parse_iso_dt(value: Any) -> Optional[datetime]:
     return dt
 
 
+def _coerce_aware(dt) -> datetime:
+    """Return dt as a timezone-aware datetime, treating naive values as local time."""
+    if dt is None:
+        return timezone.now()
+    if timezone.is_naive(dt):
+        return timezone.make_aware(dt, timezone.get_current_timezone())
+    return dt
+
+
 def _user_is_admin(user: User) -> bool:
     return getattr(user, "role", "") == "Admin"
 
@@ -448,7 +457,7 @@ def patient_thresholds_view(request, patient_id: str):
         # Sort history descending by effective_from
         hist_sorted = sorted(
             hist,
-            key=lambda x: getattr(x, "effective_from", timezone.now()),
+            key=lambda x: _coerce_aware(getattr(x, "effective_from", None)),
             reverse=True,
         )
 
@@ -496,7 +505,7 @@ def patient_thresholds_view(request, patient_id: str):
     hist = list(getattr(updated, "thresholds_history", []) or [])
     hist_sorted = sorted(
         hist,
-        key=lambda x: getattr(x, "effective_from", timezone.now()),
+        key=lambda x: _coerce_aware(getattr(x, "effective_from", None)),
         reverse=True,
     )
 

--- a/backend/tests/patient_thresholds_views/TESTING.md
+++ b/backend/tests/patient_thresholds_views/TESTING.md
@@ -16,7 +16,7 @@ for `core/views/patient_thresholds.py`.
 | `/api/patients/<patient_id>/thresholds/` | POST | `patient_thresholds_view` | 1 |
 | `/api/patients/<patient_id>/thresholds/` | DELETE | `patient_thresholds_view` | 1 |
 
-**Total: 11 tests**
+**Total: 13 tests**
 
 ---
 
@@ -35,6 +35,8 @@ for `core/views/patient_thresholds.py`.
 | `test_thresholds_helpers_parse_user_role_and_dict_fallback` | helper parsing/role/dict-conversion branches | helper outputs validated |
 | `test_thresholds_serializer_and_merge_logic` | serializer ranges + merge/equality helpers | expected validation and merge behavior |
 | `test_update_thresholds_noop_and_history_and_view_error_branches` | no-op update, history append, and exception path | no unnecessary writes + error response branch |
+| `test_coerce_aware` | `_coerce_aware()` with None, naive datetime, and aware datetime inputs | always returns aware datetime |
+| `test_history_sort_tolerates_naive_effective_from` | GET with history snapshots that have naive `effective_from` (legacy DB records) | 200, no TypeError, descending order preserved |
 
 ---
 

--- a/backend/tests/patient_thresholds_views/test_patient_threshold_helpers.py
+++ b/backend/tests/patient_thresholds_views/test_patient_threshold_helpers.py
@@ -8,10 +8,11 @@ import pytest
 from django.test import RequestFactory
 from django.utils import timezone
 
-from core.models import Patient, PatientThresholds, Therapist, User
+from core.models import Patient, PatientThresholds, PatientThresholdsSnapshot, Therapist, User
 from core.views.patient_thresholds import (
     PatientThresholdsSerializer,
     ThresholdsUpdateSerializer,
+    _coerce_aware,
     _ensure_patient_thresholds,
     _merge_thresholds,
     _parse_iso_dt,
@@ -100,6 +101,56 @@ def test_thresholds_serializer_and_merge_logic():
     merged = _merge_thresholds(current, patch)
     assert merged.steps_goal == 11000
     assert _thresholds_equal(current, PatientThresholds(steps_goal=10000)) is True
+
+
+def test_coerce_aware():
+    # None → returns timezone.now() (aware)
+    result = _coerce_aware(None)
+    assert timezone.is_aware(result)
+
+    # naive datetime → made aware
+    naive = datetime(2025, 6, 1, 12, 0, 0)
+    assert timezone.is_naive(naive)
+    result = _coerce_aware(naive)
+    assert timezone.is_aware(result)
+    assert result.year == 2025 and result.month == 6
+
+    # already-aware datetime → returned unchanged
+    aware = timezone.now()
+    result = _coerce_aware(aware)
+    assert timezone.is_aware(result)
+    assert result == aware
+
+
+def test_history_sort_tolerates_naive_effective_from():
+    """GET /thresholds/ must not raise TypeError when history contains naive datetimes."""
+    patient = _create_patient()
+    _ensure_patient_thresholds(patient)
+
+    # Inject two history snapshots with naive effective_from values directly,
+    # simulating records written before timezone awareness was enforced.
+    snap1 = PatientThresholdsSnapshot(
+        effective_from=datetime(2025, 1, 1, 8, 0, 0),  # naive
+        reason="old record 1",
+        thresholds=PatientThresholds(steps_goal=8000),
+    )
+    snap2 = PatientThresholdsSnapshot(
+        effective_from=datetime(2025, 6, 1, 8, 0, 0),  # naive
+        reason="old record 2",
+        thresholds=PatientThresholds(steps_goal=9000),
+    )
+    patient.thresholds_history = [snap1, snap2]
+    patient.save()
+
+    req = rf.get(f"/api/patients/{patient.id}/thresholds/")
+    resp = patient_thresholds_view(req, str(patient.id))
+
+    assert resp.status_code == 200
+    data = json.loads(resp.content)
+    assert len(data["history"]) == 2
+    # History is returned newest-first; June comes before January
+    assert data["history"][0]["reason"] == "old record 2"
+    assert data["history"][1]["reason"] == "old record 1"
 
 
 def test_update_thresholds_noop_and_history_and_view_error_branches():


### PR DESCRIPTION
# Description
effective_from values stored by older records may be timezone-naive, while the previous sort key fallback used timezone.now() (always aware). Python raises TypeError when comparing the two.

Add _coerce_aware() helper that normalises any naive datetime to aware using the current timezone, then apply it in both sort-key lambdas (GET handler and PATCH response).

## Tests added:
- test_coerce_aware: unit tests for None, naive, and already-aware inputs
- test_history_sort_tolerates_naive_effective_from: end-to-end GET with two naive effective_from snapshots; asserts 200 and correct descending order

