### PR TITLE
Fix #209 — Add 15-minute cooldown to Fitbit on-demand fetch to prevent 429 rate-limit errors

### DIFF
--- a/backend/core/models.py
+++ b/backend/core/models.py
@@ -60,6 +60,7 @@ class FitbitUserToken(Document):
     refresh_token = StringField(required=True, max_length=2048)
     expires_at = DateTimeField()
     fitbit_user_id = StringField(required=True)
+    last_fetched_at = DateTimeField()
 
 
 class HeartRateZone(EmbeddedDocument):

--- a/backend/core/tasks.py
+++ b/backend/core/tasks.py
@@ -79,7 +79,7 @@ def fetch_fitbit_data_async(user_id):
 
     user = User.objects(pk=user_id).first()
     if user:
-        fetch_fitbit_today_for_user(user)
+        fetch_fitbit_today_for_user(user, bypass_cooldown=True)
 
 
 @shared_task(

--- a/backend/core/views/fitbit_sync.py
+++ b/backend/core/views/fitbit_sync.py
@@ -71,7 +71,9 @@ def fetch_fitbit_today_for_user(user, bypass_cooldown: bool = False) -> int:
     if not bypass_cooldown and token.last_fetched_at:
         last = token.last_fetched_at
         if is_naive(last):
-            last = make_aware(last)
+            # MongoDB always stores UTC; replace rather than make_aware to avoid
+            # local-timezone offset turning a fresh stamp into a stale one.
+            last = last.replace(tzinfo=datetime.timezone.utc)
         age_minutes = (timezone.now() - last).total_seconds() / 60
         if age_minutes < FETCH_COOLDOWN_MINUTES:
             logger.info(f"[fitbit] skipping fetch for user={user} — last synced {age_minutes:.1f} min ago")

--- a/backend/core/views/fitbit_sync.py
+++ b/backend/core/views/fitbit_sync.py
@@ -56,7 +56,10 @@ def get_valid_access_token(user):
     return token.access_token
 
 
-def fetch_fitbit_today_for_user(user) -> int:
+FETCH_COOLDOWN_MINUTES = 15
+
+
+def fetch_fitbit_today_for_user(user, bypass_cooldown: bool = False) -> int:
     """Fetch **today only** for a single user; returns upserted day-count (0|1)."""
     today = datetime.date.today()
     token = FitbitUserToken.objects(user=user).first()
@@ -64,6 +67,15 @@ def fetch_fitbit_today_for_user(user) -> int:
         logger.info(f"[fitbit] no token for user={user}. skip")
         print(f"[fitbit] no token for user={user}. skip")
         return 0
+
+    if not bypass_cooldown and token.last_fetched_at:
+        last = token.last_fetched_at
+        if is_naive(last):
+            last = make_aware(last)
+        age_minutes = (timezone.now() - last).total_seconds() / 60
+        if age_minutes < FETCH_COOLDOWN_MINUTES:
+            logger.info(f"[fitbit] skipping fetch for user={user} — last synced {age_minutes:.1f} min ago")
+            return 0
 
     access_token = get_valid_access_token(user)
     headers = {"Authorization": f"Bearer {access_token}"}
@@ -101,6 +113,10 @@ def fetch_fitbit_today_for_user(user) -> int:
             except Exception:
                 val = 0
             series[series_key][dt] = val
+
+    # Stamp before first API call so any 429 still resets the cooldown window
+    token.last_fetched_at = timezone.now()
+    token.save()
 
     # Basic time series (today only)
     fetch_series("steps", "activities/steps")

--- a/backend/tests/core_infra/test_redcap_router_tasks.py
+++ b/backend/tests/core_infra/test_redcap_router_tasks.py
@@ -72,7 +72,7 @@ def test_fetch_fitbit_data_async_calls_sync_when_user_exists():
         patch("core.tasks.fetch_fitbit_today_for_user") as mocked,
     ):
         fetch_fitbit_data_async("507f1f77bcf86cd799439011")
-    mocked.assert_called_once_with("user-doc")
+    mocked.assert_called_once_with("user-doc", bypass_cooldown=True)
 
 
 def test_fetch_fitbit_data_async_noop_when_user_missing():

--- a/backend/tests/fitbit_sync/test_fitbit_sync.py
+++ b/backend/tests/fitbit_sync/test_fitbit_sync.py
@@ -3,6 +3,12 @@ Fitbit sync service tests
 =========================
 
 Tests core/views/fitbit_sync.py helper/service functions directly.
