### PR TITLE
236 bug interventions always served in english patient preferred language ignored

### DIFF
--- a/backend/core/views/auth_views.py
+++ b/backend/core/views/auth_views.py
@@ -1050,6 +1050,7 @@ def get_user_info(request, user_id):
         last_name = ""
         specialisation = ""
         function = ""
+        preferred_language = "en"
 
         if user.role == "Therapist":
             therapist = Therapist.objects.filter(userId=user).first()
@@ -1064,6 +1065,7 @@ def get_user_info(request, user_id):
                 first_name = patient.first_name
                 last_name = patient.name
                 function = patient.function
+                preferred_language = getattr(patient, "preferred_language", None) or "en"
 
         else:  # Admin fallback
             first_name = user.username
@@ -1075,6 +1077,7 @@ def get_user_info(request, user_id):
                 "specialisation": specialisation,
                 "function": function,
                 "role": user.role,
+                "preferred_language": preferred_language,
             },
             status=200,
         )

--- a/backend/tests/auth_views/test_get_user_info_view.py
+++ b/backend/tests/auth_views/test_get_user_info_view.py
@@ -13,7 +13,7 @@ Role-based response content
   * Therapist with a linked ``Therapist`` document → 200 with
     ``first_name``, ``last_name``, ``specialisation``, and ``role``.
   * Patient with a linked ``Patient`` document → 200 with
-    ``first_name``, ``last_name``, ``function``, and ``role``.
+    ``first_name``, ``last_name``, ``function``, ``preferred_language``, and ``role``.
   * User with no linked profile document → 200 but ``first_name`` / ``last_name``
     are empty strings (graceful degradation).
 
@@ -22,7 +22,14 @@ Resource not found (404)
 
 Response structure
   * The response always contains the keys ``first_name``, ``last_name``,
-    ``specialisation``, ``function``, and ``role``.
+    ``specialisation``, ``function``, ``role``, and ``preferred_language``.
+
+Bug #236 — preferred_language
+  * The Patient response now includes ``preferred_language`` (e.g. ``"de"``).
+    The frontend stores this in ``authStore.preferredLanguage`` and passes it
+    as the ``lang`` query parameter when fetching interventions, so patients
+    receive interventions in their stored preferred language instead of the
+    browser UI language.
 
 Authentication enforcement note
 --------------------------------
@@ -206,8 +213,89 @@ def test_get_user_info_response_shape_is_consistent(mongo_mock):
     resp = client.get(INFO_URL.format(user_id=str(user.id)))
     data = resp.json()
 
-    for key in ("first_name", "last_name", "specialisation", "function", "role"):
+    for key in ("first_name", "last_name", "specialisation", "function", "role", "preferred_language"):
         assert key in data, f"Expected key '{key}' missing from response"
+
+
+def test_get_user_info_patient_returns_preferred_language(mongo_mock):
+    """
+    Bug #236 — the get-user-info response for a Patient must include
+    ``preferred_language`` so the frontend can fetch interventions in the
+    patient's stored language rather than the browser UI language.
+    """
+    therapist_user = User(
+        username="langtherapist",
+        role="Therapist",
+        email="langtherapist@example.com",
+        createdAt=datetime.now(),
+        isActive=True,
+    ).save()
+    therapist = Therapist(userId=therapist_user, name="Lang", first_name="Dr", specializations=[]).save()
+
+    patient_user = User(
+        username="langpatient",
+        role="Patient",
+        email="langpatient@example.com",
+        createdAt=datetime.now(),
+        isActive=True,
+    ).save()
+
+    Patient(
+        userId=patient_user,
+        patient_code="PAT-LANG",
+        therapist=therapist,
+        name="Patient",
+        first_name="German",
+        reha_end_date=datetime(2030, 1, 1),
+        duration=365,
+        preferred_language="de",
+    ).save()
+
+    resp = client.get(INFO_URL.format(user_id=str(patient_user.id)))
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["preferred_language"] == "de"
+
+
+def test_get_user_info_patient_preferred_language_defaults_to_en(mongo_mock):
+    """
+    When a Patient has no ``preferred_language`` set (or the document is missing),
+    the response must default to ``"en"`` so the frontend always has a usable value.
+    """
+    therapist_user = User(
+        username="defaultlangth",
+        role="Therapist",
+        email="defaultlangth@example.com",
+        createdAt=datetime.now(),
+        isActive=True,
+    ).save()
+    therapist = Therapist(userId=therapist_user, name="Default", first_name="Dr", specializations=[]).save()
+
+    patient_user = User(
+        username="defaultlangpt",
+        role="Patient",
+        email="defaultlangpt@example.com",
+        createdAt=datetime.now(),
+        isActive=True,
+    ).save()
+
+    # Patient saved without preferred_language — model default applies
+    Patient(
+        userId=patient_user,
+        patient_code="PAT-DEFAULT",
+        therapist=therapist,
+        name="Default",
+        first_name="No",
+        reha_end_date=datetime(2030, 1, 1),
+        duration=365,
+    ).save()
+
+    resp = client.get(INFO_URL.format(user_id=str(patient_user.id)))
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["preferred_language"] == "en"
 
 
 # ===========================================================================

