### PR TITLE
Fix Health sort label direction and update all language files

### DIFF
--- a/frontend/src/assets/lang/de.json
+++ b/frontend/src/assets/lang/de.json
@@ -117,7 +117,7 @@
   "Active patients": "Aktive Patienten",
   "Reset filters": "Filter zurücksetzen",
   "Feedback (worst → best)": "Rückmeldung (schlechteste → beste)",
-  "Health (best → worst)": "Gesundheit (beste → schlechteste)",
+  "Health (worst → best)": "Gesundheit (schlechteste → beste)",
   "Adherence (high → low)": "Adhärenz (hoch → niedrig)",
   "Last login (recent first)": "Letzte Anmeldung (neueste zuerst)",
   "Newest created": "Neueste Erstellung",

--- a/frontend/src/assets/lang/en.json
+++ b/frontend/src/assets/lang/en.json
@@ -116,7 +116,7 @@
   "Active patients": "Active patients",
   "Reset filters": "Reset filters",
   "Feedback (worst → best)": "Feedback (worst → best)",
-  "Health (best → worst)": "Health (best → worst)",
+  "Health (worst → best)": "Health (worst → best)",
   "Adherence (high → low)": "Adherence (high → low)",
   "Last login (recent first)": "Last login (recent first)",
   "Newest created": "Newest created",

--- a/frontend/src/assets/lang/fr.json
+++ b/frontend/src/assets/lang/fr.json
@@ -118,7 +118,7 @@
   "Active patients": "Patients actifs",
   "Reset filters": "Réinitialiser les filtres",
   "Feedback (worst → best)": "Retour (pire → meilleur)",
-  "Health (best → worst)": "Santé (meilleur → pire)",
+  "Health (worst → best)": "Santé (pire → meilleur)",
   "Adherence (high → low)": "Adhérence (élevée → faible)",
   "Last login (recent first)": "Dernière connexion (récent d'abord)",
   "Newest created": "Le plus récent",

--- a/frontend/src/assets/lang/it.json
+++ b/frontend/src/assets/lang/it.json
@@ -117,7 +117,7 @@
   "Active patients": "Pazienti attivi",
   "Reset filters": "Reimposta",
   "Feedback (worst → best)": "Feedback (peggiore → migliore)",
-  "Health (best → worst)": "Salute (migliore → peggiore)",
+  "Health (worst → best)": "Salute (peggiore → migliore)",
   "Adherence (high → low)": "Aderenza (alto → basso)",
   "Last login (recent first)": "Ultimo accesso (recenti prima)",
   "Newest created": "Più recente",

--- a/frontend/src/assets/lang/nl.json
+++ b/frontend/src/assets/lang/nl.json
@@ -116,7 +116,7 @@
   "Active patients": "Actieve patiënten",
   "Reset filters": "Filters resetten",
   "Feedback (worst → best)": "Feedback (slechtste → beste)",
-  "Health (best → worst)": "Gezondheid (beste → slechtste)",
+  "Health (worst → best)": "Gezondheid (slechtste → beste)",
   "Adherence (high → low)": "Therapietrouw (hoog → laag)",
   "Last login (recent first)": "Laatste aanmelding (meest recent eerst)",
   "Newest created": "Nieuwste aangemaakt",

--- a/frontend/src/assets/lang/pt.json
+++ b/frontend/src/assets/lang/pt.json
@@ -116,7 +116,7 @@
   "Active patients": "Pacientes ativos",
   "Reset filters": "Repor filtros",
   "Feedback (worst → best)": "Feedback (pior → melhor)",
-  "Health (best → worst)": "Saúde (melhor → pior)",
+  "Health (worst → best)": "Saúde (pior → melhor)",
   "Adherence (high → low)": "Adesão (alta → baixa)",
   "Last login (recent first)": "Último acesso (mais recente primeiro)",
   "Newest created": "Criados mais recentemente",

--- a/frontend/src/pages/Therapist.tsx
+++ b/frontend/src/pages/Therapist.tsx
@@ -790,7 +790,7 @@ const Therapist: React.FC = observer(() => {
                     <option value="created">{String(t('Newest created'))}</option>
                     <option value="last_login">{String(t('Last login (recent first)'))}</option>
                     <option value="adherence">{String(t('Adherence (high → low)'))}</option>
-                    <option value="health">{String(t('Health (best → worst)'))}</option>
+                    <option value="health">{String(t('Health (worst → best)'))}</option>
                     <option value="feedback">{String(t('Feedback (worst → best)'))}</option>
                   </Form.Select>
                 </Col>


### PR DESCRIPTION
The health sort key orders patients worst-first (getHealth(a) - getHealth(b), where smaller score = worse health), but was labeled "Health (best → worst)". This was inconsistent both with the actual sort behavior and with the "Feedback (worst → best)" convention.

Since PR #151 hid the Health chip for ongoing patients, the sort now only meaningfully surfaces differences in the completed-patients section — surfacing the worst health scores first is the right default for that context.

Changes:
- Therapist.tsx: update option label to "Health (worst → best)"
- en/de/fr/it/pt/nl.json: rename i18n key and flip translation direction