+
+Cooldown behaviour
+------------------
+fetch_fitbit_today_for_user skips the Fitbit API when the token's
+last_fetched_at is within FETCH_COOLDOWN_MINUTES (15 min) of now.
+Pass bypass_cooldown=True (Celery task) to ignore the window.
 """
 
 from datetime import datetime, timedelta
@@ -13,7 +19,7 @@ import pytest
 from django.utils import timezone
 
 from core.models import FitbitData, FitbitUserToken, User
-from core.views.fitbit_sync import fetch_fitbit_today_for_user, get_valid_access_token
+from core.views.fitbit_sync import FETCH_COOLDOWN_MINUTES, fetch_fitbit_today_for_user, get_valid_access_token
 
 
 @pytest.fixture(autouse=True, scope="function")
@@ -35,7 +41,7 @@ def mongo_mock():
     disconnect(alias)
 
 
-def make_user_with_token(expired=False):
+def make_user_with_token(expired=False, last_fetched_at=None):
     user = User(
         username=f"u-{datetime.now().timestamp()}",
         createdAt=datetime.now(),
@@ -48,8 +54,39 @@ def make_user_with_token(expired=False):
         refresh_token="old-refresh",
         fitbit_user_id="fu",
         expires_at=exp,
+        last_fetched_at=last_fetched_at,
     ).save()
     return user, token
+
+
+def _all_empty_side_effect(url, headers=None, timeout=None):
+    """Return empty-but-valid Fitbit API responses for every endpoint."""
+    r = Mock()
+    r.status_code = 200
+    r.text = "ok"
+    mapping = {
+        "activities/steps": {"activities-steps": []},
+        "activities/floors": {"activities-floors": []},
+        "activities/distance": {"activities-distance": []},
+        "activities/calories": {"activities-calories": []},
+        "minutesVeryActive": {"activities-minutesVeryActive": []},
+        "minutesFairlyActive": {"activities-minutesFairlyActive": []},
+        "minutesLightlyActive": {"activities-minutesLightlyActive": []},
+        "minutesSedentary": {"activities-minutesSedentary": []},
+        "active-zone-minutes": {"activities-activeZoneMinutes": []},
+        "activities/heart": {"activities-heart": []},
+        "1d/1sec": {"activities-heart-intraday": {"dataset": []}},
+        "/br/": {"br": []},
+        "/hrv/": {"hrv": []},
+        "/sleep/": {"sleep": []},
+        "activities/list.json": {"activities": []},
+    }
+    for key, payload in mapping.items():
+        if key in url:
+            r.json.return_value = payload
+            return r
+    r.json.return_value = {}
+    return r
 
 
 def test_get_valid_access_token_returns_current_when_not_expired():
@@ -501,3 +538,106 @@ def test_minutes_asleep_stored_separately_from_duration(mock_get, _):
     assert row.sleep.sleep_duration == 28800000  # raw time in bed (ms)
     assert row.sleep.minutes_asleep == 435  # actual sleep (matches Fitbit app)
     assert row.sleep.awakenings == 3
+
+
+# ---------------------------------------------------------------------------
+# Cooldown / rate-limit guard
+# ---------------------------------------------------------------------------
+
+
+def test_cooldown_skips_fetch_when_recently_synced():
+    """Returns 0 immediately and makes no API calls when last_fetched_at is within the window."""
+    recent = timezone.now() - timedelta(minutes=FETCH_COOLDOWN_MINUTES - 5)
+    user, _ = make_user_with_token(expired=False, last_fetched_at=recent)
+
+    with patch("core.views.fitbit_sync.requests.get") as mock_get:
+        result = fetch_fitbit_today_for_user(user)
+
+    assert result == 0
+    mock_get.assert_not_called()
+
+
+@patch("core.views.fitbit_sync.get_valid_access_token", return_value="access")
+@patch("core.views.fitbit_sync.requests.get")
+def test_cooldown_allows_fetch_when_last_synced_is_stale(mock_get, _):
+    """Fetch proceeds when last_fetched_at is older than the cooldown window."""
+    stale = timezone.now() - timedelta(minutes=FETCH_COOLDOWN_MINUTES + 5)
+    user, _ = make_user_with_token(expired=False, last_fetched_at=stale)
+    mock_get.side_effect = _all_empty_side_effect
+
+    fetch_fitbit_today_for_user(user)
+
+    assert mock_get.called
+
+
+@patch("core.views.fitbit_sync.get_valid_access_token", return_value="access")
+@patch("core.views.fitbit_sync.requests.get")
+def test_cooldown_allows_fetch_when_last_fetched_at_is_none(mock_get, _):
+    """Fetch proceeds on the first sync when last_fetched_at has never been set."""
+    user, _ = make_user_with_token(expired=False, last_fetched_at=None)
+    mock_get.side_effect = _all_empty_side_effect
+
+    fetch_fitbit_today_for_user(user)
+
+    assert mock_get.called
+
+
+@patch("core.views.fitbit_sync.get_valid_access_token", return_value="access")
+@patch("core.views.fitbit_sync.requests.get")
+def test_bypass_cooldown_proceeds_despite_recent_sync(mock_get, _):
+    """bypass_cooldown=True ignores a recent last_fetched_at and hits the API."""
+    recent = timezone.now() - timedelta(minutes=FETCH_COOLDOWN_MINUTES - 5)
+    user, _ = make_user_with_token(expired=False, last_fetched_at=recent)
+    mock_get.side_effect = _all_empty_side_effect
+
+    fetch_fitbit_today_for_user(user, bypass_cooldown=True)
+
+    assert mock_get.called
+
+
+@patch("core.views.fitbit_sync.get_valid_access_token", return_value="access")
+@patch("core.views.fitbit_sync.requests.get")
+def test_last_fetched_at_stamped_on_token_before_api_calls(mock_get, _):
+    """last_fetched_at is written to FitbitUserToken before any API request fires."""
+    user, token = make_user_with_token(expired=False, last_fetched_at=None)
+    assert token.last_fetched_at is None
+
+    mock_get.side_effect = _all_empty_side_effect
+    fetch_fitbit_today_for_user(user)
+
+    token.reload()
+    assert token.last_fetched_at is not None
+
+
+@patch("core.views.fitbit_sync.get_valid_access_token", return_value="access")
+@patch("core.views.fitbit_sync.requests.get")
+def test_last_fetched_at_stamped_even_when_api_returns_429(mock_get, _):
+    """last_fetched_at is stamped before the first call, so 429 errors still reset the window."""
+    user, token = make_user_with_token(expired=False, last_fetched_at=None)
+
+    error_resp = Mock()
+    error_resp.status_code = 429
+    error_resp.text = '{"error":{"code":429,"status":"RESOURCE_EXHAUSTED"}}'
+    error_resp.json.return_value = {}
+    mock_get.return_value = error_resp
+
+    fetch_fitbit_today_for_user(user)
+
+    token.reload()
+    assert token.last_fetched_at is not None
+
+
+@patch("core.views.fitbit_sync.get_valid_access_token", return_value="access")
+@patch("core.views.fitbit_sync.requests.get")
+def test_cooldown_handles_naive_last_fetched_at(mock_get, _):
+    """A naive (timezone-unaware) last_fetched_at stored in MongoDB is handled correctly."""
+    from datetime import timezone as stdlib_tz
+
+    naive_recent = datetime.now(tz=stdlib_tz.utc).replace(tzinfo=None) - timedelta(minutes=5)
+    user, _ = make_user_with_token(expired=False, last_fetched_at=naive_recent)
+
+    with patch("core.views.fitbit_sync.requests.get") as mock_get_inner:
+        result = fetch_fitbit_today_for_user(user)
+
+    assert result == 0
+    mock_get_inner.assert_not_called()

--- a/backend/tests/fitbit_views/test_fitbit_views.py
+++ b/backend/tests/fitbit_views/test_fitbit_views.py
@@ -14,6 +14,12 @@ Also covers helper functions:
 - _default_thresholds
 - _merge_thresholds
 - avg_excluding_zero
+
+Cooldown guard
+--------------
+fitbit_summary calls fetch_fitbit_today_for_user without bypass_cooldown so
+the 15-minute rate-limit guard is applied on every page load. The Celery task
+(fetch_fitbit_data_async) is the only caller that sets bypass_cooldown=True.
 """
 
 import json