--- a/frontend/src/__tests__/PatientDataBootstrap.test.tsx
+++ b/frontend/src/__tests__/PatientDataBootstrap.test.tsx
@@ -17,7 +17,7 @@ jest.mock('@/services/patientDataService', () => ({
 // Auth store mock: object defined inside factory, mutated via jest.requireMock
 jest.mock('@/stores/authStore', () => ({
   __esModule: true,
-  default: { isAuthenticated: false, userType: '', id: '' },
+  default: { isAuthenticated: false, userType: '', id: '', preferredLanguage: '' },
 }));
 
 // mobx-react-lite observer is a passthrough in tests
@@ -31,6 +31,7 @@ const getAuthState = () =>
     isAuthenticated: boolean;
     userType: string;
     id: string;
+    preferredLanguage: string;
   };
 
 beforeEach(() => {
@@ -39,6 +40,7 @@ beforeEach(() => {
   s.isAuthenticated = false;
   s.userType = '';
   s.id = '';
+  s.preferredLanguage = '';
 });
 
 describe('PatientDataBootstrap', () => {
@@ -94,5 +96,32 @@ describe('PatientDataBootstrap', () => {
     const { container } = render(<PatientDataBootstrap />);
 
     expect(container).toBeEmptyDOMElement();
+  });
+
+  it('uses preferredLanguage from store instead of UI language (bug #236)', () => {
+    // Patient has German as preferred language but the UI is in English.
+    // Interventions must be fetched in German.
+    const s = getAuthState();
+    s.isAuthenticated = true;
+    s.userType = 'Patient';
+    s.id = 'patient-de';
+    s.preferredLanguage = 'de';
+
+    render(<PatientDataBootstrap />);
+
+    expect(mockInitPatientData).toHaveBeenCalledWith('patient-de', 'de');
+  });
+
+  it('falls back to i18n language when preferredLanguage is not set (bug #236)', () => {
+    // No preferred_language stored — should use the browser/UI language ('en' in tests).
+    const s = getAuthState();
+    s.isAuthenticated = true;
+    s.userType = 'Patient';
+    s.id = 'patient-en';
+    s.preferredLanguage = '';
+
+    render(<PatientDataBootstrap />);
+
+    expect(mockInitPatientData).toHaveBeenCalledWith('patient-en', 'en');
   });
 });

--- a/frontend/src/components/PatientDataBootstrap.tsx
+++ b/frontend/src/components/PatientDataBootstrap.tsx
@@ -12,9 +12,10 @@ const PatientDataBootstrap: React.FC = observer(() => {
     if (!isAuthenticated) {
       resetPatientDataInit();
     } else if (userType === 'Patient' && id) {
-      initPatientData(id, i18n.language);
+      const lang = authStore.preferredLanguage || i18n.language;
+      initPatientData(id, lang);
     }
-  }, [isAuthenticated, userType, id, i18n.language]);
+  }, [isAuthenticated, userType, id, authStore.preferredLanguage, i18n.language]);
 
   return null;
 });

--- a/frontend/src/pages/PatientInterventionDetail.tsx
+++ b/frontend/src/pages/PatientInterventionDetail.tsx
@@ -357,7 +357,7 @@ const PatientInterventionDetail: React.FC = observer(() => {
       }
 
       if (!patientInterventionsLibraryStore.visibleItemsForPatient.length) {
-        const lang = (i18n.language || 'en').slice(0, 2);
+        const lang = (authStore.preferredLanguage || i18n.language || 'en').slice(0, 2);
         await patientInterventionsLibraryStore.fetchAll({ mode: 'patient', lang });
       }
 

--- a/frontend/src/pages/PatientInterventionsLibrary.tsx
+++ b/frontend/src/pages/PatientInterventionsLibrary.tsx
@@ -242,9 +242,9 @@ const PatientInterventionsLibrary: React.FC = observer(() => {
       return;
     }
 
-    const lang = (i18n.language || 'en').slice(0, 2);
+    const lang = (authStore.preferredLanguage || i18n.language || 'en').slice(0, 2);
     patientInterventionsLibraryStore.fetchAll({ mode: 'patient', lang });
-  }, [authChecked, authStore.isAuthenticated, authStore.userType, navigate, i18n.language]);
+  }, [authChecked, authStore.isAuthenticated, authStore.userType, authStore.preferredLanguage, navigate, i18n.language]);
 
   const sourceItems = patientInterventionsLibraryStore.visibleItemsForPatient;
   const storeError = patientInterventionsLibraryStore.error;

