### PR TITLE
Fix redcap import duplicate patient code

### DIFF
--- a/backend/core/views/redcap_import_views.py
+++ b/backend/core/views/redcap_import_views.py
@@ -10,10 +10,9 @@ from django.contrib.auth.hashers import make_password
 from django.http import JsonResponse
 from django.utils import timezone
 from django.views.decorators.csrf import csrf_exempt
+from mongoengine.errors import NotUniqueError
 from rest_framework.decorators import permission_classes
 from rest_framework.permissions import IsAuthenticated
-
-from mongoengine.errors import NotUniqueError
 
 from core.models import Logs, Patient, Therapist, User  # MongoEngine models (as in your project)
 from utils.config import config

--- a/backend/core/views/redcap_import_views.py
+++ b/backend/core/views/redcap_import_views.py
@@ -13,6 +13,8 @@ from django.views.decorators.csrf import csrf_exempt
 from rest_framework.decorators import permission_classes
 from rest_framework.permissions import IsAuthenticated
 
+from mongoengine.errors import NotUniqueError
+
 from core.models import Logs, Patient, Therapist, User  # MongoEngine models (as in your project)
 from utils.config import config
 
@@ -619,6 +621,25 @@ def import_patient_from_redcap(request):
     # final identifier rule:
     final_identifier = pat_id or record_id or identifier
 
+    # patient_code is globally unique across all projects — check before creating the User
+    # so we don't leave orphaned User documents when the Patient save would fail.
+    existing_by_code = Patient.objects(patient_code=final_identifier).first()
+    if existing_by_code:
+        return JsonResponse(
+            {
+                "ok": False,
+                "error": (
+                    f"A patient with code '{final_identifier}' already exists on this platform"
+                    f" (project: {existing_by_code.project or 'unknown'})."
+                    " The same identifier cannot be imported into multiple projects."
+                ),
+                "patient_code": final_identifier,
+                "existing_project": existing_by_code.project,
+                "patientId": str(existing_by_code.id),
+            },
+            status=409,
+        )
+
     # Create platform user + patient
     now = timezone.now()
     user = None
@@ -732,6 +753,30 @@ def import_patient_from_redcap(request):
         except Exception:
             pass
         return JsonResponse({"ok": False, "error": str(e), "detail": e.detail}, status=502)
+
+    except NotUniqueError as e:
+        logger.warning("import_patient_from_redcap: duplicate patient_code=%s", final_identifier)
+        try:
+            if patient:
+                patient.delete()
+        except Exception:
+            pass
+        try:
+            if user:
+                user.delete()
+        except Exception:
+            pass
+        return JsonResponse(
+            {
+                "ok": False,
+                "error": (
+                    f"Patient with code '{final_identifier}' already exists (duplicate key)."
+                    " The same patient_code cannot appear in two projects."
+                ),
+                "patient_code": final_identifier,
+            },
+            status=409,
+        )
 
     except Exception as e:
         logger.exception("import_patient_from_redcap failed")

--- a/backend/tests/redcap_import_views/test_redcap_import_views.py
+++ b/backend/tests/redcap_import_views/test_redcap_import_views.py
@@ -376,6 +376,44 @@ def test_import_patient_already_imported(mock_get_th):
     assert resp.json()["error"] == "Patient already imported."
 
 
+@patch(
+    "core.views.redcap_import_views.redcap_export_minimal",
+    return_value=[{"record_id": "934-1", "pat_id": "", "ic": "1", "redcap_data_access_group": "inselspital"}],
+)
+@patch("core.views.redcap_import_views.get_redcap_token_for_project", return_value="tok")
+@patch("core.views.redcap_import_views.get_therapist_for_user")
+def test_import_patient_duplicate_patient_code_different_project(mock_get_th, _tok, _export):
+    """
+    Importing a patient whose record_id matches an existing patient_code from a
+    *different* project must return 409, not 500 (DuplicateKeyError).
+    No orphaned User document should be left behind.
+    """
+    _, th = create_therapist(projects=["COPAIN"])
+    mock_get_th.return_value = th
+
+    # 934-1 already exists in COMPASS
+    compass_user = User(username="934-1", role="Patient", createdAt=datetime.now(), isActive=True).save()
+    Patient(userId=compass_user, patient_code="934-1", therapist=th, project="COMPASS").save()
+
+    users_before = User.objects.count()
+
+    resp = client.post(
+        "/api/redcap/import-patient/",
+        data=json.dumps({"project": "COPAIN", "patient_code": "934-1", "password": "Strong1!"}),
+        content_type="application/json",
+        HTTP_AUTHORIZATION="Bearer test",
+    )
+
+    assert resp.status_code == 409
+    body = resp.json()
+    assert body["ok"] is False
+    assert "934-1" in body["error"]
+    assert body["existing_project"] == "COMPASS"
+
+    # No new User should have been created
+    assert User.objects.count() == users_before
+
+
 @patch("core.views.redcap_import_views.get_redcap_token_for_project", return_value=None)
 @patch("core.views.redcap_import_views.get_therapist_for_user")
 def test_import_patient_missing_token(mock_get_th, mock_token):


### PR DESCRIPTION
## Bug

Importing a REDCap patient fails with a 500 error when the patient code already exists in the database under a different project.

**Error (from production logs):**
```
mongoengine.errors.NotUniqueError: Tried to save duplicate unique keys (E11000 duplicate key error collection:
reha_advisor_prod.Patients index: patient_code_1 dup key: { patient_code: '934-1' })
```

`patient_code` has a globally unique MongoDB index, but the pre-import duplicate check in `_get_existing_identifiers_for_project` only queries within the same project — so a code existing in a different project is invisible to it, and the save crashes with a 500.

## Fix

- Added a cross-project pre-check after `final_identifier` is computed: if any `Patient` document already has that `patient_code` (regardless of project), return **409** with a descriptive error message and the conflicting project name.
- Added a `NotUniqueError` catch as a safety net for race conditions, also returning 409 with cleanup.
- The 409 `"error"` field is already propagated to the therapist UI via `importRedcapPatient()` → `extractApiMessage` → `store.redcapError` → `ErrorAlert` in `PatientPopup.tsx`.

## Error shown to therapist

> A patient with code '934-1' already exists on this platform (project: COMPASS). The same identifier cannot be imported into multiple projects.

## Branch

`fix-redcap-import-duplicate-patient-code`

## Files changed

- `backend/core/views/redcap_import_views.py` — pre-check + `NotUniqueError` handler
- `backend/tests/redcap_import_views/test_redcap_import_views.py` — new test `test_import_patient_duplicate_patient_code_different_project`
EOF
)"