@@ -470,6 +476,16 @@ def test_fitbit_summary_internal_error_branch(mock_fetch):
     resp = client.get(f"/api/fitbit/summary/{patient.id}/", HTTP_AUTHORIZATION="Bearer test")
     assert resp.status_code == 500
     assert resp.json()["error"] == "Internal Server Error"
+
+
+@patch("core.views.fitbit_view.fetch_fitbit_today_for_user")
+def test_fitbit_summary_does_not_bypass_cooldown(mock_fetch):
+    """fitbit_summary must not pass bypass_cooldown=True — the cooldown guard must apply."""
+    _, _, _, patient = create_patient_graph()
+    client.get(f"/api/fitbit/summary/{patient.id}/?days=7", HTTP_AUTHORIZATION="Bearer test")
+    mock_fetch.assert_called_once()
+    _, kwargs = mock_fetch.call_args
+    assert kwargs.get("bypass_cooldown", False) is False
 
 
 # ---------------------------------------------------------------------------

--- a/docs/16-FITBIT_INTEGRATION.md
+++ b/docs/16-FITBIT_INTEGRATION.md
@@ -1,0 +1,418 @@
+# Fitbit Integration — Technical Documentation
+
+## Overview
+
+The Fitbit integration allows patients to connect their Fitbit device to the platform. Once connected, activity, sleep, heart rate, and physiological data are fetched from the Fitbit Web API and stored in MongoDB. Therapists and the patient dashboard consume this data via REST endpoints.
+
+---
+
+## Architecture
+
+```
+Patient device (Fitbit)
+        │
+        ▼
+Fitbit Web API (api.fitbit.com)
+        │
+   ┌────┴────────────────────────────────┐
+   │  Two fetch paths                    │
+   │                                     │
+   │  1. On-demand (view layer)          │
+   │     fitbit_summary view             │
+   │     → fetch_fitbit_today_for_user() │
+   │       (15-min cooldown guard)       │
+   │                                     │
+   │  2. Scheduled (Celery)              │
+   │     run_fetch_fitbit_data task      │
+   │     → fetch_fitbit_data command     │
+   │       (30-day backfill, no cooldown)│
+   └────────────────┬────────────────────┘
+                    ▼
+              MongoDB (FitbitData)
+                    │
+        ┌───────────┴────────────┐
+        │ REST endpoints          │
+        │  /api/fitbit/summary/   │
+        │  /api/fitbit/health-data│
+        │  /api/patients/health-  │
+        │    combined-history/    │
+        └────────────────────────┘
+```
+
+---
+
+## OAuth 2.0 Connection Flow
+
+Fitbit uses the **Authorization Code** OAuth 2.0 flow.
+
+### Required environment variables
+
+| Variable | Description |
+|---|---|
+| `FITBIT_CLIENT_ID` | OAuth app client ID from dev.fitbit.com |
+| `FITBIT_CLIENT_SECRET` | OAuth app client secret |
+| `FITBIT_REDIRECT_URI` | Must match exactly what is registered in the Fitbit app (e.g. `https://reha-advisor.ch/api/fitbit/callback/`) |
+
+### Step-by-step
+
+1. **Authorisation request** — The frontend redirects the patient to Fitbit's authorisation page. The `state` parameter carries the MongoDB `User._id` so the callback can identify the patient.
+
+2. **Callback** — Fitbit redirects to `GET /api/fitbit/callback/?code=<auth_code>&state=<user_id>`.
+
+3. **Token exchange** — The backend POSTs the `code` to `https://api.fitbit.com/oauth2/token` using HTTP Basic Auth (`client_id:client_secret`). On success, the access token, refresh token, expiry, and Fitbit user ID are upserted into `FitbitUserToken`.
+
+4. **Redirect to frontend** — The callback always redirects to `{FRONTEND_URL}/patient?fitbit_status=<status>` where `status` is one of:
+
+   | Value | Meaning |
+   |---|---|
+   | `connected` | Token saved successfully |
+   | `error` | Token exchange failed |
+   | `missing_code` | Fitbit did not return an authorisation code |
+   | `unauthorized` | `state` parameter missing |
+   | `invalid_user` | `state` did not resolve to a known user |
+
+**Source:** [core/views/fitbit_view.py — `fitbit_callback`](../backend/core/views/fitbit_view.py)
+
+---
+
+## Data Models
+
+### `FitbitUserToken` (one per user)
+
+```
+user            ReferenceField(User)  — unique
+access_token    str (max 2048)
+refresh_token   str (max 2048)
+expires_at      datetime (UTC)
+fitbit_user_id  str
+last_fetched_at datetime (UTC)        — cooldown stamp; None = never fetched
+```
+
+**Source:** [core/models.py:57](../backend/core/models.py#L57)
+
+### `FitbitData` (one document per user per day)
+
+Unique on `(user, date)`. All numeric fields are `None` when not yet received.
+
+| Field | Type | Source |
+|---|---|---|
+| `steps` | int | `activities/steps` |
+| `floors` | int | `activities/floors` |
+| `distance` | float (km) | `activities/distance` |
+| `calories` | float | `activities/calories` |
+| `active_minutes` | int | AZM if available, else `minutesVeryActive + minutesFairlyActive` |
+| `inactivity_minutes` | int | `1440 − (active_minutes + sleep_minutes)` |
+| `resting_heart_rate` | int | `activities/heart` summary |
+| `max_heart_rate` | int | Derived from intraday 1-sec HR dataset |
+| `heart_rate_zones` | list[HeartRateZone] | `activities/heart` summary |
+| `wear_time_minutes` | int \| None | Distinct minutes with HR > 0 in intraday dataset |
+| `sleep` | SleepData | `sleep/date` endpoint |
+| `breathing_rate` | dict | `br/date` endpoint |
+| `hrv` | dict | `hrv/date` endpoint |
+| `exercise` | dynamic | `activities/list.json` |
+| `weight_kg` | float | Merged from `PatientVitals` |
+| `bp_sys` / `bp_dia` | int | Merged from `PatientVitals` |
+
+#### Embedded: `SleepData`
+
+| Field | Notes |
+|---|---|
+| `sleep_duration` | Total time in bed in **milliseconds** (includes awake periods) |
+| `minutes_asleep` | Actual sleep in minutes — matches Fitbit app display |
+| `sleep_start` / `sleep_end` | ISO datetime strings |
+| `awakenings` | Count of wake-ups |
+
+**Source:** [core/models.py:114](../backend/core/models.py#L114)
+
+---
+
+## Token Refresh
+
+`get_valid_access_token(user)` in [fitbit_sync.py](../backend/core/views/fitbit_sync.py) is called before every API request:
+
+1. Load `FitbitUserToken` for the user.
+2. If `expires_at ≤ now`, POST to `https://api.fitbit.com/oauth2/token` with `grant_type=refresh_token`.
+3. On success, update `access_token`, `refresh_token`, `expires_at` in MongoDB.
+4. On failure, raise — the caller logs the error and skips the user.
+
+---
+
+## Data Fetch: Two Paths
+
+### 1. On-demand fetch (per page load)
+
+**Entry point:** `fetch_fitbit_today_for_user(user, bypass_cooldown=False)`
+**Source:** [core/views/fitbit_sync.py](../backend/core/views/fitbit_sync.py)
+
+Called from `fitbit_summary` on every request. Fetches **today only** (single-day range). Makes ~13 Fitbit API calls per invocation:
+
+| Endpoint | Data |
+|---|---|
+| `activities/steps/date` | Steps |
+| `activities/floors/date` | Floors |
+| `activities/distance/date` | Distance |
+| `activities/calories/date` | Calories |
+| `activities/minutesVeryActive/date` | Very active minutes |
+| `activities/minutesFairlyActive/date` | Fairly active minutes |
+| `activities/minutesLightlyActive/date` | Lightly active minutes |
+| `activities/minutesSedentary/date` | Sedentary minutes |
+| `activities/heart/date` | Resting HR + HR zones |
+| `activities/active-zone-minutes/date` | Active Zone Minutes |
+| `br/date` | Breathing rate |
+| `hrv/date` | HRV |
+| `activities/heart/date/1d/1sec` | Intraday HR (wear time + max HR) |
+| `sleep/date` | Sleep |
+| `activities/list.json` | Exercise sessions |
+
+Results are upserted into `FitbitData` for today. Returns `1` if a row was written, `0` if no data was returned by Fitbit.
+
+#### Rate-limit cooldown guard
+
+The Fitbit API enforces ~150 requests per user per hour. With ~13 calls per fetch, a page refresh every few minutes quickly exhausts the quota (HTTP 429 `RESOURCE_EXHAUSTED`).
+
+**Guard behaviour:**
+
+- Before any API call, `FitbitUserToken.last_fetched_at` is checked.
+- If `last_fetched_at` is within **15 minutes** of now, the function returns immediately with `0` — no API calls are made.
+- `last_fetched_at` is stamped (and saved to MongoDB) **before** the first API call, so even a run that hits 429 errors resets the window.
+- The cooldown constant is `FETCH_COOLDOWN_MINUTES = 15` at the top of `fitbit_sync.py`.
+
+**Bypassing the cooldown:**
+
+Pass `bypass_cooldown=True` to skip the check entirely. The Celery task `fetch_fitbit_data_async` always does this because it is scheduled and should not be blocked by the on-demand stamp.
+
+```python
+# View (applies cooldown)
+fetch_fitbit_today_for_user(user)
+
+# Celery task (bypasses cooldown)
+fetch_fitbit_today_for_user(user, bypass_cooldown=True)
+```
+
+> **Timezone note:** MongoDB stores datetimes in UTC. When retrieved, MongoEngine may return a naive datetime. The guard converts naive timestamps with `.replace(tzinfo=datetime.timezone.utc)` — not `make_aware()` — to avoid local-timezone offsets silently disabling the cooldown in non-UTC deployments.
+
+---
+
+### 2. Scheduled backfill (Celery)
+
+**Entry points:**
+
+| Task name | What it does |
+|---|---|
+| `core.tasks.run_fetch_fitbit_data` | Runs the `fetch_fitbit_data` management command for all connected users; scheduled via Celery Beat |
+| `core.tasks.fetch_fitbit_data_async` | Fetches today for a single user; called ad-hoc (e.g. from auth flow) |
+
+**Management command:** `python manage.py fetch_fitbit_data`
+**Source:** [core/management/commands/fetch_fitbit_data.py](../backend/core/management/commands/fetch_fitbit_data.py)
+
+Iterates all `FitbitUserToken` documents and fetches the **last 30 days** for each user. Per-day intraday HR is fetched individually (30 separate requests per user) to derive `max_heart_rate` and `wear_time_minutes`. The command does **not** apply the 15-minute cooldown — it is designed for bulk backfill runs.
+
+---
+
+## REST Endpoints
+
+All endpoints are prefixed with `/api/` and require an `Authorization: Bearer <jwt>` header.
+
+### `GET /api/fitbit/status/<patient_id>/`
+
+Returns whether the patient has a connected Fitbit and the date of the last stored data point.
+
+**Response:**
+```json
+{
+  "connected": true,
+  "has_data": true,
+  "last_data": "2026-05-04T08:00:00"
+}
+```
+
+`patient_id` may be either a `Patient._id` or a `User._id`.
+
+---
+
+### `GET /api/fitbit/callback/`
+
+OAuth callback. Not called by clients directly — Fitbit redirects here after user authorisation. Always responds with a 302 redirect to the frontend.
+
+---
+
+### `GET /api/fitbit/summary/<patient_id>/`
+
+Main dashboard endpoint. Triggers an on-demand today-fetch (subject to the 15-minute cooldown), then returns a summary of the requested period.
+
+**Query parameters:**
+
+| Parameter | Default | Range | Description |
+|---|---|---|---|
+| `days` | `7` | 1–31 | Number of days to include in the period |
+
+**Response shape:**
+```json
+{
+  "connected": true,
+  "thresholds": { "steps_goal": 10000, "active_minutes_green": 30, ... },
+  "last_sync": "2026-05-04T08:00:00",
+  "today": {
+    "steps": 4200,
+    "active_minutes": 22,
+    "sleep_minutes": 420,
+    "resting_heart_rate": 62,
+    "bp_sys": null,
+    "bp_dia": null,
+    "weight_kg": null
+  },
+  "period": {
+    "days": 7,
+    "totals": { "steps": 29000, "active_minutes": 140, ... },
+    "averages": { "steps": 4143, "active_minutes": 20, ... },
+    "daily": [
+      { "date": "2026-04-28T...", "steps": 3100, "active_minutes": 18, "sleep_minutes": 410, ... }
+    ]
+  }
+}
+```
+
+Blood pressure and weight in `today` and `daily` are merged from `PatientVitals` when not present in `FitbitData`.
+
+**Thresholds** are read from `patient.thresholds` (if set) and merged with backend defaults:
+
+| Key | Default |
+|---|---|
+| `steps_goal` | 10 000 |
+| `active_minutes_green` | 30 min |
+| `active_minutes_yellow` | 20 min |
+| `sleep_green_min` | 420 min (7 h) |
+| `sleep_yellow_min` | 360 min (6 h) |
+| `bp_sys_green_max` | 129 mmHg |
+| `bp_sys_yellow_max` | 139 mmHg |
+| `bp_dia_green_max` | 84 mmHg |
+| `bp_dia_yellow_max` | 89 mmHg |
+
+---
+
+### `GET /api/fitbit/health-data/<patient_id>/`
+
+Detailed day-by-day export including sleep, HR zones, and exercise sessions. No live Fitbit fetch — reads from MongoDB only.
+
+**Query parameters:**
+
+| Parameter | Default | Description |
+|---|---|---|
+| `from` | 30 days ago | Start date `YYYY-MM-DD` |
+| `to` | today | End date `YYYY-MM-DD` |
+
+**Response shape:**
+```json
+{
+  "data": [
+    {
+      "date": "04.05.2026",
+      "steps": 6200,
+      "resting_heart_rate": 60,
+      "floors": 8,
+      "distance": 4.8,
+      "calories": 2100,
+      "active_minutes": 35,
+      "breathing_rate": { "breathingRate": 14.2 },
+      "hrv": { "dailyRmssd": 38.5 },
+      "sleep": {
+        "sleep_minutes": 480,
+        "sleep_hours": 8.0,
+        "minutes_asleep": 435,
+        "sleep_start": "2026-05-03T23:00:00",
+        "sleep_end": "2026-05-04T07:00:00",
+        "awakenings": 2
+      },
+      "heart_rate_zones": [
+        { "name": "Fat Burn", "minutes": 22, "min": 97, "max": 135, "range_str": "97-135 bpm", "caloriesOut": 180 }
+      ],
+      "exercise": {
+        "sessions": [
+          { "name": "Walk", "duration_min": 35, "duration_hr": 0.58, "calories": 210, "averageHeartRate": 112, "maxHeartRate": 140 }
+        ]
+      },
+      "weight_kg": 72.5,
+      "bp_sys": 122,
+      "bp_dia": 78
+    }
+  ]
+}
+```
+
+Dates are returned in European format (`DD.MM.YYYY`).  
+`sleep_minutes` reflects time **in bed** (from `sleep_duration`); `minutes_asleep` reflects actual sleep time (matches the Fitbit app).
+
+---
+
+### `POST /api/fitbit/manual_steps/<patient_id>/`
+
+Allows a therapist to manually record a step count for a given date (for patients without a device).
+
+**Request body:**
+```json
+{ "date": "2026-05-04", "steps": 3500 }
+```
+
+**Response:**
+```json
+{ "success": true, "steps": 3500, "date": "2026-05-04" }
+```
+
+Upserts into `FitbitData(user, date)`. Does not touch any other field.
+
+---
+
+### `GET /api/patients/health-combined-history/<patient_id>/`
+
+Returns Fitbit data, questionnaire responses, and intervention adherence in a single payload. Used by the researcher view and export tools.
+
+**Query parameters:** `from`, `to` (both `YYYY-MM-DD`, default: last 30 days)
+
+`PatientVitals` entries are merged into `FitbitData` documents (and saved back to MongoDB) so the combined response has a unified per-day object.
+
+---
+
+## Error Handling
+
+| Scenario | Behaviour |
+|---|---|
+| No `FitbitUserToken` for user | `fetch_fitbit_today_for_user` returns `0`; view still renders with `connected: false` |
+| Token refresh fails | Exception raised; logged at ERROR; fetch is aborted for that user |
+| Individual Fitbit endpoint returns non-200 | Warning logged; that field is left `None`; other fields still fetched |
+| Fitbit returns 429 | Warning logged per field; `last_fetched_at` already stamped → cooldown applies for the next 15 min |
+| `fitbit_summary` raises an unhandled exception | Returns `{"error": "Internal Server Error"}` with HTTP 500 |
+
+---
+
+## Fitbit API Rate Limits
+
+Fitbit enforces **150 API calls per user per hour** (as of the Personal tier).
+
+Each call to `fetch_fitbit_today_for_user` makes ~13–15 API calls. The 15-minute cooldown limits on-demand fetches to at most **4 per hour (~60 calls)**, well within the quota. The scheduled backfill command runs outside the cooldown and is invoked at most once per hour by Celery Beat.
+
+If a user's quota is exhausted (HTTP 429), all subsequent fetches within the cooldown window are blocked automatically. The next permitted fetch attempt is ~15 minutes after the 429-triggering run.
+
+---
+
+## Adding a New Fitbit Data Field
+
+1. **Add the field** to `FitbitData` in [core/models.py](../backend/core/models.py).
+2. **Fetch the data** in `fetch_fitbit_today_for_user` ([fitbit_sync.py](../backend/core/views/fitbit_sync.py)) and in the management command ([fetch_fitbit_data.py](../backend/core/management/commands/fetch_fitbit_data.py)).
+3. **Expose it** in whichever endpoints need it (`fitbit_summary`, `get_fitbit_health_data`, `health_combined_history`).
+4. **Add tests** in [tests/fitbit_sync/test_fitbit_sync.py](../backend/tests/fitbit_sync/test_fitbit_sync.py) and [tests/fitbit_views/test_fitbit_views.py](../backend/tests/fitbit_views/test_fitbit_views.py).
+
+MongoDB is schema-less, so no migration is needed — new fields are `None` in existing documents until the next sync.
+
+---
+
+## Related Files
+
+| File | Purpose |
+|---|---|
+| [core/views/fitbit_sync.py](../backend/core/views/fitbit_sync.py) | `fetch_fitbit_today_for_user`, token refresh, cooldown guard |
+| [core/views/fitbit_view.py](../backend/core/views/fitbit_view.py) | All Fitbit REST endpoints |
+| [core/management/commands/fetch_fitbit_data.py](../backend/core/management/commands/fetch_fitbit_data.py) | 30-day bulk backfill command |
+| [core/tasks.py](../backend/core/tasks.py) | Celery tasks wrapping the above |
+| [core/models.py](../backend/core/models.py) | `FitbitUserToken`, `FitbitData`, embedded documents |
+| [tests/fitbit_sync/test_fitbit_sync.py](../backend/tests/fitbit_sync/test_fitbit_sync.py) | Unit tests for sync service and cooldown |
+| [tests/fitbit_views/test_fitbit_views.py](../backend/tests/fitbit_views/test_fitbit_views.py) | Integration tests for all Fitbit endpoints |

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -28,6 +28,7 @@ Complete technical documentation and guides for RehaAdvisor developers and users
 | [12-CONTRIBUTING.md](./12-CONTRIBUTING.md) | Code contribution guidelines | Contributors | 11 KB |
 | [CONTRIBUTING_QUICKSTART.md](./CONTRIBUTING_QUICKSTART.md) | First contribution path and review expectations | New Contributors | Quickstart |
 | [15-STUDY_INTEGRATION.md](./15-STUDY_INTEGRATION.md) | REDCap connection, patient import, consent gate, wearables sync | Study Coordinators, DevOps | — |
+| [16-FITBIT_INTEGRATION.md](./16-FITBIT_INTEGRATION.md) | Fitbit OAuth flow, data models, sync paths, API endpoints, rate-limit guard | Backend Developers, DevOps | — |
 | [13-CODE_STANDARDS.md](./13-CODE_STANDARDS.md) | Code style and best practices | Developers | 15 KB |
 | [14-CI_ENVIRONMENT_CONTRACT.md](./14-CI_ENVIRONMENT_CONTRACT.md) | CI test environment and security contract | DevOps, Backend Developers | 3 KB |
 


### PR DESCRIPTION
<h2 style="color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(37, 37, 38); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Problem</h2><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(37, 37, 38); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Every request to <code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">GET /api/fitbit/summary/&lt;patient_id&gt;/</code> called <code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">fetch_fitbit_today_for_user()</code> synchronously, firing <strong>~13 Fitbit API requests per page load per user</strong>. The Fitbit API enforces a 150-request/hour quota, so a few quick page refreshes exhausted it entirely and produced <code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">429 RESOURCE_EXHAUSTED</code> errors for the remainder of the hour — silently leaving fields like <code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">minutesFairlyActive</code> blank in the UI.</p><h2 style="color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(37, 37, 38); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Solution</h2><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(37, 37, 38); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">A <strong>15-minute cooldown guard</strong> on <code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">fetch_fitbit_today_for_user</code>. On-demand fetches (triggered by page loads) are skipped if the token's <code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">last_fetched_at</code> stamp is within the window. Scheduled Celery syncs bypass the guard and always run.</p><h3 style="color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(37, 37, 38); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Changes</h3><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(37, 37, 38); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><strong><code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">backend/core/models.py</code></strong></p><ul style="padding-inline-start: 2em; color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(37, 37, 38); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li>Added<span> </span><code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">last_fetched_at = DateTimeField()</code><span> </span>to<span> </span><code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">FitbitUserToken</code><span> </span>— records when the last API fetch was attempted for a user.</li></ul><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(37, 37, 38); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><strong><code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">backend/core/views/fitbit_sync.py</code></strong></p><ul style="padding-inline-start: 2em; color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(37, 37, 38); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li>Added<span> </span><code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">FETCH_COOLDOWN_MINUTES = 15</code><span> </span>constant.</li><li>Added<span> </span><code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">bypass_cooldown: bool = False</code><span> </span>parameter to<span> </span><code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">fetch_fitbit_today_for_user</code>.</li><li>Cooldown check: if<span> </span><code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">last_fetched_at</code><span> </span>is within the window, return<span> </span><code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">0</code><span> </span>immediately — no API calls made.</li><li><code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">last_fetched_at</code><span> </span>is stamped<span> </span><strong>before</strong><span> </span>the first API call, so even a run that hits 429s resets the window and prevents a retry storm.</li><li>Naive datetimes from MongoDB are treated as UTC via<span> </span><code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">.replace(tzinfo=datetime.timezone.utc)</code><span> </span>rather than<span> </span><code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">make_aware()</code><span> </span>— the latter uses the local timezone setting (e.g. UTC+2), which would silently disable the cooldown in non-UTC deployments.</li></ul><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(37, 37, 38); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><strong><code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">backend/core/tasks.py</code></strong></p><ul style="padding-inline-start: 2em; color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(37, 37, 38); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li><code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">fetch_fitbit_data_async</code><span> </span>now passes<span> </span><code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">bypass_cooldown=True</code><span> </span>so the scheduled Celery task always runs regardless of the cooldown stamp.</li></ul><h3 style="color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(37, 37, 38); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Rate-limit math</h3>
  | Calls/hour
-- | --
Before (no guard) | Unbounded — exhausted in ~12 refreshes
After (15-min cooldown) | ≤ 4 on-demand fetches × 13 calls = ~52 calls/hour
Fitbit quota | 150 calls/hour

<h2 style="color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(37, 37, 38); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Tests</h2><ul style="padding-inline-start: 2em; color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(37, 37, 38); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li><strong>7 new tests</strong><span> </span>in<span> </span><code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">test_fitbit_sync.py</code><span> </span>covering all cooldown branches: skips within the window, proceeds when stale or<span> </span><code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">None</code>,<span> </span><code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">bypass_cooldown=True</code><span> </span>always hits the API, stamp is written before API calls, 429 errors still reset the window, naive UTC datetimes handled correctly.</li><li><strong>1 new test</strong><span> </span>in<span> </span><code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">test_fitbit_views.py</code><span> </span>asserting<span> </span><code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">fitbit_summary</code><span> </span>does<span> </span><strong>not</strong><span> </span>pass<span> </span><code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">bypass_cooldown=True</code><span> </span>(the guard must apply on page load).</li><li><strong>Updated</strong><span> </span><code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">test_redcap_router_tasks.py</code><span> </span>to expect<span> </span><code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">bypass_cooldown=True</code><span> </span>in the Celery task call.</li><li>All<span> </span><strong>58 tests</strong><span> </span>pass.</li></ul><h2 style="color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(37, 37, 38); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Documentation</h2><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(37, 37, 38); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Added <code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">docs/16-FITBIT_INTEGRATION.md</code> — full technical reference covering the OAuth flow, data models, both fetch paths, all REST endpoints with request/response shapes, error handling, rate-limit behaviour, and a guide for adding new data fields.</p>