--- a/frontend/src/pages/PatientInterventionsLibrary.tsx
+++ b/frontend/src/pages/PatientInterventionsLibrary.tsx
@@ -244,7 +244,14 @@ const PatientInterventionsLibrary: React.FC = observer(() => {
 
     const lang = (authStore.preferredLanguage || i18n.language || 'en').slice(0, 2);
     patientInterventionsLibraryStore.fetchAll({ mode: 'patient', lang });
-  }, [authChecked, authStore.isAuthenticated, authStore.userType, authStore.preferredLanguage, navigate, i18n.language]);
+  }, [
+    authChecked,
+    authStore.isAuthenticated,
+    authStore.userType,
+    authStore.preferredLanguage,
+    navigate,
+    i18n.language,
+  ]);
 
   const sourceItems = patientInterventionsLibraryStore.visibleItemsForPatient;
   const storeError = patientInterventionsLibraryStore.error;

--- a/frontend/src/stores/authStore.ts
+++ b/frontend/src/stores/authStore.ts
@@ -22,6 +22,7 @@ class AuthStore {
   // User profile (display + logic)
   firstName = '';
   specialisations: string[] = [];
+  preferredLanguage = '';
 
   // 2FA
   partialLogin = false;
@@ -95,6 +96,11 @@ class AuthStore {
     localStorage.setItem('specialisations', cleaned.join(','));
   };
 
+  setPreferredLanguage = (lang: string) => {
+    this.preferredLanguage = lang;
+    localStorage.setItem('preferredLanguage', lang);
+  };
+
   setOnLogoutCallback(callback: () => void) {
     this.onLogoutCallback = callback;
   }
@@ -144,6 +150,7 @@ class AuthStore {
         if (data.first_name) this.setFirstName(String(data.first_name));
         const specs = this._parseSpecialisationsFromPayload(data);
         if (specs.length) this.setSpecialisations(specs);
+        if (data.preferred_language) this.setPreferredLanguage(String(data.preferred_language));
       });
     } catch (err) {
       console.warn('Failed to fetch user info:', err);
@@ -334,6 +341,7 @@ class AuthStore {
             .filter(Boolean)
         : [];
 
+      this.preferredLanguage = localStorage.getItem('preferredLanguage') || '';
       this.partialLogin = false;
       this.loginErrorMessage = '';
     });
@@ -457,6 +465,7 @@ class AuthStore {
       this.id = '';
       this.firstName = '';
       this.specialisations = [];
+      this.preferredLanguage = '';
       this.partialLogin = false;
     });
   }


### PR DESCRIPTION
# Description
Interventions shown to patients were always fetched in the UI language (the language the browser or app was set to), completely ignoring the preferred_language field stored on the Patient document. A German-speaking patient whose app UI was set to English received all intervention titles, descriptions, and links in English.

**Root cause:** Every call site that fetched the intervention library used i18n.language — the React-i18next UI locale — as the lang parameter. i18n.language reflects the interface language, not the patient's content-language preference stored in the database.

## Fix (three layers):

1. Backend — GET /api/auth/get-user-info/<user_id>/ now includes preferred_language in the response for Patient users, defaulting to "en" when the field is absent.
2. Auth store — authStore gains a preferredLanguage observable, populated from the API response and persisted in localStorage so it survives page reloads. Cleared on logout.
3. Frontend call sites — PatientDataBootstrap, PatientInterventionsLibrary, and PatientInterventionDetail all now use authStore.preferredLanguage || i18n.language so the patient's stored language takes priority over the UI locale.

Related Issue
[#236 — Interventions always served in English, patient preferred language ignored](https://github.com/telerehabilitation/telerehabapp/issues/236)

### Type of change
 Bug fix (non-breaking change that fixes an issue)
### Tests
Backend — backend/tests/auth_views/test_get_user_info_view.py:

1. test_get_user_info_patient_returns_preferred_language — asserts the response includes preferred_language: "de" for a patient with that field set.
2. test_get_user_info_patient_preferred_language_defaults_to_en — asserts the response returns "en" when the field is missing.
3. test_get_user_info_response_shape_is_consistent — updated to verify preferred_language is always present in the response shape.


Frontend — frontend/src/__tests__/PatientDataBootstrap.test.tsx:

1. uses preferredLanguage from store instead of UI language (bug #236) — asserts initPatientData is called with "de" when authStore.preferredLanguage is "de", regardless of the i18n UI locale.
2. falls back to i18n language when preferredLanguage is not set (bug #236) — asserts the fallback to i18n.language when no preferred language is stored.

Checklist

- [x]  I have read the contributing guidelines.
- [x]  I have read the code of conduct.
- [x]  I have commented my code, particularly in hard-to-understand areas.
- [x]  I have made corresponding changes to the documentation.
- [x]  My changes generate no new warnings.
- [x]  I have added tests that prove my fix is effective or that my feature works.