### PR TITLE
Fix: Handle REDCap API errors for pat_id filter and implement fallbac…

### DIFF
--- a/backend/core/services/redcap_service.py
+++ b/backend/core/services/redcap_service.py
@@ -164,8 +164,21 @@ def export_record_by_pat_id(project_name: str, pat_id: str) -> List[Dict[str, An
         if rows:
             return rows
     except RedcapError as e:
-        # If REDCap errors here, bubble up (view collects errors per project).
-        raise
+        detail = e.detail if isinstance(e.detail, dict) else {}
+        status = detail.get("status", 0)
+        # 400 → pat_id not a valid field in this project (e.g. COPAIN).
+        # 408 → REDCap timed out evaluating filterLogic on a non-existent field;
+        #        this happens when _post_redcap_with_field_fallback strips pat_id
+        #        from the fields list and retries, but the filterLogic still
+        #        references [pat_id] which doesn't exist in the project schema.
+        # In both cases fall through to the record_id lookup below.
+        if status not in (400, 408):
+            raise
+        logger.info(
+            "pat_id filter returned status %s for project %s — falling back to record_id filter",
+            status,
+            project_name,
+        )
 
     # 2) Fallback: try record_id match (works for identifiers like "1" or "905-1")
     try:

--- a/backend/tests/redcap_service/test_redcap_service.py
+++ b/backend/tests/redcap_service/test_redcap_service.py
@@ -113,6 +113,97 @@ def test_export_record_by_pat_id_invalid_json_and_redcap_error(monkeypatch):
             export_record_by_pat_id("COMPASS", "X1")
 
 
+def test_export_record_by_pat_id_pat_id_400_falls_back_to_record_id(monkeypatch):
+    """
+    When the pat_id filterLogic returns 400 (field doesn't exist in the project),
+    export_record_by_pat_id must fall through to the record_id lookup instead of
+    propagating the error. Reproduces the COPAIN pat_id-missing scenario.
+    """
+    monkeypatch.setattr(svc, "resolve_project", lambda p: p)
+    monkeypatch.setattr(svc, "get_token_for_project", lambda p: "tok")
+    monkeypatch.setattr(
+        svc,
+        "config",
+        {"RedCap_Characteristics": ["pat_id", "record_id"]},
+        raising=False,
+    )
+
+    pat_id_error = RedcapError(
+        "REDCap API returned non-200.",
+        detail={
+            "status": 400,
+            "text": '{"error":"The following values in the parameter \\"fields\\" are not valid: \'pat_id\'"}',
+        },
+    )
+    record_id_row = json.dumps([{"record_id": "934-18"}])
+
+    # First _post_redcap call (pat_id filter, first attempt) → 400
+    # Second call (record_id filter) → success
+    with patch(
+        "core.services.redcap_service._post_redcap",
+        side_effect=[pat_id_error, record_id_row],
+    ) as mock_post:
+        rows = export_record_by_pat_id("COPAIN", "934-18")
+
+    assert rows == [{"record_id": "934-18"}]
+    assert mock_post.call_count == 2
+
+
+def test_export_record_by_pat_id_pat_id_408_falls_back_to_record_id(monkeypatch):
+    """
+    When the pat_id filterLogic causes a 408 timeout (REDCap times out evaluating
+    a filterLogic on a field that doesn't exist — happens after _post_redcap_with_field_fallback
+    strips pat_id from fields but filterLogic still references [pat_id]),
+    export_record_by_pat_id must fall through to the record_id lookup.
+    """
+    monkeypatch.setattr(svc, "resolve_project", lambda p: p)
+    monkeypatch.setattr(svc, "get_token_for_project", lambda p: "tok")
+    monkeypatch.setattr(
+        svc,
+        "config",
+        {"RedCap_Characteristics": ["pat_id", "record_id"]},
+        raising=False,
+    )
+
+    timeout_error = RedcapError(
+        "REDCap API returned non-200.",
+        detail={"status": 408, "text": "<html>408 Request Timeout</html>"},
+    )
+    record_id_row = json.dumps([{"record_id": "934-18"}])
+
+    # First call (pat_id filter, retry after field-strip) → 408
+    # Second call (record_id filter) → success
+    with patch(
+        "core.services.redcap_service._post_redcap",
+        side_effect=[timeout_error, record_id_row],
+    ) as mock_post:
+        rows = export_record_by_pat_id("COPAIN", "934-18")
+
+    assert rows == [{"record_id": "934-18"}]
+    assert mock_post.call_count == 2
+
+
+def test_export_record_by_pat_id_non_400_408_error_still_raises(monkeypatch):
+    """Non-400/408 errors from the pat_id filter must still propagate."""
+    monkeypatch.setattr(svc, "resolve_project", lambda p: p)
+    monkeypatch.setattr(svc, "get_token_for_project", lambda p: "tok")
+    monkeypatch.setattr(
+        svc,
+        "config",
+        {"RedCap_Characteristics": ["record_id"]},
+        raising=False,
+    )
+
+    server_error = RedcapError(
+        "REDCap API returned non-200.",
+        detail={"status": 500, "text": "Internal Server Error"},
+    )
+    with patch("core.services.redcap_service._post_redcap", side_effect=server_error):
+        with pytest.raises(RedcapError) as exc_info:
+            export_record_by_pat_id("COPAIN", "934-18")
+    assert exc_info.value.detail["status"] == 500
+
+
 # ---------------------------------------------------------------------------
 # REDCap connection tests
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Bug

Loading a COPAIN patient's REDCap data fails with a 408 timeout. Two errors occur in sequence for the same request:

**Step 1 — 400 (invalid fields):**
```
RedcapError: {'status': 400, 'text': '{"error":"The following values in the parameter \"fields\" are not valid: \'pat_id\',\'secondary_languages\',\'diabetes\',\'obesity\',\'pepticulcer\',\'cogn_imp\'"}'}
```

**Step 2 — 408 (timeout on retry):**
```
RedcapError: {'status': 408, 'text': '<!DOCTYPE HTML ...><title>408 Request Timeout</title>...'}
  File "core/services/redcap_service.py", line 92, in _post_redcap_with_field_fallback
  File "core/services/redcap_service.py", line 163, in export_record_by_pat_id
    rows = _export_with_filter(f"[pat_id] = '{identifier}'")
```

**Endpoint:**
```
GET /api/redcap/patient/?patient_code=934-18&therapistUserId=...&project=COPAIN
```

## Root cause

COPAIN does not have a `pat_id` field in its REDCap schema. The lookup in `export_record_by_pat_id` uses `filterLogic: "[pat_id] = '934-18'"`.

1. First request → REDCap returns 400 (invalid fields including `pat_id`)
2. `_post_redcap_with_field_fallback` strips `pat_id` from the **fields list** and retries
3. Retry still carries `filterLogic: "[pat_id] = '934-18'"` — REDCap scans all records for a field that doesn't exist → **408 timeout**
4. The existing `record_id` fallback is never reached because the except block unconditionally re-raised

## Fix

In `export_record_by_pat_id` (`core/services/redcap_service.py`), catch 400 and 408 errors from the `[pat_id]` filter and fall through to the `[record_id]` lookup instead of propagating. Non-400/408 errors still raise.

## Branch

`fix-redcap-copain-pat-id-timeout`

## Files changed

- `backend/core/services/redcap_service.py` — fall through to `record_id` filter on 400/408
- `backend/tests/redcap_service/test_redcap_service.py` — three new tests covering the 400 fallback, 408 fallback, and non-400/408 re-raise
EOF