### PR TITLE
218 bug failed to export wearables baseline for 934 8 redcap api returned non 200

### DIFF
--- a/backend/core/services/wearables_redcap_service.py
+++ b/backend/core/services/wearables_redcap_service.py
@@ -9,6 +9,7 @@ from typing import Any, Dict, List, Optional, Tuple
 from core.models import FitbitData, Patient
 from core.services.redcap_service import (
     RedcapError,
+    _parse_invalid_fields,
     _post_redcap,
     export_record_by_pat_id,
     get_token_for_project,
@@ -60,8 +61,8 @@ def _as_utc(dt: datetime) -> datetime:
 
 
 def _fmt_dmy(dt: datetime) -> str:
-    """Format date as DD-MM-YYYY for REDCap date_dmy fields."""
-    return dt.strftime("%d-%m-%Y")
+    """Format date as YYYY-MM-DD — REDCap import always requires Y-M-D regardless of field display format."""
+    return dt.strftime("%Y-%m-%d")
 
 
 def _pick_best_wear_week(
@@ -229,6 +230,31 @@ def _resolve_event_names(
     return ev_baseline, ev_followup
 
 
+def _import_record(token: str, payload: Dict[str, Any], record: Dict[str, Any]) -> None:
+    """
+    POST a wearables record to REDCap.  On 400 with invalid field names (the
+    same error REDCap returns for mismatched instrument field names across
+    projects), strips the offending fields and retries once — mirroring the
+    behaviour of _post_redcap_with_field_fallback used on the read side.
+    Raises RedcapError on final failure.
+    """
+    try:
+        _post_redcap(token, payload)
+        return
+    except RedcapError as e:
+        if e.args[0] != "REDCap API returned non-200.":
+            raise
+        detail_text = e.detail.get("text", "") if isinstance(e.detail, dict) else str(e.detail or "")
+        invalid = _parse_invalid_fields(detail_text)
+        if not invalid:
+            raise
+        trimmed = {k: v for k, v in record.items() if k not in invalid}
+        if not trimmed or trimmed == record:
+            raise
+        logger.info("Retrying wearables import without unsupported fields: %s", sorted(invalid))
+        _post_redcap(token, {**payload, "data": json.dumps([trimmed])})
+
+
 def export_wearables_to_redcap(
     patient: Patient,
     event_baseline: Optional[str] = None,
@@ -311,7 +337,7 @@ def export_wearables_to_redcap(
             "data": json.dumps([record]),
         }
         try:
-            _post_redcap(token, payload)
+            _import_record(token, payload, record)
             results[period] = "ok"
             payloads[period]["status"] = "sent"
             logger.info(
@@ -327,10 +353,11 @@ def export_wearables_to_redcap(
             payloads[period]["status"] = "error"
             payloads[period]["error"] = str(e)
             logger.error(
-                "Failed to export wearables [%s] for %s: %s",
+                "Failed to export wearables [%s] for %s: %s | detail=%s",
                 period,
                 patient.patient_code,
                 e,
+                getattr(e, "detail", None),
             )
 
     if return_payloads:

--- a/backend/tests/wearables_redcap/test_wearables_redcap_service.py
+++ b/backend/tests/wearables_redcap/test_wearables_redcap_service.py
@@ -601,7 +601,9 @@ class TestExportWearablesToRedcap:
                 )
             return '{"count":1}'
 
-        with patch("core.services.wearables_redcap_service.export_record_by_pat_id", return_value=[{"record_id": "42"}]):
+        with patch(
+            "core.services.wearables_redcap_service.export_record_by_pat_id", return_value=[{"record_id": "42"}]
+        ):
             with patch("core.services.wearables_redcap_service._post_redcap", side_effect=_fake_post):
                 results = export_wearables_to_redcap(patient)
 

--- a/backend/tests/wearables_redcap/test_wearables_redcap_service.py
+++ b/backend/tests/wearables_redcap/test_wearables_redcap_service.py
@@ -7,7 +7,7 @@ Unit and integration tests for core/services/wearables_redcap_service.py
 Coverage
 --------
 Pure-function unit tests (no DB):
-  - _fmt_dmy              date formatted as DD-MM-YYYY
+  - _fmt_dmy              date formatted as YYYY-MM-DD (REDCap import format)
   - _format_sleep         COMPASS: integer hours / COPAIN: HH:MM
   - _pick_best_wear_week  picks ISO week with highest total wear_time_minutes
   - _compute_averages     per-field daily averages, correct sleep format
@@ -25,7 +25,7 @@ DB-backed tests (mongomock):
       · raises ValueError when patient has no project
       · raises ValueError when no REDCap record is found
       · writes correct payload to REDCap including record_id, event name,
-        wearables_complete="1", and date_dmy-formatted dates
+        wearables_complete="1", and YYYY-MM-DD formatted dates
       · returns "skipped" for a period with no Fitbit data
       · captures RedcapError and returns "error: ..." string
 """
@@ -126,10 +126,10 @@ def _make_fitbit_day(user, date: datetime, steps=5000, active_min=30, inactive_m
 
 def test_fmt_dmy():
     d = datetime(2024, 3, 5, tzinfo=dt_tz.utc)
-    assert _fmt_dmy(d) == "05-03-2024"
+    assert _fmt_dmy(d) == "2024-03-05"
 
     d2 = datetime(2024, 12, 31, tzinfo=dt_tz.utc)
-    assert _fmt_dmy(d2) == "31-12-2024"
+    assert _fmt_dmy(d2) == "2024-12-31"
 
 
 class TestFormatSleep:
@@ -387,12 +387,10 @@ class TestComputeWearablesSummary:
         day = reha_end + timedelta(days=2)
         _make_fitbit_day(user, day, wear_min=500)
         summary = compute_wearables_summary(patient)
-        # monitoring_start should be DD-MM-YYYY
+        # monitoring_start should be YYYY-MM-DD (REDCap import format)
         start = summary["baseline"]["monitoring_start"]
         assert len(start) == 10
-        assert start[2] == "-" and start[5] == "-"
-        # year in last 4 chars
-        assert start[-4:] == "2024"
+        assert start[:4] == "2024" and start[4] == "-" and start[7] == "-"
 
     def test_monitoring_days_matches_records_in_best_week(self):
         reha_end = datetime(2024, 1, 1, tzinfo=dt_tz.utc)
@@ -480,9 +478,9 @@ class TestExportWearablesToRedcap:
         assert record["wearables_complete"] == "1"  # Unverified
         assert record["redcap_event_name"] == "visit_baseline_arm_1"
 
-        # Date format: DD-MM-YYYY
+        # Date format: YYYY-MM-DD (REDCap import always requires Y-M-D)
         start = record["monitoring_start"]
-        assert start[2] == "-" and start[5] == "-" and start[-4:] == "2024"
+        assert start[:4] == "2024" and start[4] == "-" and start[7] == "-"
 
     def test_return_payloads_includes_sent_and_skipped_details(self, monkeypatch):
         reha_end = datetime(2024, 1, 1, tzinfo=dt_tz.utc)
@@ -580,3 +578,35 @@ class TestExportWearablesToRedcap:
 
         record = json.loads(captured[0]["data"])[0]
         assert "redcap_event_name" not in record
+
+    def test_invalid_field_stripped_and_retried(self, monkeypatch):
+        """
+        When REDCap returns 400 with an 'invalid field' message on the first
+        import attempt, the offending field is stripped and the request retried.
+        The second attempt must succeed and the period result must be "ok".
+        """
+        reha_end = datetime(2024, 1, 1, tzinfo=dt_tz.utc)
+        user, patient = _make_patient(project="COMPASS", reha_end_date=reha_end)
+        _make_fitbit_day(user, reha_end + timedelta(days=2), wear_min=600, steps=4000)
+        monkeypatch.setenv("REDCAP_TOKEN_COMPASS", "tok")
+
+        calls = []
+
+        def _fake_post(token, payload, timeout=30):
+            calls.append(json.loads(payload["data"])[0])
+            if len(calls) == 1:
+                raise RedcapError(
+                    "REDCap API returned non-200.",
+                    detail={"status": 400, "text": "The following values are not valid: 'wearables_complete'"},
+                )
+            return '{"count":1}'
+
+        with patch("core.services.wearables_redcap_service.export_record_by_pat_id", return_value=[{"record_id": "42"}]):
+            with patch("core.services.wearables_redcap_service._post_redcap", side_effect=_fake_post):
+                results = export_wearables_to_redcap(patient)
+
+        assert results["baseline"] == "ok"
+        assert len(calls) == 2
+        assert "wearables_complete" in calls[0]
+        assert "wearables_complete" not in calls[1]
+        assert calls[1]["fitbit_steps"] == "4000"


### PR DESCRIPTION
# Summary

- Root cause 1 (date format): `_fmt_dmy` formatted dates as `DD-MM-YYYY` (e.g. 19-04-2026), but the REDCap import API always requires `YYYY-MM-DD` regardless of the field's display format. This caused every baseline/followup import to be rejected with HTTP 400 and the message "Dates must be imported in Y-M-D format."
- Root cause 2 (silent failure): The wearables import used bare _post_redcap with no field-fallback retry, unlike the record-lookup side which already used `_post_redcap_with_field_fallback`. When REDCap rejected a field name, the error was caught but only the generic `"REDCap API returned non-200."` string was logged — the actual REDCap response text was swallowed.
- Fix: Corrected the date format to `YYYY-MM-DD`. Added `_import_record()` helper that mirrors the existing field-fallback pattern: on a 400 with a parseable invalid-field message, the offending field is stripped from the record and the request is retried once. Also added `detail=` to the error log so future failures expose the raw REDCap response.
The fix was verified live against patient `934-2` (COPAIN), which successfully pushed wearables baseline to REDCap event `t0_at_disch_arm_1`.

## Test plan

- [x]  Run backend tests: `docker exec django pytest tests/wearables_redcap/ -v` — all 49 pass
- [x]  Trigger sync for a COPAIN patient with Fitbit data in the baseline window and confirm `"baseline": "ok"` in the response
- [x]  Confirm the wearables record appears in REDCap at the correct event with dates in `YYYY-MM-DD` format
- [x]  Confirm that if a field is invalid for a given project, the retry log line appears and the import still succeeds with the remaining fields