### PR TITLE
fix(Profile): enable saving specialization modifications

### DIFF
--- a/frontend/src/__tests__/components/UserProfile/EditProfileSheet.test.tsx
+++ b/frontend/src/__tests__/components/UserProfile/EditProfileSheet.test.tsx
@@ -19,6 +19,7 @@ jest.mock('../../../config/config.json', () => ({
       fields: [
         { be_name: 'email', label: 'Email', type: 'email', options: [] },
         { be_name: 'phone', label: 'Phone', type: 'text', options: [] },
+        { be_name: 'specialisation', label: 'Specialization', type: 'multi-select', options: [] },
       ],
     },
   ],
@@ -255,6 +256,26 @@ describe('EditTherapistInfo', () => {
 
     await waitFor(() => {
       expect(screen.getByText('Server error')).toBeInTheDocument();
+    });
+  });
+
+  it('calls updateProfile with specializations key (not specialisation) when specialisation field changes', async () => {
+    const userWithSpec = { ...baseUser, specializations: ['Cardiology'] };
+    setup(userWithSpec);
+
+    // The mock react-select renders a <select> with aria-label matching placeholder
+    const select = screen.getByRole('combobox', { name: 'Select...' });
+    fireEvent.change(select, { target: { value: 'Cardiology' } });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save Changes' }));
+
+    await waitFor(() => {
+      expect(mockStore.updateProfile).toHaveBeenCalledWith(
+        expect.objectContaining({ specializations: ['Cardiology'] })
+      );
+      expect(mockStore.updateProfile).toHaveBeenCalledWith(
+        expect.not.objectContaining({ specialisation: expect.anything() })
+      );
     });
   });
 });

--- a/frontend/src/components/UserProfile/EditProfileSheet.tsx
+++ b/frontend/src/components/UserProfile/EditProfileSheet.tsx
@@ -111,6 +111,12 @@ const EditProfileSheet: React.FC<Props> = observer(({ show, userData, onCancel }
     return Array.isArray(field.options) ? field.options : [];
   };
 
+  // Map config be_name values to the actual backend field keys
+  const resolveDataKey = (be_name: string): string => {
+    if (be_name === 'specialisation') return 'specializations';
+    return be_name;
+  };
+
   const validateProfile = (): boolean => {
     if (formData.email && !isValidEmail(formData.email)) {
       setError(t('Invalid email format.'));
@@ -225,12 +231,12 @@ const EditProfileSheet: React.FC<Props> = observer(({ show, userData, onCancel }
                         value: opt,
                         label: t(opt),
                       }))}
-                      value={(Array.isArray(formData[field.be_name])
-                        ? formData[field.be_name]
+                      value={(Array.isArray(formData[resolveDataKey(field.be_name)])
+                        ? formData[resolveDataKey(field.be_name)]
                         : []
                       ).map((val: string) => ({ value: val, label: t(val) }))}
                       onChange={(selected) =>
-                        handleMultiSelectChange(selected as any, field.be_name)
+                        handleMultiSelectChange(selected as any, resolveDataKey(field.be_name))
                       }
                       placeholder={t('Select...')}
                     />


### PR DESCRIPTION
# Description

Fixes a bug where changes to the specialization field in the therapist profile edit sheet were not being saved. The config uses specialisation (British spelling) but the backend/state key is specializations. Added a resolveDataKey mapping so the multi-select correctly reads from and writes to the right field.

## Related Issue
https://github.com/ARTORG-GERONTECHNOLOGY/Bearny-RehaAdvisor/issues/208

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Tests

1. Log in as a therapist
2. Go to Profile → Edit Info
3. Change the Specialization field
4. Save, changes should now persist correctly

## Checklist

- [x] I have read the [contributing guidelines](/docs/12-CONTRIBUTING.md).
- [x] I have read the [code of conduct](/CODE_OF_CONDUCT.md).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
