### PR TITLE
Fix: Update patient ID format validation and test cases to Pxxx-xxxTx (#216)

### DIFF
--- a/frontend/src/__tests__/pages/HealthSlider.fullsync.test.tsx
+++ b/frontend/src/__tests__/pages/HealthSlider.fullsync.test.tsx
@@ -43,8 +43,8 @@ describe('HealthSlider (Full Sync)', () => {
   const originalAlert = window.alert;
 
   // Helper to enter patient ID (since eva2 uses form, not prompt)
-  const enterPatientId = async (patientId = 'P01') => {
-    const input = screen.getByPlaceholderText('P01');
+  const enterPatientId = async (patientId = 'P001-001T1') => {
+    const input = screen.getByPlaceholderText('P001-001T1');
     fireEvent.change(input, { target: { value: patientId } });
     fireEvent.click(screen.getByRole('button', { name: 'Weiter' }));
     await waitFor(() => {
@@ -56,7 +56,7 @@ describe('HealthSlider (Full Sync)', () => {
     jest.restoreAllMocks();
     localStorage.clear();
 
-    window.prompt = jest.fn(() => 'P01') as any;
+    window.prompt = jest.fn(() => 'P001-001T1') as any;
     window.alert = jest.fn() as any;
 
     // Mock URL methods before spying
@@ -117,18 +117,18 @@ describe('HealthSlider (Full Sync)', () => {
     window.alert = originalAlert;
   });
 
-  it('prompts for patient id (Pxx) and stores it', async () => {
+  it('prompts for patient id (Pxxx-xxxTx) and stores it', async () => {
     render(<HealthSlider />);
     await enterPatientId();
 
     // Check patient ID is stored
-    expect(localStorage.getItem('patient_id')).toBe('P01');
+    expect(localStorage.getItem('patient_id')).toBe('P001-001T1');
 
     // Now click mic permission button
     fireEvent.click(screen.getByRole('button', { name: /Übungslauf starten/i }));
 
     await waitFor(() => {
-      expect(screen.getByText(/ID: P01/)).toBeInTheDocument();
+      expect(screen.getByText(/ID: P001-001T1/)).toBeInTheDocument();
     });
   });
 

--- a/frontend/src/pages/eva2.tsx
+++ b/frontend/src/pages/eva2.tsx
@@ -8,7 +8,7 @@
  * State machine (rendered screens in order)
  * -----------------------------------------
  * 1. Patient-ID input   — when no patientId in URL param or localStorage.
- *                         Validates "P\d+" format, persists to localStorage.
+ *                         Validates "P\d+-\d+T\d+" format, persists to localStorage.
  * 2. Mic permission     — requests getUserMedia; shows "Übungslauf starten" button.
  * 3. Practice mode      — one warm-up question (not uploaded to backend).
  * 4. Survey questions   — 29 ICF domain questions with vertical slider + optional audio cue.
@@ -375,8 +375,8 @@ export default function HealthSlider() {
 
   const submitPatientId = () => {
     const v = patientIdInput.trim();
-    if (!/^P\d+$/.test(v)) {
-      setPatientIdError('ID muss mit P beginnen, gefolgt von Ziffern (z.B. P01).');
+    if (!/^P\d+-\d+T\d+$/.test(v)) {
+      setPatientIdError('ID muss dem Format Pxxx-xxxTx entsprechen (z.B. P001-001T1).');
       return;
     }
     localStorage.setItem('patient_id', v);
@@ -809,7 +809,7 @@ export default function HealthSlider() {
         <h1 style={{ ...styles.title, marginTop: 24 }}>Patienten-ID eingeben</h1>
         <div style={{ marginTop: 24, textAlign: 'center', maxWidth: 400, width: '100%' }}>
           <p style={{ fontSize: 16, color: '#444', marginBottom: 16 }}>
-            Bitte geben Sie die Patienten-ID ein (Format: P01, P02...).
+            Bitte geben Sie die Patienten-ID ein (Format: P001-001T1).
           </p>
           <input
             type="text"
@@ -821,7 +821,7 @@ export default function HealthSlider() {
             onKeyDown={(e) => {
               if (e.key === 'Enter') submitPatientId();
             }}
-            placeholder="P01"
+            placeholder="P001-001T1"
             autoFocus
             style={{
               width: '100%',


### PR DESCRIPTION
# Description

- Changed the patient ID validation regex in the ICF questionnaire from P\d+ (e.g. P01) to P\d+-\d+T\d+ (e.g. P001-001T1) to match the new ID scheme
- Updated the input placeholder, description text, and error message in eva2.tsx accordingly
- Updated HealthSlider.fullsync.test.tsx to use the new format in the patient ID entry helper and all related assertions

## Related Issue
[IssueName](IssueLink)

## Type of change

- [x] Other - Id update for a study

## Tests

- [x] Run frontend tests: docker exec react npx jest --testPathPattern="HealthSlider|eva" --no-coverage — all 43 tests pass
- [x]  Open /icf in the browser and verify:

  - [x] Entering an old-format ID (e.g. P01) is rejected with the new error message
  - [x] Entering a new-format ID (e.g. P001-001T1) is accepted and the survey proceeds
  - [x] The footer shows the correct ID throughout the session

## Checklist

- [x] I have read the [contributing guidelines](/docs/12-CONTRIBUTING.md).
- [x] I have read the [code of conduct](/CODE_OF_CONDUCT.md).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation. 
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
