### PR TITLE
Fix #207 — Therapist password change always rejected with 400

### DIFF
--- a/backend/core/views/user_views.py
+++ b/backend/core/views/user_views.py
@@ -12,13 +12,8 @@ GET    /api/users/<user_id>/profile/
     Patient response: all User + Patient fields except the excluded set.
 
 PUT    /api/users/<user_id>/profile/
-    Update whitelisted profile fields.  Two modes:
-
-    1. Password change — send ``oldPassword``/``newPassword`` (camelCase) or
-       ``old_password``/``new_password`` (snake_case).  Old password is verified
-       before any change is saved.
-
-    2. Field update — send any subset of the allowed fields below.  Forbidden
+    Update whitelisted profile fields.  Password changes are not accepted here;
+    use the dedicated ``change-password`` endpoint instead.  Forbidden
        fields (``role``, ``pwdhash``, ``createdAt``, etc.) are silently stripped
        (overposting protection).  Empty string / null values are skipped so they
        never erase existing data.
@@ -43,8 +38,9 @@ DELETE /api/users/<user_id>/profile/
     hard-deleted; audit trail (rehabilitation plans, logs) is preserved.
 
 PUT    /api/users/<user_id>/change-password/
-    Intentionally returns HTTP 400 when password fields are supplied — callers
-    should use the profile PUT endpoint instead.  Rate-limited (5 per 5 min).
+    Self-service password change.  Requires ``old_password`` and ``new_password``
+    in the request body.  Rate-limited (5 attempts per 5 min).  New password must
+    be 8+ chars with upper, lower, digit, and special character.
 
 PUT    /api/patients/<patient_id>/reset-password/
     Therapist-initiated password reset for a patient.  No old password needed.
@@ -188,18 +184,6 @@ def change_password(request, therapist_id):
 
     old_password = data.get("old_password")
     new_password = data.get("new_password")
-
-    # If client attempts a password update here, block it.
-    if new_password is not None or old_password is not None:
-        if not old_password:
-            return JsonResponse({"error": "Old password required"}, status=400)
-
-        # We intentionally do NOT change passwords here.
-        # Use the dedicated endpoint for rate limiting + strength rules.
-        return JsonResponse(
-            {"error": "Password updates must use the change-password endpoint."},
-            status=400,
-        )
 
     if not old_password or not new_password:
         return JsonResponse({"error": "Missing password fields"}, status=400)

--- a/backend/tests/user_views/test_user_views.py
+++ b/backend/tests/user_views/test_user_views.py
@@ -1020,29 +1020,34 @@ def test_decline_user_get_method_not_allowed():
 # ===========================================================================
 
 
-def test_change_password_with_both_fields_returns_400():
+def test_change_password_success():
     """
-    Sending ``old_password`` + ``new_password`` to the change-password
-    endpoint returns 400 with a message directing callers to the dedicated
-    password-change flow.  This is the current intentional behaviour.
+    Sending correct ``old_password`` + strong ``new_password`` to the
+    change-password endpoint returns 200 with a success message.
+    ``check_password`` and ``make_password`` are mocked for determinism.
     """
     user, _ = create_user_and_therapist()
-    resp = client.put(
-        f"/api/users/{user.id}/change-password/",
-        data=json.dumps({"old_password": "old", "new_password": "New!pass1"}),
-        content_type="application/json",
-        HTTP_AUTHORIZATION="Bearer test",
-    )
-    assert resp.status_code == 400
-    assert (
-        "change-password" in resp.json().get("error", "").lower() or "password" in resp.json().get("error", "").lower()
-    )
+    user.pwdhash = "oldhash"
+    user.save()
+
+    with (
+        mock.patch("core.views.user_views.check_password", return_value=True),
+        mock.patch("core.views.user_views.make_password", return_value="new_hashed"),
+    ):
+        resp = client.put(
+            f"/api/users/{user.id}/change-password/",
+            data=json.dumps({"old_password": "OldPass1!", "new_password": "NewPass1!"}),
+            content_type="application/json",
+            HTTP_AUTHORIZATION="Bearer test",
+        )
+    assert resp.status_code == 200
+    assert "Password changed" in resp.json().get("message", "")
 
 
 def test_change_password_missing_old_returns_400():
     """
     Sending only ``new_password`` (no ``old_password``) returns 400 with
-    'Old password required'.
+    'Missing password fields'.
     """
     user, _ = create_user_and_therapist()
     resp = client.put(
@@ -1052,7 +1057,7 @@ def test_change_password_missing_old_returns_400():
         HTTP_AUTHORIZATION="Bearer test",
     )
     assert resp.status_code == 400
-    assert "Old password required" in resp.json().get("error", "")
+    assert "Missing password fields" in resp.json().get("error", "")
 
 
 def test_change_password_missing_both_returns_400():


### PR DESCRIPTION
## Summary

- The `change_password` view (`PUT /api/users/<id>/change-password/`) contained a dead-code guard block that fired unconditionally on every valid request and returned `400 "Password updates must use the change-password endpoint."` before the real implementation was ever reached. The guard was intended to block password changes on the *profile* endpoint — it was written into the wrong view.
- Removed the misplaced guard. The working implementation already present below it (rate limiting → old-password verification → strength check → save) now executes normally.
- Fixed the stale module docstring that described the endpoint as intentionally returning 400.

## Changes

**`backend/core/views/user_views.py`**
- Removed the 11-line dead-code block that unconditionally short-circuited `change_password` with a 400 response.
- Updated the module docstring to correctly describe `PUT /api/users/<id>/change-password/` as a working self-service password change endpoint.

**`backend/tests/user_views/test_user_views.py`**
- Replaced `test_change_password_with_both_fields_returns_400` (which verified the broken behaviour) with `test_change_password_success` — confirms a valid `old_password` + strong `new_password` returns `200`.
- Updated `test_change_password_missing_old_returns_400` to assert `"Missing password fields"` (the error from the real validation path) instead of `"Old password required"` (the error from the now-removed dead code).

## Test plan

- [x] All 874 tests pass (`docker exec django pytest tests/ -q`)
- [x] `test_change_password_success` confirms the happy path returns 200
- [x] Rate limiting, wrong old password (403), missing fields (400), and method guard (405) tests all pass unchanged
