### PR TITLE
238 feature admin export tab full or partial db export grouped by clinic as csv

### DIFF
--- a/backend/core/urls.py
+++ b/backend/core/urls.py
@@ -42,6 +42,7 @@ from core.views.redcap_import_views import (
 from core.views.redcap_patient_views import redcap_patient
 from core.views.redcap_views import redcap_projects, redcap_record
 from core.views.therapist_access_views import therapist_access
+from core.views.admin_export_views import admin_export_clinics, admin_export_patients
 from core.views.therapist_projects import therapist_projects
 from core.views.wearables_redcap_view import sync_wearables_to_redcap_view
 
@@ -50,6 +51,9 @@ urlpatterns = [
     path("api/admin/pending-users/", user_views.get_pending_users),
     path("api/admin/accept-user/", user_views.accept_user),
     path("api/admin/decline-user/", user_views.decline_user),
+    # Admin data export
+    path("api/admin/export/patients/", admin_export_patients),
+    path("api/admin/export/clinics/", admin_export_clinics),
     # Therapist access change requests
     path("api/therapist/access-change-request/", submit_access_change_request),
     path("api/admin/access-change-requests/", admin_access_change_requests),

--- a/backend/core/urls.py
+++ b/backend/core/urls.py
@@ -15,6 +15,7 @@ from core.views.access_change_views import (
     admin_access_change_requests,
     submit_access_change_request,
 )
+from core.views.admin_export_views import admin_export_clinics, admin_export_patients
 from core.views.eva_view import (
     delete_healthslider_session,
     download_healthslider_audio,
@@ -42,7 +43,6 @@ from core.views.redcap_import_views import (
 from core.views.redcap_patient_views import redcap_patient
 from core.views.redcap_views import redcap_projects, redcap_record
 from core.views.therapist_access_views import therapist_access
-from core.views.admin_export_views import admin_export_clinics, admin_export_patients
 from core.views.therapist_projects import therapist_projects
 from core.views.wearables_redcap_view import sync_wearables_to_redcap_view
 

--- a/backend/core/views/admin_export_views.py
+++ b/backend/core/views/admin_export_views.py
@@ -51,6 +51,7 @@ logger = logging.getLogger(__name__)
 # Shared helpers
 # ---------------------------------------------------------------------------
 
+
 def _fmt_date(dt):
     if dt is None:
         return ""
@@ -125,41 +126,62 @@ def _intervention_info(ref):
 # CSV sheet builders
 # ---------------------------------------------------------------------------
 
+
 def _csv_patients(patients):
     headers = [
-        "clinic", "project", "patient_code", "first_name", "last_name",
-        "age", "sex", "diagnosis", "function", "therapist",
-        "reha_end_date", "study_end_date", "duration_days",
-        "preferred_language", "created_at",
+        "clinic",
+        "project",
+        "patient_code",
+        "first_name",
+        "last_name",
+        "age",
+        "sex",
+        "diagnosis",
+        "function",
+        "therapist",
+        "reha_end_date",
+        "study_end_date",
+        "duration_days",
+        "preferred_language",
+        "created_at",
     ]
     rows = []
     for pt in patients:
-        rows.append({
-            "clinic": getattr(pt, "clinic", "") or "",
-            "project": getattr(pt, "project", "") or "",
-            "patient_code": getattr(pt, "patient_code", "") or "",
-            "first_name": getattr(pt, "first_name", "") or "",
-            "last_name": getattr(pt, "name", "") or "",
-            "age": getattr(pt, "age", "") or "",
-            "sex": getattr(pt, "sex", "") or "",
-            "diagnosis": _join(getattr(pt, "diagnosis", None)),
-            "function": _join(getattr(pt, "function", None)),
-            "therapist": _therapist_name(pt),
-            "reha_end_date": _fmt_date(getattr(pt, "reha_end_date", None)),
-            "study_end_date": _fmt_date(getattr(pt, "study_end_date", None)),
-            "duration_days": str(getattr(pt, "duration", "") or ""),
-            "preferred_language": getattr(pt, "preferred_language", "") or "",
-            "created_at": _fmt_date(getattr(pt, "createdAt", None)),
-        })
+        rows.append(
+            {
+                "clinic": getattr(pt, "clinic", "") or "",
+                "project": getattr(pt, "project", "") or "",
+                "patient_code": getattr(pt, "patient_code", "") or "",
+                "first_name": getattr(pt, "first_name", "") or "",
+                "last_name": getattr(pt, "name", "") or "",
+                "age": getattr(pt, "age", "") or "",
+                "sex": getattr(pt, "sex", "") or "",
+                "diagnosis": _join(getattr(pt, "diagnosis", None)),
+                "function": _join(getattr(pt, "function", None)),
+                "therapist": _therapist_name(pt),
+                "reha_end_date": _fmt_date(getattr(pt, "reha_end_date", None)),
+                "study_end_date": _fmt_date(getattr(pt, "study_end_date", None)),
+                "duration_days": str(getattr(pt, "duration", "") or ""),
+                "preferred_language": getattr(pt, "preferred_language", "") or "",
+                "created_at": _fmt_date(getattr(pt, "createdAt", None)),
+            }
+        )
     return _make_csv(headers, rows)
 
 
 def _csv_rehab_calendar(patients, patient_map):
     """One row per scheduled date per intervention assignment per plan."""
     headers = [
-        "clinic", "patient_code", "plan_status", "plan_start", "plan_end",
-        "intervention_external_id", "intervention_title",
-        "scheduled_date", "frequency", "notes",
+        "clinic",
+        "patient_code",
+        "plan_status",
+        "plan_start",
+        "plan_end",
+        "intervention_external_id",
+        "intervention_title",
+        "scheduled_date",
+        "frequency",
+        "notes",
     ]
     rows = []
     pt_ids = list(patient_map.keys())
@@ -174,33 +196,55 @@ def _csv_rehab_calendar(patients, patient_map):
         plan_start = _fmt_date(getattr(plan, "startDate", None))
         plan_end = _fmt_date(getattr(plan, "endDate", None))
         plan_status = getattr(plan, "status", "") or ""
-        for assignment in (getattr(plan, "interventions", None) or []):
+        for assignment in getattr(plan, "interventions", None) or []:
             ext_id, title = _intervention_info(getattr(assignment, "interventionId", None))
             frequency = getattr(assignment, "frequency", "") or ""
             notes = getattr(assignment, "notes", "") or ""
             dates = getattr(assignment, "dates", None) or []
             if dates:
                 for d in dates:
-                    rows.append({
-                        "clinic": clinic, "patient_code": code,
-                        "plan_status": plan_status, "plan_start": plan_start, "plan_end": plan_end,
-                        "intervention_external_id": ext_id, "intervention_title": title,
-                        "scheduled_date": _fmt_date(d), "frequency": frequency, "notes": notes,
-                    })
+                    rows.append(
+                        {
+                            "clinic": clinic,
+                            "patient_code": code,
+                            "plan_status": plan_status,
+                            "plan_start": plan_start,
+                            "plan_end": plan_end,
+                            "intervention_external_id": ext_id,
+                            "intervention_title": title,
+                            "scheduled_date": _fmt_date(d),
+                            "frequency": frequency,
+                            "notes": notes,
+                        }
+                    )
             else:
-                rows.append({
-                    "clinic": clinic, "patient_code": code,
-                    "plan_status": plan_status, "plan_start": plan_start, "plan_end": plan_end,
-                    "intervention_external_id": ext_id, "intervention_title": title,
-                    "scheduled_date": "", "frequency": frequency, "notes": notes,
-                })
+                rows.append(
+                    {
+                        "clinic": clinic,
+                        "patient_code": code,
+                        "plan_status": plan_status,
+                        "plan_start": plan_start,
+                        "plan_end": plan_end,
+                        "intervention_external_id": ext_id,
+                        "intervention_title": title,
+                        "scheduled_date": "",
+                        "frequency": frequency,
+                        "notes": notes,
+                    }
+                )
     return _make_csv(headers, rows)
 
 
 def _csv_intervention_logs(patient_map):
     headers = [
-        "clinic", "patient_code", "intervention_external_id", "intervention_title",
-        "date", "status", "comments", "created_at",
+        "clinic",
+        "patient_code",
+        "intervention_external_id",
+        "intervention_title",
+        "date",
+        "status",
+        "comments",
+        "created_at",
     ]
     rows = []
     pt_ids = list(patient_map.keys())
@@ -214,24 +258,32 @@ def _csv_intervention_logs(patient_map):
         if not pt:
             continue
         ext_id, title = _intervention_info(getattr(log, "interventionId", None))
-        rows.append({
-            "clinic": getattr(pt, "clinic", "") or "",
-            "patient_code": getattr(pt, "patient_code", "") or "",
-            "intervention_external_id": ext_id,
-            "intervention_title": title,
-            "date": _fmt_date(getattr(log, "date", None)),
-            "status": _join(getattr(log, "status", None)),
-            "comments": getattr(log, "comments", "") or "",
-            "created_at": _fmt_datetime(getattr(log, "createdAt", None)),
-        })
+        rows.append(
+            {
+                "clinic": getattr(pt, "clinic", "") or "",
+                "patient_code": getattr(pt, "patient_code", "") or "",
+                "intervention_external_id": ext_id,
+                "intervention_title": title,
+                "date": _fmt_date(getattr(log, "date", None)),
+                "status": _join(getattr(log, "status", None)),
+                "comments": getattr(log, "comments", "") or "",
+                "created_at": _fmt_datetime(getattr(log, "createdAt", None)),
+            }
+        )
     return _make_csv(headers, rows)
 
 
 def _csv_intervention_feedback(patient_map):
     """FeedbackEntry items embedded inside PatientInterventionLogs."""
     headers = [
-        "clinic", "patient_code", "intervention_external_id",
-        "log_date", "feedback_date", "question_key", "answer_keys", "comment",
+        "clinic",
+        "patient_code",
+        "intervention_external_id",
+        "log_date",
+        "feedback_date",
+        "question_key",
+        "answer_keys",
+        "comment",
     ]
     rows = []
     pt_ids = list(patient_map.keys())
@@ -245,24 +297,32 @@ def _csv_intervention_feedback(patient_map):
         if not pt:
             continue
         ext_id, _ = _intervention_info(getattr(log, "interventionId", None))
-        for entry in (getattr(log, "feedback", None) or []):
-            rows.append({
-                "clinic": getattr(pt, "clinic", "") or "",
-                "patient_code": getattr(pt, "patient_code", "") or "",
-                "intervention_external_id": ext_id,
-                "log_date": _fmt_date(getattr(log, "date", None)),
-                "feedback_date": _fmt_date(getattr(entry, "date", None)),
-                "question_key": _question_key(entry),
-                "answer_keys": _answer_keys(entry),
-                "comment": getattr(entry, "comment", "") or "",
-            })
+        for entry in getattr(log, "feedback", None) or []:
+            rows.append(
+                {
+                    "clinic": getattr(pt, "clinic", "") or "",
+                    "patient_code": getattr(pt, "patient_code", "") or "",
+                    "intervention_external_id": ext_id,
+                    "log_date": _fmt_date(getattr(log, "date", None)),
+                    "feedback_date": _fmt_date(getattr(entry, "date", None)),
+                    "question_key": _question_key(entry),
+                    "answer_keys": _answer_keys(entry),
+                    "comment": getattr(entry, "comment", "") or "",
+                }
+            )
     return _make_csv(headers, rows)
 
 
 def _csv_health_vitals(patient_map):
     headers = [
-        "clinic", "patient_code", "date",
-        "weight_kg", "bp_sys", "bp_dia", "source", "note",
+        "clinic",
+        "patient_code",
+        "date",
+        "weight_kg",
+        "bp_sys",
+        "bp_dia",
+        "source",
+        "note",
     ]
     rows = []
     pt_ids = list(patient_map.keys())
@@ -275,27 +335,37 @@ def _csv_health_vitals(patient_map):
         pt = patient_map.get(pt_id)
         if not pt:
             continue
-        rows.append({
-            "clinic": getattr(pt, "clinic", "") or "",
-            "patient_code": getattr(pt, "patient_code", "") or "",
-            "date": _fmt_date(getattr(v, "date", None)),
-            "weight_kg": str(getattr(v, "weight_kg", "") or ""),
-            "bp_sys": str(getattr(v, "bp_sys", "") or ""),
-            "bp_dia": str(getattr(v, "bp_dia", "") or ""),
-            "source": getattr(v, "source", "") or "",
-            "note": getattr(v, "note", "") or "",
-        })
+        rows.append(
+            {
+                "clinic": getattr(pt, "clinic", "") or "",
+                "patient_code": getattr(pt, "patient_code", "") or "",
+                "date": _fmt_date(getattr(v, "date", None)),
+                "weight_kg": str(getattr(v, "weight_kg", "") or ""),
+                "bp_sys": str(getattr(v, "bp_sys", "") or ""),
+                "bp_dia": str(getattr(v, "bp_dia", "") or ""),
+                "source": getattr(v, "source", "") or "",
+                "note": getattr(v, "note", "") or "",
+            }
+        )
     return _make_csv(headers, rows)
 
 
 def _csv_health_fitbit(patients, user_map):
     """user_map: user_id string → Patient doc."""
     headers = [
-        "clinic", "patient_code", "date",
-        "steps", "active_minutes", "sleep_duration_min",
-        "resting_heart_rate", "max_heart_rate",
-        "calories", "distance_km",
-        "weight_kg", "bp_sys", "bp_dia",
+        "clinic",
+        "patient_code",
+        "date",
+        "steps",
+        "active_minutes",
+        "sleep_duration_min",
+        "resting_heart_rate",
+        "max_heart_rate",
+        "calories",
+        "distance_km",
+        "weight_kg",
+        "bp_sys",
+        "bp_dia",
     ]
     rows = []
     user_ids = list(user_map.keys())
@@ -312,29 +382,36 @@ def _csv_health_fitbit(patients, user_map):
         sleep_min = ""
         if sleep:
             sleep_min = str(getattr(sleep, "sleep_duration", "") or getattr(sleep, "minutes_asleep", "") or "")
-        rows.append({
-            "clinic": getattr(pt, "clinic", "") or "",
-            "patient_code": getattr(pt, "patient_code", "") or "",
-            "date": _fmt_date(getattr(fb, "date", None)),
-            "steps": str(getattr(fb, "steps", "") or ""),
-            "active_minutes": str(getattr(fb, "active_minutes", "") or ""),
-            "sleep_duration_min": sleep_min,
-            "resting_heart_rate": str(getattr(fb, "resting_heart_rate", "") or ""),
-            "max_heart_rate": str(getattr(fb, "max_heart_rate", "") or ""),
-            "calories": str(getattr(fb, "calories", "") or ""),
-            "distance_km": str(getattr(fb, "distance", "") or ""),
-            "weight_kg": str(getattr(fb, "weight_kg", "") or ""),
-            "bp_sys": str(getattr(fb, "bp_sys", "") or ""),
-            "bp_dia": str(getattr(fb, "bp_dia", "") or ""),
-        })
+        rows.append(
+            {
+                "clinic": getattr(pt, "clinic", "") or "",
+                "patient_code": getattr(pt, "patient_code", "") or "",
+                "date": _fmt_date(getattr(fb, "date", None)),
+                "steps": str(getattr(fb, "steps", "") or ""),
+                "active_minutes": str(getattr(fb, "active_minutes", "") or ""),
+                "sleep_duration_min": sleep_min,
+                "resting_heart_rate": str(getattr(fb, "resting_heart_rate", "") or ""),
+                "max_heart_rate": str(getattr(fb, "max_heart_rate", "") or ""),
+                "calories": str(getattr(fb, "calories", "") or ""),
+                "distance_km": str(getattr(fb, "distance", "") or ""),
+                "weight_kg": str(getattr(fb, "weight_kg", "") or ""),
+                "bp_sys": str(getattr(fb, "bp_sys", "") or ""),
+                "bp_dia": str(getattr(fb, "bp_dia", "") or ""),
+            }
+        )
     return _make_csv(headers, rows)
 
 
 def _csv_questionnaire_answers(patient_map):
     """PatientICFRating — health-status questionnaire responses."""
     headers = [
-        "clinic", "patient_code", "date", "icf_code",
-        "question_key", "rating", "comment",
+        "clinic",
+        "patient_code",
+        "date",
+        "icf_code",
+        "question_key",
+        "rating",
+        "comment",
     ]
     rows = []
     pt_ids = list(patient_map.keys())
@@ -358,85 +435,108 @@ def _csv_questionnaire_answers(patient_map):
             for fe in (getattr(r, "feedback_entries", None) or [])
             if (getattr(fe, "comment", "") or "").strip()
         )
-        rows.append({
-            "clinic": getattr(pt, "clinic", "") or "",
-            "patient_code": getattr(pt, "patient_code", "") or "",
-            "date": _fmt_date(getattr(r, "date", None)),
-            "icf_code": getattr(r, "icfCode", "") or "",
-            "question_key": q_key,
-            "rating": str(getattr(r, "rating", "") or ""),
-            "comment": comments,
-        })
+        rows.append(
+            {
+                "clinic": getattr(pt, "clinic", "") or "",
+                "patient_code": getattr(pt, "patient_code", "") or "",
+                "date": _fmt_date(getattr(r, "date", None)),
+                "icf_code": getattr(r, "icfCode", "") or "",
+                "question_key": q_key,
+                "rating": str(getattr(r, "rating", "") or ""),
+                "comment": comments,
+            }
+        )
     return _make_csv(headers, rows)
 
 
 def _csv_thresholds(patients):
     headers = [
-        "clinic", "patient_code",
+        "clinic",
+        "patient_code",
         "steps_goal",
-        "active_minutes_green", "active_minutes_yellow",
-        "sleep_green_min", "sleep_yellow_min",
-        "bp_sys_green_max", "bp_sys_yellow_max",
-        "bp_dia_green_max", "bp_dia_yellow_max",
+        "active_minutes_green",
+        "active_minutes_yellow",
+        "sleep_green_min",
+        "sleep_yellow_min",
+        "bp_sys_green_max",
+        "bp_sys_yellow_max",
+        "bp_dia_green_max",
+        "bp_dia_yellow_max",
     ]
     rows = []
     for pt in patients:
         th = getattr(pt, "thresholds", None)
         if th is None:
             continue
-        rows.append({
-            "clinic": getattr(pt, "clinic", "") or "",
-            "patient_code": getattr(pt, "patient_code", "") or "",
-            "steps_goal": str(getattr(th, "steps_goal", "") or ""),
-            "active_minutes_green": str(getattr(th, "active_minutes_green", "") or ""),
-            "active_minutes_yellow": str(getattr(th, "active_minutes_yellow", "") or ""),
-            "sleep_green_min": str(getattr(th, "sleep_green_min", "") or ""),
-            "sleep_yellow_min": str(getattr(th, "sleep_yellow_min", "") or ""),
-            "bp_sys_green_max": str(getattr(th, "bp_sys_green_max", "") or ""),
-            "bp_sys_yellow_max": str(getattr(th, "bp_sys_yellow_max", "") or ""),
-            "bp_dia_green_max": str(getattr(th, "bp_dia_green_max", "") or ""),
-            "bp_dia_yellow_max": str(getattr(th, "bp_dia_yellow_max", "") or ""),
-        })
+        rows.append(
+            {
+                "clinic": getattr(pt, "clinic", "") or "",
+                "patient_code": getattr(pt, "patient_code", "") or "",
+                "steps_goal": str(getattr(th, "steps_goal", "") or ""),
+                "active_minutes_green": str(getattr(th, "active_minutes_green", "") or ""),
+                "active_minutes_yellow": str(getattr(th, "active_minutes_yellow", "") or ""),
+                "sleep_green_min": str(getattr(th, "sleep_green_min", "") or ""),
+                "sleep_yellow_min": str(getattr(th, "sleep_yellow_min", "") or ""),
+                "bp_sys_green_max": str(getattr(th, "bp_sys_green_max", "") or ""),
+                "bp_sys_yellow_max": str(getattr(th, "bp_sys_yellow_max", "") or ""),
+                "bp_dia_green_max": str(getattr(th, "bp_dia_green_max", "") or ""),
+                "bp_dia_yellow_max": str(getattr(th, "bp_dia_yellow_max", "") or ""),
+            }
+        )
     return _make_csv(headers, rows)
 
 
 def _csv_threshold_history(patients):
     headers = [
-        "clinic", "patient_code", "effective_from", "changed_by", "reason",
+        "clinic",
+        "patient_code",
+        "effective_from",
+        "changed_by",
+        "reason",
         "steps_goal",
-        "active_minutes_green", "active_minutes_yellow",
-        "sleep_green_min", "sleep_yellow_min",
-        "bp_sys_green_max", "bp_sys_yellow_max",
-        "bp_dia_green_max", "bp_dia_yellow_max",
+        "active_minutes_green",
+        "active_minutes_yellow",
+        "sleep_green_min",
+        "sleep_yellow_min",
+        "bp_sys_green_max",
+        "bp_sys_yellow_max",
+        "bp_dia_green_max",
+        "bp_dia_yellow_max",
     ]
     rows = []
     for pt in patients:
-        for snap in (getattr(pt, "thresholds_history", None) or []):
+        for snap in getattr(pt, "thresholds_history", None) or []:
             th = getattr(snap, "thresholds", None)
-            rows.append({
-                "clinic": getattr(pt, "clinic", "") or "",
-                "patient_code": getattr(pt, "patient_code", "") or "",
-                "effective_from": _fmt_datetime(getattr(snap, "effective_from", None)),
-                "changed_by": getattr(snap, "changed_by", "") or "",
-                "reason": getattr(snap, "reason", "") or "",
-                "steps_goal": str(getattr(th, "steps_goal", "") or "") if th else "",
-                "active_minutes_green": str(getattr(th, "active_minutes_green", "") or "") if th else "",
-                "active_minutes_yellow": str(getattr(th, "active_minutes_yellow", "") or "") if th else "",
-                "sleep_green_min": str(getattr(th, "sleep_green_min", "") or "") if th else "",
-                "sleep_yellow_min": str(getattr(th, "sleep_yellow_min", "") or "") if th else "",
-                "bp_sys_green_max": str(getattr(th, "bp_sys_green_max", "") or "") if th else "",
-                "bp_sys_yellow_max": str(getattr(th, "bp_sys_yellow_max", "") or "") if th else "",
-                "bp_dia_green_max": str(getattr(th, "bp_dia_green_max", "") or "") if th else "",
-                "bp_dia_yellow_max": str(getattr(th, "bp_dia_yellow_max", "") or "") if th else "",
-            })
+            rows.append(
+                {
+                    "clinic": getattr(pt, "clinic", "") or "",
+                    "patient_code": getattr(pt, "patient_code", "") or "",
+                    "effective_from": _fmt_datetime(getattr(snap, "effective_from", None)),
+                    "changed_by": getattr(snap, "changed_by", "") or "",
+                    "reason": getattr(snap, "reason", "") or "",
+                    "steps_goal": str(getattr(th, "steps_goal", "") or "") if th else "",
+                    "active_minutes_green": str(getattr(th, "active_minutes_green", "") or "") if th else "",
+                    "active_minutes_yellow": str(getattr(th, "active_minutes_yellow", "") or "") if th else "",
+                    "sleep_green_min": str(getattr(th, "sleep_green_min", "") or "") if th else "",
+                    "sleep_yellow_min": str(getattr(th, "sleep_yellow_min", "") or "") if th else "",
+                    "bp_sys_green_max": str(getattr(th, "bp_sys_green_max", "") or "") if th else "",
+                    "bp_sys_yellow_max": str(getattr(th, "bp_sys_yellow_max", "") or "") if th else "",
+                    "bp_dia_green_max": str(getattr(th, "bp_dia_green_max", "") or "") if th else "",
+                    "bp_dia_yellow_max": str(getattr(th, "bp_dia_yellow_max", "") or "") if th else "",
+                }
+            )
     return _make_csv(headers, rows)
 
 
 def _csv_activity_logs(patient_map):
     """Logs documents where the patient field matches a patient in the export scope."""
     headers = [
-        "clinic", "patient_code", "action",
-        "timestamp", "actor_role", "details",
+        "clinic",
+        "patient_code",
+        "action",
+        "timestamp",
+        "actor_role",
+        "details",
     ]
     rows = []
     pt_ids = list(patient_map.keys())
@@ -448,20 +548,23 @@ def _csv_activity_logs(patient_map):
         except Exception:
             pt_id = None
         pt = patient_map.get(pt_id) if pt_id else None
-        rows.append({
-            "clinic": getattr(pt, "clinic", "") if pt else "",
-            "patient_code": getattr(pt, "patient_code", "") if pt else "",
-            "action": getattr(log, "action", "") or "",
-            "timestamp": _fmt_datetime(getattr(log, "timestamp", None)),
-            "actor_role": getattr(log, "actor_role", "") or "",
-            "details": getattr(log, "details", "") or "",
-        })
+        rows.append(
+            {
+                "clinic": getattr(pt, "clinic", "") if pt else "",
+                "patient_code": getattr(pt, "patient_code", "") if pt else "",
+                "action": getattr(log, "action", "") or "",
+                "timestamp": _fmt_datetime(getattr(log, "timestamp", None)),
+                "actor_role": getattr(log, "actor_role", "") or "",
+                "details": getattr(log, "details", "") or "",
+            }
+        )
     return _make_csv(headers, rows)
 
 
 # ---------------------------------------------------------------------------
 # View functions
 # ---------------------------------------------------------------------------
+
 
 @csrf_exempt
 @permission_classes([IsAuthenticated])
@@ -501,16 +604,16 @@ def admin_export_patients(request):
                 pass
 
         sheets = [
-            ("patients.csv",               _csv_patients(patients)),
-            ("rehab_calendar.csv",          _csv_rehab_calendar(patients, patient_map)),
-            ("intervention_logs.csv",       _csv_intervention_logs(patient_map)),
-            ("intervention_feedback.csv",   _csv_intervention_feedback(patient_map)),
-            ("health_vitals.csv",           _csv_health_vitals(patient_map)),
-            ("health_fitbit.csv",           _csv_health_fitbit(patients, user_map)),
-            ("questionnaire_answers.csv",   _csv_questionnaire_answers(patient_map)),
-            ("thresholds.csv",              _csv_thresholds(patients)),
-            ("threshold_history.csv",       _csv_threshold_history(patients)),
-            ("activity_logs.csv",           _csv_activity_logs(patient_map)),
+            ("patients.csv", _csv_patients(patients)),
+            ("rehab_calendar.csv", _csv_rehab_calendar(patients, patient_map)),
+            ("intervention_logs.csv", _csv_intervention_logs(patient_map)),
+            ("intervention_feedback.csv", _csv_intervention_feedback(patient_map)),
+            ("health_vitals.csv", _csv_health_vitals(patient_map)),
+            ("health_fitbit.csv", _csv_health_fitbit(patients, user_map)),
+            ("questionnaire_answers.csv", _csv_questionnaire_answers(patient_map)),
+            ("thresholds.csv", _csv_thresholds(patients)),
+            ("threshold_history.csv", _csv_threshold_history(patients)),
+            ("activity_logs.csv", _csv_activity_logs(patient_map)),
         ]
 
         zip_buf = io.BytesIO()
@@ -542,9 +645,7 @@ def admin_export_clinics(request):
         return JsonResponse({"error": "Method not allowed"}, status=405)
 
     try:
-        clinics = sorted(
-            {(getattr(p, "clinic", "") or "").strip() for p in Patient.objects.only("clinic")} - {""}
-        )
+        clinics = sorted({(getattr(p, "clinic", "") or "").strip() for p in Patient.objects.only("clinic")} - {""})
         return JsonResponse({"clinics": clinics}, status=200)
     except Exception:
         logger.exception("admin_export_clinics failed")

--- a/backend/core/views/admin_export_views.py
+++ b/backend/core/views/admin_export_views.py
@@ -1,0 +1,159 @@
+"""
+Admin export endpoint: download patient data as CSV, optionally filtered by clinic.
+
+Route registered in urls.py:
+  GET /api/admin/export/patients/?clinics=all
+  GET /api/admin/export/patients/?clinics=Inselspital,Bern
+
+Query parameters
+----------------
+clinics : str, optional
+    Comma-separated list of clinic names to include, or "all" / omitted for
+    the full database.
+
+Response
+--------
+200  text/csv attachment — filename: patients_export_<iso-date>.csv
+400  JSON  {"error": "..."} for bad input
+500  JSON  {"error": "Internal server error"} on unexpected failure
+
+CSV column order (grouped/sorted by clinic)
+------------------------------------------
+clinic, project, patient_code, first_name, last_name, age, sex,
+diagnosis, function, therapist, reha_end_date, study_end_date,
+duration_days, preferred_language, created_at
+"""
+
+import csv
+import io
+import logging
+from datetime import date
+
+from django.http import HttpResponse, JsonResponse
+from django.views.decorators.csrf import csrf_exempt
+from rest_framework.decorators import permission_classes
+from rest_framework.permissions import IsAuthenticated
+
+from core.models import Patient, Therapist
+
+logger = logging.getLogger(__name__)
+
+# Ordered CSV header
+_HEADERS = [
+    "clinic",
+    "project",
+    "patient_code",
+    "first_name",
+    "last_name",
+    "age",
+    "sex",
+    "diagnosis",
+    "function",
+    "therapist",
+    "reha_end_date",
+    "study_end_date",
+    "duration_days",
+    "preferred_language",
+    "created_at",
+]
+
+
+def _therapist_name(patient):
+    try:
+        th = patient.therapist
+        if th is None:
+            return ""
+        first = getattr(th, "first_name", "") or ""
+        last = getattr(th, "name", "") or ""
+        return f"{first} {last}".strip()
+    except Exception:
+        return ""
+
+
+def _fmt_date(dt):
+    if dt is None:
+        return ""
+    try:
+        return dt.strftime("%Y-%m-%d")
+    except Exception:
+        return ""
+
+
+def _row(patient):
+    return {
+        "clinic": getattr(patient, "clinic", "") or "",
+        "project": getattr(patient, "project", "") or "",
+        "patient_code": getattr(patient, "patient_code", "") or "",
+        "first_name": getattr(patient, "first_name", "") or "",
+        "last_name": getattr(patient, "name", "") or "",
+        "age": getattr(patient, "age", "") or "",
+        "sex": getattr(patient, "sex", "") or "",
+        "diagnosis": "; ".join(getattr(patient, "diagnosis", None) or []),
+        "function": "; ".join(getattr(patient, "function", None) or []),
+        "therapist": _therapist_name(patient),
+        "reha_end_date": _fmt_date(getattr(patient, "reha_end_date", None)),
+        "study_end_date": _fmt_date(getattr(patient, "study_end_date", None)),
+        "duration_days": str(getattr(patient, "duration", "") or ""),
+        "preferred_language": getattr(patient, "preferred_language", "") or "",
+        "created_at": _fmt_date(getattr(patient, "createdAt", None)),
+    }
+
+
+@csrf_exempt
+@permission_classes([IsAuthenticated])
+def admin_export_patients(request):
+    if request.method != "GET":
+        return JsonResponse({"error": "Method not allowed"}, status=405)
+
+    try:
+        clinics_param = (request.GET.get("clinics") or "all").strip()
+
+        if clinics_param.lower() == "all" or not clinics_param:
+            qs = Patient.objects.all()
+        else:
+            requested = [c.strip() for c in clinics_param.split(",") if c.strip()]
+            if not requested:
+                return JsonResponse({"error": "No valid clinic names provided"}, status=400)
+            qs = Patient.objects(clinic__in=requested)
+
+        # Sort by clinic then patient_code for grouped output
+        patients = list(qs.order_by("clinic", "patient_code"))
+
+        output = io.StringIO()
+        writer = csv.DictWriter(output, fieldnames=_HEADERS, extrasaction="ignore")
+        writer.writeheader()
+        for pt in patients:
+            writer.writerow(_row(pt))
+
+        today = date.today().isoformat()
+        filename = f"patients_export_{today}.csv"
+
+        response = HttpResponse(output.getvalue(), content_type="text/csv; charset=utf-8")
+        response["Content-Disposition"] = f'attachment; filename="{filename}"'
+        return response
+
+    except Exception:
+        logger.exception("admin_export_patients failed")
+        return JsonResponse({"error": "Internal server error"}, status=500)
+
+
+@csrf_exempt
+@permission_classes([IsAuthenticated])
+def admin_export_clinics(request):
+    """
+    GET /api/admin/export/clinics/
+    Returns the list of distinct clinic names present in the Patient collection.
+    Used by the frontend to populate the clinic filter checkboxes.
+    """
+    if request.method != "GET":
+        return JsonResponse({"error": "Method not allowed"}, status=405)
+
+    try:
+        clinics = sorted(
+            {(getattr(p, "clinic", "") or "").strip() for p in Patient.objects.only("clinic")}
+            - {""}
+        )
+        return JsonResponse({"clinics": clinics}, status=200)
+    except Exception:
+        logger.exception("admin_export_clinics failed")
+        return JsonResponse({"error": "Internal server error"}, status=500)

--- a/backend/core/views/admin_export_views.py
+++ b/backend/core/views/admin_export_views.py
@@ -149,10 +149,7 @@ def admin_export_clinics(request):
         return JsonResponse({"error": "Method not allowed"}, status=405)
 
     try:
-        clinics = sorted(
-            {(getattr(p, "clinic", "") or "").strip() for p in Patient.objects.only("clinic")}
-            - {""}
-        )
+        clinics = sorted({(getattr(p, "clinic", "") or "").strip() for p in Patient.objects.only("clinic")} - {""})
         return JsonResponse({"clinics": clinics}, status=200)
     except Exception:
         logger.exception("admin_export_clinics failed")

--- a/backend/core/views/admin_export_views.py
+++ b/backend/core/views/admin_export_views.py
@@ -1,32 +1,30 @@
 """
-Admin export endpoint: download patient data as CSV, optionally filtered by clinic.
+Admin export endpoint: download a ZIP archive containing one CSV per data type,
+optionally filtered by clinic.
 
-Route registered in urls.py:
-  GET /api/admin/export/patients/?clinics=all
-  GET /api/admin/export/patients/?clinics=Inselspital,Bern
+Routes registered in urls.py:
+  GET /api/admin/export/patients/?clinics=all   → ZIP download
+  GET /api/admin/export/patients/?clinics=A,B   → ZIP filtered to those clinics
+  GET /api/admin/export/clinics/                → JSON list of distinct clinic names
 
-Query parameters
-----------------
-clinics : str, optional
-    Comma-separated list of clinic names to include, or "all" / omitted for
-    the full database.
-
-Response
---------
-200  text/csv attachment — filename: patients_export_<iso-date>.csv
-400  JSON  {"error": "..."} for bad input
-500  JSON  {"error": "Internal server error"} on unexpected failure
-
-CSV column order (grouped/sorted by clinic)
-------------------------------------------
-clinic, project, patient_code, first_name, last_name, age, sex,
-diagnosis, function, therapist, reha_end_date, study_end_date,
-duration_days, preferred_language, created_at
+ZIP contents
+------------
+patients.csv            — demographics
+rehab_calendar.csv      — scheduled intervention dates from RehabilitationPlans
+intervention_logs.csv   — PatientInterventionLogs execution records
+intervention_feedback.csv — per-intervention FeedbackEntry answers
+health_vitals.csv       — manually-entered PatientVitals (weight, BP)
+health_fitbit.csv       — FitbitData (steps, sleep, HR, ...)
+questionnaire_answers.csv — PatientICFRating health-status questionnaire answers
+thresholds.csv          — current PatientThresholds per patient
+threshold_history.csv   — PatientThresholdsSnapshot change history
+activity_logs.csv       — Logs (platform activity events)
 """
 
 import csv
 import io
 import logging
+import zipfile
 from datetime import date
 
 from django.http import HttpResponse, JsonResponse
@@ -34,41 +32,24 @@ from django.views.decorators.csrf import csrf_exempt
 from rest_framework.decorators import permission_classes
 from rest_framework.permissions import IsAuthenticated
 
-from core.models import Patient, Therapist
+from core.models import (
+    FitbitData,
+    GeneralFeedback,
+    Intervention,
+    Logs,
+    Patient,
+    PatientICFRating,
+    PatientInterventionLogs,
+    PatientVitals,
+    RehabilitationPlan,
+)
 
 logger = logging.getLogger(__name__)
 
-# Ordered CSV header
-_HEADERS = [
-    "clinic",
-    "project",
-    "patient_code",
-    "first_name",
-    "last_name",
-    "age",
-    "sex",
-    "diagnosis",
-    "function",
-    "therapist",
-    "reha_end_date",
-    "study_end_date",
-    "duration_days",
-    "preferred_language",
-    "created_at",
-]
 
-
-def _therapist_name(patient):
-    try:
-        th = patient.therapist
-        if th is None:
-            return ""
-        first = getattr(th, "first_name", "") or ""
-        last = getattr(th, "name", "") or ""
-        return f"{first} {last}".strip()
-    except Exception:
-        return ""
-
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
 
 def _fmt_date(dt):
     if dt is None:
@@ -79,29 +60,418 @@ def _fmt_date(dt):
         return ""
 
 
-def _row(patient):
-    return {
-        "clinic": getattr(patient, "clinic", "") or "",
-        "project": getattr(patient, "project", "") or "",
-        "patient_code": getattr(patient, "patient_code", "") or "",
-        "first_name": getattr(patient, "first_name", "") or "",
-        "last_name": getattr(patient, "name", "") or "",
-        "age": getattr(patient, "age", "") or "",
-        "sex": getattr(patient, "sex", "") or "",
-        "diagnosis": "; ".join(getattr(patient, "diagnosis", None) or []),
-        "function": "; ".join(getattr(patient, "function", None) or []),
-        "therapist": _therapist_name(patient),
-        "reha_end_date": _fmt_date(getattr(patient, "reha_end_date", None)),
-        "study_end_date": _fmt_date(getattr(patient, "study_end_date", None)),
-        "duration_days": str(getattr(patient, "duration", "") or ""),
-        "preferred_language": getattr(patient, "preferred_language", "") or "",
-        "created_at": _fmt_date(getattr(patient, "createdAt", None)),
-    }
+def _fmt_datetime(dt):
+    if dt is None:
+        return ""
+    try:
+        return dt.strftime("%Y-%m-%d %H:%M:%S")
+    except Exception:
+        return ""
 
+
+def _join(lst):
+    """Safely join a list of strings with semicolons."""
+    if not lst:
+        return ""
+    return "; ".join(str(x) for x in lst if x)
+
+
+def _therapist_name(patient):
+    try:
+        th = patient.therapist
+        if th is None:
+            return ""
+        return f"{getattr(th, 'first_name', '') or ''} {getattr(th, 'name', '') or ''}".strip()
+    except Exception:
+        return ""
+
+
+def _make_csv(headers, rows):
+    """Return a StringIO containing a CSV with the given headers and row dicts."""
+    buf = io.StringIO()
+    writer = csv.DictWriter(buf, fieldnames=headers, extrasaction="ignore")
+    writer.writeheader()
+    for row in rows:
+        writer.writerow(row)
+    return buf
+
+
+def _question_key(feedback_entry):
+    try:
+        q = feedback_entry.questionId
+        return getattr(q, "questionKey", "") or ""
+    except Exception:
+        return ""
+
+
+def _answer_keys(feedback_entry):
+    try:
+        return "; ".join(a.key for a in (feedback_entry.answerKey or []) if getattr(a, "key", None))
+    except Exception:
+        return ""
+
+
+def _intervention_info(ref):
+    """Return (external_id, title) from an Intervention reference, safe."""
+    try:
+        if ref is None:
+            return "", ""
+        return getattr(ref, "external_id", "") or "", getattr(ref, "title", "") or ""
+    except Exception:
+        return "", ""
+
+
+# ---------------------------------------------------------------------------
+# CSV sheet builders
+# ---------------------------------------------------------------------------
+
+def _csv_patients(patients):
+    headers = [
+        "clinic", "project", "patient_code", "first_name", "last_name",
+        "age", "sex", "diagnosis", "function", "therapist",
+        "reha_end_date", "study_end_date", "duration_days",
+        "preferred_language", "created_at",
+    ]
+    rows = []
+    for pt in patients:
+        rows.append({
+            "clinic": getattr(pt, "clinic", "") or "",
+            "project": getattr(pt, "project", "") or "",
+            "patient_code": getattr(pt, "patient_code", "") or "",
+            "first_name": getattr(pt, "first_name", "") or "",
+            "last_name": getattr(pt, "name", "") or "",
+            "age": getattr(pt, "age", "") or "",
+            "sex": getattr(pt, "sex", "") or "",
+            "diagnosis": _join(getattr(pt, "diagnosis", None)),
+            "function": _join(getattr(pt, "function", None)),
+            "therapist": _therapist_name(pt),
+            "reha_end_date": _fmt_date(getattr(pt, "reha_end_date", None)),
+            "study_end_date": _fmt_date(getattr(pt, "study_end_date", None)),
+            "duration_days": str(getattr(pt, "duration", "") or ""),
+            "preferred_language": getattr(pt, "preferred_language", "") or "",
+            "created_at": _fmt_date(getattr(pt, "createdAt", None)),
+        })
+    return _make_csv(headers, rows)
+
+
+def _csv_rehab_calendar(patients, patient_map):
+    """One row per scheduled date per intervention assignment per plan."""
+    headers = [
+        "clinic", "patient_code", "plan_status", "plan_start", "plan_end",
+        "intervention_external_id", "intervention_title",
+        "scheduled_date", "frequency", "notes",
+    ]
+    rows = []
+    pt_ids = list(patient_map.keys())
+    plans = list(RehabilitationPlan.objects(patientId__in=pt_ids))
+    for plan in plans:
+        pt_id = str(plan.patientId.id) if hasattr(plan.patientId, "id") else str(plan.patientId)
+        pt = patient_map.get(pt_id)
+        if not pt:
+            continue
+        clinic = getattr(pt, "clinic", "") or ""
+        code = getattr(pt, "patient_code", "") or ""
+        plan_start = _fmt_date(getattr(plan, "startDate", None))
+        plan_end = _fmt_date(getattr(plan, "endDate", None))
+        plan_status = getattr(plan, "status", "") or ""
+        for assignment in (getattr(plan, "interventions", None) or []):
+            ext_id, title = _intervention_info(getattr(assignment, "interventionId", None))
+            frequency = getattr(assignment, "frequency", "") or ""
+            notes = getattr(assignment, "notes", "") or ""
+            dates = getattr(assignment, "dates", None) or []
+            if dates:
+                for d in dates:
+                    rows.append({
+                        "clinic": clinic, "patient_code": code,
+                        "plan_status": plan_status, "plan_start": plan_start, "plan_end": plan_end,
+                        "intervention_external_id": ext_id, "intervention_title": title,
+                        "scheduled_date": _fmt_date(d), "frequency": frequency, "notes": notes,
+                    })
+            else:
+                rows.append({
+                    "clinic": clinic, "patient_code": code,
+                    "plan_status": plan_status, "plan_start": plan_start, "plan_end": plan_end,
+                    "intervention_external_id": ext_id, "intervention_title": title,
+                    "scheduled_date": "", "frequency": frequency, "notes": notes,
+                })
+    return _make_csv(headers, rows)
+
+
+def _csv_intervention_logs(patient_map):
+    headers = [
+        "clinic", "patient_code", "intervention_external_id", "intervention_title",
+        "date", "status", "comments", "created_at",
+    ]
+    rows = []
+    pt_ids = list(patient_map.keys())
+    logs = list(PatientInterventionLogs.objects(userId__in=pt_ids))
+    for log in logs:
+        try:
+            pt_id = str(log.userId.id) if hasattr(log.userId, "id") else str(log.userId)
+        except Exception:
+            continue
+        pt = patient_map.get(pt_id)
+        if not pt:
+            continue
+        ext_id, title = _intervention_info(getattr(log, "interventionId", None))
+        rows.append({
+            "clinic": getattr(pt, "clinic", "") or "",
+            "patient_code": getattr(pt, "patient_code", "") or "",
+            "intervention_external_id": ext_id,
+            "intervention_title": title,
+            "date": _fmt_date(getattr(log, "date", None)),
+            "status": _join(getattr(log, "status", None)),
+            "comments": getattr(log, "comments", "") or "",
+            "created_at": _fmt_datetime(getattr(log, "createdAt", None)),
+        })
+    return _make_csv(headers, rows)
+
+
+def _csv_intervention_feedback(patient_map):
+    """FeedbackEntry items embedded inside PatientInterventionLogs."""
+    headers = [
+        "clinic", "patient_code", "intervention_external_id",
+        "log_date", "feedback_date", "question_key", "answer_keys", "comment",
+    ]
+    rows = []
+    pt_ids = list(patient_map.keys())
+    logs = list(PatientInterventionLogs.objects(userId__in=pt_ids))
+    for log in logs:
+        try:
+            pt_id = str(log.userId.id) if hasattr(log.userId, "id") else str(log.userId)
+        except Exception:
+            continue
+        pt = patient_map.get(pt_id)
+        if not pt:
+            continue
+        ext_id, _ = _intervention_info(getattr(log, "interventionId", None))
+        for entry in (getattr(log, "feedback", None) or []):
+            rows.append({
+                "clinic": getattr(pt, "clinic", "") or "",
+                "patient_code": getattr(pt, "patient_code", "") or "",
+                "intervention_external_id": ext_id,
+                "log_date": _fmt_date(getattr(log, "date", None)),
+                "feedback_date": _fmt_date(getattr(entry, "date", None)),
+                "question_key": _question_key(entry),
+                "answer_keys": _answer_keys(entry),
+                "comment": getattr(entry, "comment", "") or "",
+            })
+    return _make_csv(headers, rows)
+
+
+def _csv_health_vitals(patient_map):
+    headers = [
+        "clinic", "patient_code", "date",
+        "weight_kg", "bp_sys", "bp_dia", "source", "note",
+    ]
+    rows = []
+    pt_ids = list(patient_map.keys())
+    vitals = list(PatientVitals.objects(patientId__in=pt_ids).order_by("date"))
+    for v in vitals:
+        try:
+            pt_id = str(v.patientId.id) if hasattr(v.patientId, "id") else str(v.patientId)
+        except Exception:
+            continue
+        pt = patient_map.get(pt_id)
+        if not pt:
+            continue
+        rows.append({
+            "clinic": getattr(pt, "clinic", "") or "",
+            "patient_code": getattr(pt, "patient_code", "") or "",
+            "date": _fmt_date(getattr(v, "date", None)),
+            "weight_kg": str(getattr(v, "weight_kg", "") or ""),
+            "bp_sys": str(getattr(v, "bp_sys", "") or ""),
+            "bp_dia": str(getattr(v, "bp_dia", "") or ""),
+            "source": getattr(v, "source", "") or "",
+            "note": getattr(v, "note", "") or "",
+        })
+    return _make_csv(headers, rows)
+
+
+def _csv_health_fitbit(patients, user_map):
+    """user_map: user_id string → Patient doc."""
+    headers = [
+        "clinic", "patient_code", "date",
+        "steps", "active_minutes", "sleep_duration_min",
+        "resting_heart_rate", "max_heart_rate",
+        "calories", "distance_km",
+        "weight_kg", "bp_sys", "bp_dia",
+    ]
+    rows = []
+    user_ids = list(user_map.keys())
+    fitbit_rows = list(FitbitData.objects(user__in=user_ids).order_by("date"))
+    for fb in fitbit_rows:
+        try:
+            uid = str(fb.user.id) if hasattr(fb.user, "id") else str(fb.user)
+        except Exception:
+            continue
+        pt = user_map.get(uid)
+        if not pt:
+            continue
+        sleep = getattr(fb, "sleep", None)
+        sleep_min = ""
+        if sleep:
+            sleep_min = str(getattr(sleep, "sleep_duration", "") or getattr(sleep, "minutes_asleep", "") or "")
+        rows.append({
+            "clinic": getattr(pt, "clinic", "") or "",
+            "patient_code": getattr(pt, "patient_code", "") or "",
+            "date": _fmt_date(getattr(fb, "date", None)),
+            "steps": str(getattr(fb, "steps", "") or ""),
+            "active_minutes": str(getattr(fb, "active_minutes", "") or ""),
+            "sleep_duration_min": sleep_min,
+            "resting_heart_rate": str(getattr(fb, "resting_heart_rate", "") or ""),
+            "max_heart_rate": str(getattr(fb, "max_heart_rate", "") or ""),
+            "calories": str(getattr(fb, "calories", "") or ""),
+            "distance_km": str(getattr(fb, "distance", "") or ""),
+            "weight_kg": str(getattr(fb, "weight_kg", "") or ""),
+            "bp_sys": str(getattr(fb, "bp_sys", "") or ""),
+            "bp_dia": str(getattr(fb, "bp_dia", "") or ""),
+        })
+    return _make_csv(headers, rows)
+
+
+def _csv_questionnaire_answers(patient_map):
+    """PatientICFRating — health-status questionnaire responses."""
+    headers = [
+        "clinic", "patient_code", "date", "icf_code",
+        "question_key", "rating", "comment",
+    ]
+    rows = []
+    pt_ids = list(patient_map.keys())
+    ratings = list(PatientICFRating.objects(patientId__in=pt_ids).order_by("date"))
+    for r in ratings:
+        try:
+            pt_id = str(r.patientId.id) if hasattr(r.patientId, "id") else str(r.patientId)
+        except Exception:
+            continue
+        pt = patient_map.get(pt_id)
+        if not pt:
+            continue
+        # Resolve question key
+        try:
+            q_key = getattr(r.questionId, "questionKey", "") or ""
+        except Exception:
+            q_key = ""
+        # Comments from nested feedback_entries
+        comments = "; ".join(
+            (getattr(fe, "comment", "") or "")
+            for fe in (getattr(r, "feedback_entries", None) or [])
+            if (getattr(fe, "comment", "") or "").strip()
+        )
+        rows.append({
+            "clinic": getattr(pt, "clinic", "") or "",
+            "patient_code": getattr(pt, "patient_code", "") or "",
+            "date": _fmt_date(getattr(r, "date", None)),
+            "icf_code": getattr(r, "icfCode", "") or "",
+            "question_key": q_key,
+            "rating": str(getattr(r, "rating", "") or ""),
+            "comment": comments,
+        })
+    return _make_csv(headers, rows)
+
+
+def _csv_thresholds(patients):
+    headers = [
+        "clinic", "patient_code",
+        "steps_goal",
+        "active_minutes_green", "active_minutes_yellow",
+        "sleep_green_min", "sleep_yellow_min",
+        "bp_sys_green_max", "bp_sys_yellow_max",
+        "bp_dia_green_max", "bp_dia_yellow_max",
+    ]
+    rows = []
+    for pt in patients:
+        th = getattr(pt, "thresholds", None)
+        if th is None:
+            continue
+        rows.append({
+            "clinic": getattr(pt, "clinic", "") or "",
+            "patient_code": getattr(pt, "patient_code", "") or "",
+            "steps_goal": str(getattr(th, "steps_goal", "") or ""),
+            "active_minutes_green": str(getattr(th, "active_minutes_green", "") or ""),
+            "active_minutes_yellow": str(getattr(th, "active_minutes_yellow", "") or ""),
+            "sleep_green_min": str(getattr(th, "sleep_green_min", "") or ""),
+            "sleep_yellow_min": str(getattr(th, "sleep_yellow_min", "") or ""),
+            "bp_sys_green_max": str(getattr(th, "bp_sys_green_max", "") or ""),
+            "bp_sys_yellow_max": str(getattr(th, "bp_sys_yellow_max", "") or ""),
+            "bp_dia_green_max": str(getattr(th, "bp_dia_green_max", "") or ""),
+            "bp_dia_yellow_max": str(getattr(th, "bp_dia_yellow_max", "") or ""),
+        })
+    return _make_csv(headers, rows)
+
+
+def _csv_threshold_history(patients):
+    headers = [
+        "clinic", "patient_code", "effective_from", "changed_by", "reason",
+        "steps_goal",
+        "active_minutes_green", "active_minutes_yellow",
+        "sleep_green_min", "sleep_yellow_min",
+        "bp_sys_green_max", "bp_sys_yellow_max",
+        "bp_dia_green_max", "bp_dia_yellow_max",
+    ]
+    rows = []
+    for pt in patients:
+        for snap in (getattr(pt, "thresholds_history", None) or []):
+            th = getattr(snap, "thresholds", None)
+            rows.append({
+                "clinic": getattr(pt, "clinic", "") or "",
+                "patient_code": getattr(pt, "patient_code", "") or "",
+                "effective_from": _fmt_datetime(getattr(snap, "effective_from", None)),
+                "changed_by": getattr(snap, "changed_by", "") or "",
+                "reason": getattr(snap, "reason", "") or "",
+                "steps_goal": str(getattr(th, "steps_goal", "") or "") if th else "",
+                "active_minutes_green": str(getattr(th, "active_minutes_green", "") or "") if th else "",
+                "active_minutes_yellow": str(getattr(th, "active_minutes_yellow", "") or "") if th else "",
+                "sleep_green_min": str(getattr(th, "sleep_green_min", "") or "") if th else "",
+                "sleep_yellow_min": str(getattr(th, "sleep_yellow_min", "") or "") if th else "",
+                "bp_sys_green_max": str(getattr(th, "bp_sys_green_max", "") or "") if th else "",
+                "bp_sys_yellow_max": str(getattr(th, "bp_sys_yellow_max", "") or "") if th else "",
+                "bp_dia_green_max": str(getattr(th, "bp_dia_green_max", "") or "") if th else "",
+                "bp_dia_yellow_max": str(getattr(th, "bp_dia_yellow_max", "") or "") if th else "",
+            })
+    return _make_csv(headers, rows)
+
+
+def _csv_activity_logs(patient_map):
+    """Logs documents where the patient field matches a patient in the export scope."""
+    headers = [
+        "clinic", "patient_code", "action",
+        "timestamp", "actor_role", "details",
+    ]
+    rows = []
+    pt_ids = list(patient_map.keys())
+    activity_logs = list(Logs.objects(patient__in=pt_ids).order_by("-timestamp"))
+    for log in activity_logs:
+        try:
+            pt_ref = getattr(log, "patient", None)
+            pt_id = str(pt_ref.id) if pt_ref and hasattr(pt_ref, "id") else str(pt_ref) if pt_ref else None
+        except Exception:
+            pt_id = None
+        pt = patient_map.get(pt_id) if pt_id else None
+        rows.append({
+            "clinic": getattr(pt, "clinic", "") if pt else "",
+            "patient_code": getattr(pt, "patient_code", "") if pt else "",
+            "action": getattr(log, "action", "") or "",
+            "timestamp": _fmt_datetime(getattr(log, "timestamp", None)),
+            "actor_role": getattr(log, "actor_role", "") or "",
+            "details": getattr(log, "details", "") or "",
+        })
+    return _make_csv(headers, rows)
+
+
+# ---------------------------------------------------------------------------
+# View functions
+# ---------------------------------------------------------------------------
 
 @csrf_exempt
 @permission_classes([IsAuthenticated])
 def admin_export_patients(request):
+    """
+    GET /api/admin/export/patients/?clinics=all
+    GET /api/admin/export/patients/?clinics=Inselspital,Bern
+
+    Returns a ZIP attachment containing one CSV per data type.
+    """
     if request.method != "GET":
         return JsonResponse({"error": "Method not allowed"}, status=405)
 
@@ -116,19 +486,42 @@ def admin_export_patients(request):
                 return JsonResponse({"error": "No valid clinic names provided"}, status=400)
             qs = Patient.objects(clinic__in=requested)
 
-        # Sort by clinic then patient_code for grouped output
         patients = list(qs.order_by("clinic", "patient_code"))
 
-        output = io.StringIO()
-        writer = csv.DictWriter(output, fieldnames=_HEADERS, extrasaction="ignore")
-        writer.writeheader()
+        # patient_id (str) → Patient doc — used for cross-collection lookups
+        patient_map = {str(pt.pk): pt for pt in patients}
+
+        # user_id (str) → Patient doc — used for FitbitData (indexed by User)
+        user_map = {}
         for pt in patients:
-            writer.writerow(_row(pt))
+            try:
+                uid = str(pt.userId.id) if hasattr(pt.userId, "id") else str(pt.userId)
+                user_map[uid] = pt
+            except Exception:
+                pass
+
+        sheets = [
+            ("patients.csv",               _csv_patients(patients)),
+            ("rehab_calendar.csv",          _csv_rehab_calendar(patients, patient_map)),
+            ("intervention_logs.csv",       _csv_intervention_logs(patient_map)),
+            ("intervention_feedback.csv",   _csv_intervention_feedback(patient_map)),
+            ("health_vitals.csv",           _csv_health_vitals(patient_map)),
+            ("health_fitbit.csv",           _csv_health_fitbit(patients, user_map)),
+            ("questionnaire_answers.csv",   _csv_questionnaire_answers(patient_map)),
+            ("thresholds.csv",              _csv_thresholds(patients)),
+            ("threshold_history.csv",       _csv_threshold_history(patients)),
+            ("activity_logs.csv",           _csv_activity_logs(patient_map)),
+        ]
+
+        zip_buf = io.BytesIO()
+        with zipfile.ZipFile(zip_buf, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+            for filename, csv_buf in sheets:
+                zf.writestr(filename, csv_buf.getvalue().encode("utf-8"))
 
         today = date.today().isoformat()
-        filename = f"patients_export_{today}.csv"
+        filename = f"export_{today}.zip"
 
-        response = HttpResponse(output.getvalue(), content_type="text/csv; charset=utf-8")
+        response = HttpResponse(zip_buf.getvalue(), content_type="application/zip")
         response["Content-Disposition"] = f'attachment; filename="{filename}"'
         return response
 
@@ -142,14 +535,16 @@ def admin_export_patients(request):
 def admin_export_clinics(request):
     """
     GET /api/admin/export/clinics/
-    Returns the list of distinct clinic names present in the Patient collection.
-    Used by the frontend to populate the clinic filter checkboxes.
+    Returns distinct clinic names present in the Patient collection.
+    Used by the frontend to populate the clinic-filter checkboxes.
     """
     if request.method != "GET":
         return JsonResponse({"error": "Method not allowed"}, status=405)
 
     try:
-        clinics = sorted({(getattr(p, "clinic", "") or "").strip() for p in Patient.objects.only("clinic")} - {""})
+        clinics = sorted(
+            {(getattr(p, "clinic", "") or "").strip() for p in Patient.objects.only("clinic")} - {""}
+        )
         return JsonResponse({"clinics": clinics}, status=200)
     except Exception:
         logger.exception("admin_export_clinics failed")

--- a/backend/tests/admin_export_views/TESTING.md
+++ b/backend/tests/admin_export_views/TESTING.md
@@ -10,54 +10,92 @@ endpoints under `/api/admin/export/`.
 
 | Endpoint | HTTP verb | View function | Tests |
 |---|---|---|---|
-| `/api/admin/export/patients/` | GET | `admin_export_patients` | 12 |
+| `/api/admin/export/patients/` | GET | `admin_export_patients` | 22 |
 | `/api/admin/export/clinics/` | GET | `admin_export_clinics` | 4 |
 
-**Total: 16 tests**
+**Total: 26 tests**
 
 ---
 
 ## Feature overview
 
-The export feature lets an Admin download patient data as a CSV file,
-optionally scoped to one or more clinics.
+The export feature lets an Admin download a complete snapshot of patient-related
+data as a ZIP archive, optionally scoped to one or more clinics.
 
 ```
 Admin GET /api/admin/export/clinics/
   → JSON list of distinct clinic names present in the Patient collection
 
 Admin GET /api/admin/export/patients/?clinics=all
-  → CSV attachment — all patients, sorted by clinic then patient_code
+  → ZIP attachment — all patients, all data types
 
 Admin GET /api/admin/export/patients/?clinics=Inselspital,Bern
-  → CSV attachment — only patients whose clinic matches the filter
+  → ZIP attachment — same data, filtered to those clinics
 ```
 
-### CSV column order
+### ZIP contents — one CSV per data type
 
-| Column | Source field |
-|---|---|
-| `clinic` | `Patient.clinic` |
-| `project` | `Patient.project` |
-| `patient_code` | `Patient.patient_code` |
-| `first_name` | `Patient.first_name` |
-| `last_name` | `Patient.name` |
-| `age` | `Patient.age` |
-| `sex` | `Patient.sex` |
-| `diagnosis` | `Patient.diagnosis` (list → semicolon-joined) |
-| `function` | `Patient.function` (list → semicolon-joined) |
-| `therapist` | `Therapist.first_name + Therapist.name` (safe dereference) |
-| `reha_end_date` | `Patient.reha_end_date` (YYYY-MM-DD) |
-| `study_end_date` | `Patient.study_end_date` (YYYY-MM-DD) |
-| `duration_days` | `Patient.duration` |
-| `preferred_language` | `Patient.preferred_language` |
-| `created_at` | `Patient.createdAt` (YYYY-MM-DD) |
+| File | Source model(s) | Description |
+|---|---|---|
+| `patients.csv` | `Patient` | Demographic data |
+| `rehab_calendar.csv` | `RehabilitationPlan` + `InterventionAssignment` | Scheduled intervention dates |
+| `intervention_logs.csv` | `PatientInterventionLogs` | Daily execution records |
+| `intervention_feedback.csv` | `FeedbackEntry` (embedded in logs) | Per-intervention questionnaire answers |
+| `health_vitals.csv` | `PatientVitals` | Manually entered weight and blood pressure |
+| `health_fitbit.csv` | `FitbitData` | Wearable data (steps, sleep, HR, …) |
+| `questionnaire_answers.csv` | `PatientICFRating` | Health-status ICF questionnaire responses |
+| `thresholds.csv` | `PatientThresholds` (embedded in Patient) | Current alert thresholds per patient |
+| `threshold_history.csv` | `PatientThresholdsSnapshot` (embedded list) | History of threshold changes |
+| `activity_logs.csv` | `Logs` | Platform activity events linked to patients |
 
-### Grouping
+### CSV column schemas
 
-Rows are sorted by `clinic` (ascending) then `patient_code` (ascending),
-so the file is naturally "grouped by clinic" without requiring a split into
-separate sheets.
+#### `patients.csv`
+`clinic`, `project`, `patient_code`, `first_name`, `last_name`, `age`, `sex`,
+`diagnosis` (`;`-joined), `function` (`;`-joined), `therapist`, `reha_end_date`,
+`study_end_date`, `duration_days`, `preferred_language`, `created_at`
+
+#### `rehab_calendar.csv`
+`clinic`, `patient_code`, `plan_status`, `plan_start`, `plan_end`,
+`intervention_external_id`, `intervention_title`, `scheduled_date`,
+`frequency`, `notes`
+— One row per scheduled date per `InterventionAssignment`; if an assignment has
+no dates, one row is emitted with an empty `scheduled_date`.
+
+#### `intervention_logs.csv`
+`clinic`, `patient_code`, `intervention_external_id`, `intervention_title`,
+`date`, `status` (`;`-joined list), `comments`, `created_at`
+
+#### `intervention_feedback.csv`
+`clinic`, `patient_code`, `intervention_external_id`, `log_date`,
+`feedback_date`, `question_key`, `answer_keys` (`;`-joined), `comment`
+
+#### `health_vitals.csv`
+`clinic`, `patient_code`, `date`, `weight_kg`, `bp_sys`, `bp_dia`,
+`source`, `note`
+
+#### `health_fitbit.csv`
+`clinic`, `patient_code`, `date`, `steps`, `active_minutes`,
+`sleep_duration_min`, `resting_heart_rate`, `max_heart_rate`,
+`calories`, `distance_km`, `weight_kg`, `bp_sys`, `bp_dia`
+— Resolved via `FitbitData.user → User → Patient` using a pre-built lookup map.
+
+#### `questionnaire_answers.csv`
+`clinic`, `patient_code`, `date`, `icf_code`, `question_key`, `rating`,
+`comment` (from nested `feedback_entries`)
+
+#### `thresholds.csv`
+`clinic`, `patient_code`, `steps_goal`, `active_minutes_green`,
+`active_minutes_yellow`, `sleep_green_min`, `sleep_yellow_min`,
+`bp_sys_green_max`, `bp_sys_yellow_max`, `bp_dia_green_max`, `bp_dia_yellow_max`
+
+#### `threshold_history.csv`
+`clinic`, `patient_code`, `effective_from`, `changed_by`, `reason`,
++ same threshold columns as above
+
+#### `activity_logs.csv`
+`clinic`, `patient_code`, `action`, `timestamp`, `actor_role`, `details`
+— Only logs where `Logs.patient` is set (i.e. patient-linked events).
 
 ---
 
@@ -67,32 +105,98 @@ separate sheets.
 
 | Parameter | Default | Description |
 |---|---|---|
-| `clinics` | `all` | Comma-separated clinic names, or the literal string `"all"` to include every patient |
+| `clinics` | `all` | Comma-separated clinic names, or `"all"` for every patient |
 
 ### Tests
 
+#### ZIP structure and response headers
+
 | Test | Scenario | Expected |
 |---|---|---|
-| `test_export_returns_csv_content_type` | GET with no params | 200, `Content-Type: text/csv` |
-| `test_export_returns_attachment_header` | GET with no params | `Content-Disposition` contains `attachment`, `patients_export_`, `.csv` |
-| `test_export_all_returns_all_patients` | Two patients in different clinics, no filter | Both patients present in CSV |
-| `test_export_clinics_all_param_returns_all_patients` | Two patients, `?clinics=all` | Both patients present in CSV |
-| `test_export_filters_by_single_clinic` | Two patients, filter to one clinic | Only the matching patient returned |
-| `test_export_filters_by_multiple_clinics` | Three patients in three clinics, filter to two | Exactly the two matching patients returned |
-| `test_export_csv_has_expected_headers` | GET with no params | Header row contains `clinic`, `project`, `patient_code`, `first_name`, `last_name`, `therapist`, `reha_end_date`, `preferred_language` |
-| `test_export_row_contains_correct_field_values` | One patient with specific data | Row values match patient fields; `reha_end_date` formatted as YYYY-MM-DD; `duration_days` as string |
-| `test_export_multivalued_fields_joined_by_semicolon` | Patient with `diagnosis=["Stroke","Parkinson"]` and `function=["balance","coordination"]` | Fields serialised as `"Stroke; Parkinson"` and `"balance; coordination"` |
-| `test_export_grouped_sorted_by_clinic` | Three patients with clinics Zurich, Aachen, Bern | `clinic` column values are in ascending order |
-| `test_export_empty_when_clinic_not_in_db` | Filter to a clinic with no patients | Empty CSV (header row only) |
+| `test_export_returns_zip_content_type` | GET with no params | 200, `Content-Type: application/zip` |
+| `test_export_returns_attachment_header` | GET with no params | `Content-Disposition` contains `attachment`, `export_`, `.zip` |
+| `test_export_zip_contains_all_expected_csv_files` | GET with no params | ZIP namelist equals the 10-file set exactly |
 | `test_export_method_not_allowed` | POST | 405 |
+
+#### Clinic filtering
+
+| Test | Scenario | Expected |
+|---|---|---|
+| `test_export_all_includes_all_patients` | Two patients in different clinics, no filter | Both present in `patients.csv` |
+| `test_export_clinics_all_param_returns_all` | `?clinics=all` | Both patients returned |
+| `test_export_filters_by_single_clinic` | `?clinics=Inselspital` | Only the Inselspital patient returned |
+| `test_export_filters_by_multiple_clinics` | `?clinics=Inselspital,Bern` | Exactly those two patients |
+| `test_export_empty_when_clinic_not_in_db` | `?clinics=NonExistent` | `patients.csv` is header-only |
+
+#### `patients.csv`
+
+| Test | Scenario | Expected |
+|---|---|---|
+| `test_patients_csv_has_expected_headers` | GET | Header row contains all required column names |
+| `test_patients_csv_correct_field_values` | One patient with specific data | All fields match; list fields are semicolon-joined; date is YYYY-MM-DD |
+| `test_patients_csv_sorted_by_clinic` | Three patients with clinics Zurich, Aachen, Bern | Rows ordered alphabetically by clinic |
+
+#### `rehab_calendar.csv`
+
+| Test | Scenario | Expected |
+|---|---|---|
+| `test_rehab_calendar_csv_contains_scheduled_dates` | Plan with two scheduled dates | Two rows; correct `patient_code`, `clinic`, `intervention_external_id`, `scheduled_date`, `frequency`, `notes` |
+| `test_rehab_calendar_empty_without_plans` | Patient with no RehabilitationPlan | Empty CSV |
+
+#### `intervention_logs.csv`
+
+| Test | Scenario | Expected |
+|---|---|---|
+| `test_intervention_logs_csv_contains_log_rows` | One PatientInterventionLog | Row with correct `patient_code`, `clinic`, `status`, `comments`, `date` |
+
+#### `intervention_feedback.csv`
+
+| Test | Scenario | Expected |
+|---|---|---|
+| `test_intervention_feedback_csv_contains_feedback_entries` | Log with one FeedbackEntry referencing a FeedbackQuestion | Row with correct `question_key` and `comment` |
+
+#### `health_vitals.csv`
+
+| Test | Scenario | Expected |
+|---|---|---|
+| `test_health_vitals_csv_contains_vitals_rows` | One PatientVitals record | Row with `weight_kg`, `bp_sys`, `bp_dia`, `source` |
+
+#### `health_fitbit.csv`
+
+| Test | Scenario | Expected |
+|---|---|---|
+| `test_health_fitbit_csv_contains_fitbit_rows` | One FitbitData document | Row resolved via user → patient; correct `steps`, `active_minutes`, `resting_heart_rate` |
+
+#### `questionnaire_answers.csv`
+
+| Test | Scenario | Expected |
+|---|---|---|
+| `test_questionnaire_answers_csv_contains_icf_ratings` | One PatientICFRating | Row with `icf_code`, `question_key`, `rating` |
+
+#### `thresholds.csv`
+
+| Test | Scenario | Expected |
+|---|---|---|
+| `test_thresholds_csv_contains_current_thresholds` | Patient with `steps_goal=12000` | Row reflects the updated value |
+
+#### `threshold_history.csv`
+
+| Test | Scenario | Expected |
+|---|---|---|
+| `test_threshold_history_csv_contains_snapshots` | One PatientThresholdsSnapshot | Row with `changed_by`, `reason`, `effective_from`, `steps_goal` |
+
+#### `activity_logs.csv`
+
+| Test | Scenario | Expected |
+|---|---|---|
+| `test_activity_logs_csv_contains_patient_logs` | One Logs document with `patient` reference | Row with `action`, `actor_role`, `details`, resolved `patient_code` and `clinic` |
 
 ---
 
 ## `admin_export_clinics` — `GET /api/admin/export/clinics/`
 
 Returns a sorted JSON list of distinct, non-empty clinic names from the
-Patient collection.  The frontend uses this to populate the clinic-filter
-checkboxes so the list stays in sync with whatever is actually in the database.
+Patient collection. Used by the frontend to populate checkboxes dynamically.
 
 ### Response shape
 
@@ -105,7 +209,7 @@ checkboxes so the list stays in sync with whatever is actually in the database.
 | Test | Scenario | Expected |
 |---|---|---|
 | `test_clinics_returns_200` | GET | 200, `clinics` key present |
-| `test_clinics_returns_distinct_non_empty_names` | Two patients in `Inselspital`, one in `Bern` | `["Bern", "Inselspital"]` (no duplicates, sorted) |
+| `test_clinics_returns_distinct_sorted_names` | Two patients in `Inselspital`, one in `Bern` | `["Bern", "Inselspital"]` |
 | `test_clinics_empty_when_no_patients` | Empty DB | `{ "clinics": [] }` |
 | `test_clinics_method_not_allowed` | POST | 405 |
 
@@ -114,7 +218,6 @@ checkboxes so the list stays in sync with whatever is actually in the database.
 ## Running the tests
 
 ```bash
-# From the project root (runs inside the django container)
 docker exec django pytest tests/admin_export_views/ -v
 ```
 
@@ -124,14 +227,14 @@ docker exec django pytest tests/admin_export_views/ -v
 
 ### `mongo_mock` fixture
 
-Function-scoped `autouse` fixture that connects to an in-memory mongomock
-instance for every test and disconnects after.  Tests are fully isolated —
-no shared state between test functions.
+Function-scoped `autouse` fixture — clean in-memory mongomock per test.
 
 ### Factory helpers
 
 | Helper | Creates |
 |---|---|
-| `_make_therapist(suffix)` | A `User` + `Therapist` document |
-| `_make_patient(therapist, patient_code, clinic, ...)` | A `User` + `Patient` document with the given attributes |
-| `_parse_csv(response)` | Decodes the response body as UTF-8 and returns a list of `dict` rows via `csv.DictReader` |
+| `_make_therapist(suffix)` | `User` + `Therapist` |
+| `_make_patient(therapist, patient_code, clinic, ...)` | `User` + `Patient` |
+| `_make_intervention(external_id, language)` | `Intervention` |
+| `_open_zip(response)` | Returns `ZipFile` from HTTP response bytes |
+| `_read_csv_from_zip(zf, filename)` | Returns list of row dicts from a named CSV in the ZIP |

--- a/backend/tests/admin_export_views/TESTING.md
+++ b/backend/tests/admin_export_views/TESTING.md
@@ -1,0 +1,137 @@
+# Admin Export Views — Test Documentation
+
+This document describes every test in
+[`test_admin_export_views.py`](test_admin_export_views.py) for the two
+endpoints under `/api/admin/export/`.
+
+---
+
+## Endpoints and their test coverage
+
+| Endpoint | HTTP verb | View function | Tests |
+|---|---|---|---|
+| `/api/admin/export/patients/` | GET | `admin_export_patients` | 12 |
+| `/api/admin/export/clinics/` | GET | `admin_export_clinics` | 4 |
+
+**Total: 16 tests**
+
+---
+
+## Feature overview
+
+The export feature lets an Admin download patient data as a CSV file,
+optionally scoped to one or more clinics.
+
+```
+Admin GET /api/admin/export/clinics/
+  → JSON list of distinct clinic names present in the Patient collection
+
+Admin GET /api/admin/export/patients/?clinics=all
+  → CSV attachment — all patients, sorted by clinic then patient_code
+
+Admin GET /api/admin/export/patients/?clinics=Inselspital,Bern
+  → CSV attachment — only patients whose clinic matches the filter
+```
+
+### CSV column order
+
+| Column | Source field |
+|---|---|
+| `clinic` | `Patient.clinic` |
+| `project` | `Patient.project` |
+| `patient_code` | `Patient.patient_code` |
+| `first_name` | `Patient.first_name` |
+| `last_name` | `Patient.name` |
+| `age` | `Patient.age` |
+| `sex` | `Patient.sex` |
+| `diagnosis` | `Patient.diagnosis` (list → semicolon-joined) |
+| `function` | `Patient.function` (list → semicolon-joined) |
+| `therapist` | `Therapist.first_name + Therapist.name` (safe dereference) |
+| `reha_end_date` | `Patient.reha_end_date` (YYYY-MM-DD) |
+| `study_end_date` | `Patient.study_end_date` (YYYY-MM-DD) |
+| `duration_days` | `Patient.duration` |
+| `preferred_language` | `Patient.preferred_language` |
+| `created_at` | `Patient.createdAt` (YYYY-MM-DD) |
+
+### Grouping
+
+Rows are sorted by `clinic` (ascending) then `patient_code` (ascending),
+so the file is naturally "grouped by clinic" without requiring a split into
+separate sheets.
+
+---
+
+## `admin_export_patients` — `GET /api/admin/export/patients/`
+
+### Query parameters
+
+| Parameter | Default | Description |
+|---|---|---|
+| `clinics` | `all` | Comma-separated clinic names, or the literal string `"all"` to include every patient |
+
+### Tests
+
+| Test | Scenario | Expected |
+|---|---|---|
+| `test_export_returns_csv_content_type` | GET with no params | 200, `Content-Type: text/csv` |
+| `test_export_returns_attachment_header` | GET with no params | `Content-Disposition` contains `attachment`, `patients_export_`, `.csv` |
+| `test_export_all_returns_all_patients` | Two patients in different clinics, no filter | Both patients present in CSV |
+| `test_export_clinics_all_param_returns_all_patients` | Two patients, `?clinics=all` | Both patients present in CSV |
+| `test_export_filters_by_single_clinic` | Two patients, filter to one clinic | Only the matching patient returned |
+| `test_export_filters_by_multiple_clinics` | Three patients in three clinics, filter to two | Exactly the two matching patients returned |
+| `test_export_csv_has_expected_headers` | GET with no params | Header row contains `clinic`, `project`, `patient_code`, `first_name`, `last_name`, `therapist`, `reha_end_date`, `preferred_language` |
+| `test_export_row_contains_correct_field_values` | One patient with specific data | Row values match patient fields; `reha_end_date` formatted as YYYY-MM-DD; `duration_days` as string |
+| `test_export_multivalued_fields_joined_by_semicolon` | Patient with `diagnosis=["Stroke","Parkinson"]` and `function=["balance","coordination"]` | Fields serialised as `"Stroke; Parkinson"` and `"balance; coordination"` |
+| `test_export_grouped_sorted_by_clinic` | Three patients with clinics Zurich, Aachen, Bern | `clinic` column values are in ascending order |
+| `test_export_empty_when_clinic_not_in_db` | Filter to a clinic with no patients | Empty CSV (header row only) |
+| `test_export_method_not_allowed` | POST | 405 |
+
+---
+
+## `admin_export_clinics` — `GET /api/admin/export/clinics/`
+
+Returns a sorted JSON list of distinct, non-empty clinic names from the
+Patient collection.  The frontend uses this to populate the clinic-filter
+checkboxes so the list stays in sync with whatever is actually in the database.
+
+### Response shape
+
+```json
+{ "clinics": ["Bern", "Inselspital", "Leuven"] }
+```
+
+### Tests
+
+| Test | Scenario | Expected |
+|---|---|---|
+| `test_clinics_returns_200` | GET | 200, `clinics` key present |
+| `test_clinics_returns_distinct_non_empty_names` | Two patients in `Inselspital`, one in `Bern` | `["Bern", "Inselspital"]` (no duplicates, sorted) |
+| `test_clinics_empty_when_no_patients` | Empty DB | `{ "clinics": [] }` |
+| `test_clinics_method_not_allowed` | POST | 405 |
+
+---
+
+## Running the tests
+
+```bash
+# From the project root (runs inside the django container)
+docker exec django pytest tests/admin_export_views/ -v
+```
+
+---
+
+## Test infrastructure
+
+### `mongo_mock` fixture
+
+Function-scoped `autouse` fixture that connects to an in-memory mongomock
+instance for every test and disconnects after.  Tests are fully isolated —
+no shared state between test functions.
+
+### Factory helpers
+
+| Helper | Creates |
+|---|---|
+| `_make_therapist(suffix)` | A `User` + `Therapist` document |
+| `_make_patient(therapist, patient_code, clinic, ...)` | A `User` + `Patient` document with the given attributes |
+| `_parse_csv(response)` | Decodes the response body as UTF-8 and returns a list of `dict` rows via `csv.DictReader` |

--- a/backend/tests/admin_export_views/test_admin_export_views.py
+++ b/backend/tests/admin_export_views/test_admin_export_views.py
@@ -49,6 +49,8 @@ from core.models import (
     FeedbackEntry,
     FeedbackQuestion,
     FitbitData,
+    Intervention,
+    InterventionAssignment,
     Logs,
     Patient,
     PatientICFRating,
@@ -59,8 +61,6 @@ from core.models import (
     RehabilitationPlan,
     Therapist,
     User,
-    Intervention,
-    InterventionAssignment,
 )
 
 # ---------------------------------------------------------------------------
@@ -288,17 +288,30 @@ def test_patients_csv_has_expected_headers(mongo_mock):
     with _open_zip(resp) as zf:
         with zf.open("patients.csv") as f:
             header = f.read().decode("utf-8").splitlines()[0]
-    for col in ("clinic", "project", "patient_code", "first_name", "last_name",
-                "therapist", "reha_end_date", "preferred_language"):
+    for col in (
+        "clinic",
+        "project",
+        "patient_code",
+        "first_name",
+        "last_name",
+        "therapist",
+        "reha_end_date",
+        "preferred_language",
+    ):
         assert col in header
 
 
 def test_patients_csv_correct_field_values(mongo_mock):
     therapist = _make_therapist("x")
     _make_patient(
-        therapist, patient_code="PAT999", clinic="Inselspital", project="RehaStudy",
-        first_name="Zara", last_name="Doe",
-        diagnosis=["Stroke"], function=["mobility", "strength"],
+        therapist,
+        patient_code="PAT999",
+        clinic="Inselspital",
+        project="RehaStudy",
+        first_name="Zara",
+        last_name="Doe",
+        diagnosis=["Stroke"],
+        function=["mobility", "strength"],
     )
 
     with _open_zip(client.get(EXPORT_URL)) as zf:
@@ -386,8 +399,10 @@ def test_intervention_logs_csv_contains_log_rows(mongo_mock):
     patient = _make_patient(therapist, "P001", clinic="Inselspital")
     intervention = _make_intervention()
     plan = RehabilitationPlan(
-        patientId=patient, therapistId=therapist,
-        startDate=datetime(2025, 1, 1), endDate=datetime(2025, 3, 31),
+        patientId=patient,
+        therapistId=therapist,
+        startDate=datetime(2025, 1, 1),
+        endDate=datetime(2025, 3, 31),
         status="active",
     ).save()
 
@@ -421,8 +436,10 @@ def test_intervention_feedback_csv_contains_feedback_entries(mongo_mock):
     patient = _make_patient(therapist, "P001", clinic="Inselspital")
     intervention = _make_intervention()
     plan = RehabilitationPlan(
-        patientId=patient, therapistId=therapist,
-        startDate=datetime(2025, 1, 1), endDate=datetime(2025, 3, 31),
+        patientId=patient,
+        therapistId=therapist,
+        startDate=datetime(2025, 1, 1),
+        endDate=datetime(2025, 3, 31),
         status="active",
     ).save()
 

--- a/backend/tests/admin_export_views/test_admin_export_views.py
+++ b/backend/tests/admin_export_views/test_admin_export_views.py
@@ -1,0 +1,318 @@
+"""
+Admin export view tests
+— ``GET /api/admin/export/patients/``
+— ``GET /api/admin/export/clinics/``
+======================================
+
+Coverage
+--------
+Patient CSV export
+  * Returns 200 with Content-Type text/csv and Content-Disposition attachment.
+  * Includes all patients when no clinic filter is given.
+  * Includes all patients when clinics=all.
+  * Filters correctly to selected clinic(s).
+  * Excludes patients from clinics not in the requested list.
+  * CSV has the expected header row.
+  * CSV rows contain correct field values.
+  * Multi-value fields (diagnosis, function) are semicolon-joined.
+  * Returns 405 for non-GET requests.
+  * Returns 200 empty CSV (header only) when no patients match the filter.
+
+Clinics list endpoint
+  * Returns 200 with a ``clinics`` array.
+  * Array contains distinct, non-empty clinic names present in the DB.
+  * Returns empty list when no patients exist.
+  * Returns 405 for non-GET requests.
+
+Test setup
+----------
+Each test uses the ``mongo_mock`` autouse fixture providing an isolated
+in-memory mongomock connection.
+"""
+
+import csv
+import io
+from datetime import datetime
+
+import mongomock
+import pytest
+from django.test import Client
+from mongoengine import connect, disconnect
+
+from core.models import Patient, Therapist, User
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def mongo_mock():
+    alias = "default"
+    from mongoengine.connection import _connections
+
+    if alias in _connections:
+        disconnect(alias)
+
+    conn = connect(
+        "mongoenginetest",
+        alias=alias,
+        host="mongodb://localhost",
+        mongo_client_class=mongomock.MongoClient,
+    )
+    yield conn
+    disconnect(alias)
+
+
+client = Client()
+
+EXPORT_URL = "/api/admin/export/patients/"
+CLINICS_URL = "/api/admin/export/clinics/"
+
+
+# ---------------------------------------------------------------------------
+# Factory helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_therapist(suffix="a"):
+    user = User(
+        username=f"therapist_{suffix}",
+        email=f"th_{suffix}@example.com",
+        createdAt=datetime.now(),
+        isActive=True,
+    ).save()
+    return Therapist(
+        userId=user,
+        name=f"Last_{suffix}",
+        first_name=f"First_{suffix}",
+        specializations=[],
+        clinics=[],
+        default_recommendations=[],
+    ).save()
+
+
+def _make_patient(
+    therapist,
+    patient_code="PAT001",
+    clinic="Inselspital",
+    project="Project A",
+    first_name="Alice",
+    last_name="Smith",
+    diagnosis=None,
+    function=None,
+):
+    user = User(
+        username=f"patient_{patient_code}",
+        email=f"{patient_code}@example.com",
+        createdAt=datetime.now(),
+        isActive=True,
+    ).save()
+    return Patient(
+        userId=user,
+        patient_code=patient_code,
+        therapist=therapist,
+        name=last_name,
+        first_name=first_name,
+        clinic=clinic,
+        project=project,
+        diagnosis=diagnosis or [],
+        function=function or [],
+        reha_end_date=datetime(2025, 12, 31),
+        duration=90,
+        preferred_language="de",
+    ).save()
+
+
+def _parse_csv(response):
+    """Return list of dicts from a CSV response."""
+    text = response.content.decode("utf-8")
+    reader = csv.DictReader(io.StringIO(text))
+    return list(reader)
+
+
+# ===========================================================================
+# Patient CSV export — happy paths
+# ===========================================================================
+
+
+def test_export_returns_csv_content_type(mongo_mock):
+    resp = client.get(EXPORT_URL)
+
+    assert resp.status_code == 200
+    assert "text/csv" in resp["Content-Type"]
+
+
+def test_export_returns_attachment_header(mongo_mock):
+    resp = client.get(EXPORT_URL)
+
+    disposition = resp["Content-Disposition"]
+    assert "attachment" in disposition
+    assert "patients_export_" in disposition
+    assert ".csv" in disposition
+
+
+def test_export_all_returns_all_patients(mongo_mock):
+    therapist = _make_therapist()
+    _make_patient(therapist, "P001", clinic="Inselspital")
+    _make_patient(therapist, "P002", clinic="Bern")
+
+    rows = _parse_csv(client.get(EXPORT_URL))
+
+    codes = {r["patient_code"] for r in rows}
+    assert "P001" in codes
+    assert "P002" in codes
+
+
+def test_export_clinics_all_param_returns_all_patients(mongo_mock):
+    therapist = _make_therapist()
+    _make_patient(therapist, "P001", clinic="Inselspital")
+    _make_patient(therapist, "P002", clinic="Leuven")
+
+    rows = _parse_csv(client.get(EXPORT_URL + "?clinics=all"))
+
+    assert len(rows) == 2
+
+
+def test_export_filters_by_single_clinic(mongo_mock):
+    therapist = _make_therapist()
+    _make_patient(therapist, "P001", clinic="Inselspital")
+    _make_patient(therapist, "P002", clinic="Bern")
+
+    rows = _parse_csv(client.get(EXPORT_URL + "?clinics=Inselspital"))
+
+    assert len(rows) == 1
+    assert rows[0]["patient_code"] == "P001"
+    assert rows[0]["clinic"] == "Inselspital"
+
+
+def test_export_filters_by_multiple_clinics(mongo_mock):
+    therapist = _make_therapist()
+    _make_patient(therapist, "P001", clinic="Inselspital")
+    _make_patient(therapist, "P002", clinic="Bern")
+    _make_patient(therapist, "P003", clinic="Leuven")
+
+    rows = _parse_csv(client.get(EXPORT_URL + "?clinics=Inselspital,Bern"))
+
+    codes = {r["patient_code"] for r in rows}
+    assert codes == {"P001", "P002"}
+    assert "P003" not in codes
+
+
+def test_export_csv_has_expected_headers(mongo_mock):
+    resp = client.get(EXPORT_URL)
+    text = resp.content.decode("utf-8")
+    header_line = text.splitlines()[0]
+    headers = [h.strip() for h in header_line.split(",")]
+
+    for expected in [
+        "clinic",
+        "project",
+        "patient_code",
+        "first_name",
+        "last_name",
+        "therapist",
+        "reha_end_date",
+        "preferred_language",
+    ]:
+        assert expected in headers, f"Missing header: {expected}"
+
+
+def test_export_row_contains_correct_field_values(mongo_mock):
+    therapist = _make_therapist("x")
+    _make_patient(
+        therapist,
+        patient_code="PAT999",
+        clinic="Inselspital",
+        project="RehaStudy",
+        first_name="Zara",
+        last_name="Doe",
+        diagnosis=["Stroke"],
+        function=["mobility", "strength"],
+    )
+
+    rows = _parse_csv(client.get(EXPORT_URL))
+    assert len(rows) == 1
+    row = rows[0]
+
+    assert row["patient_code"] == "PAT999"
+    assert row["clinic"] == "Inselspital"
+    assert row["project"] == "RehaStudy"
+    assert row["first_name"] == "Zara"
+    assert row["last_name"] == "Doe"
+    assert row["preferred_language"] == "de"
+    assert row["reha_end_date"] == "2025-12-31"
+    assert row["duration_days"] == "90"
+
+
+def test_export_multivalued_fields_joined_by_semicolon(mongo_mock):
+    therapist = _make_therapist()
+    _make_patient(
+        therapist,
+        patient_code="MULTI01",
+        diagnosis=["Stroke", "Parkinson"],
+        function=["balance", "coordination"],
+    )
+
+    rows = _parse_csv(client.get(EXPORT_URL))
+    row = rows[0]
+
+    assert row["diagnosis"] == "Stroke; Parkinson"
+    assert row["function"] == "balance; coordination"
+
+
+def test_export_grouped_sorted_by_clinic(mongo_mock):
+    therapist = _make_therapist()
+    _make_patient(therapist, "P_Z", clinic="Zurich")
+    _make_patient(therapist, "P_A", clinic="Aachen")
+    _make_patient(therapist, "P_B", clinic="Bern")
+
+    rows = _parse_csv(client.get(EXPORT_URL))
+    clinic_order = [r["clinic"] for r in rows]
+
+    assert clinic_order == sorted(clinic_order), "Rows should be sorted by clinic"
+
+
+def test_export_empty_when_clinic_not_in_db(mongo_mock):
+    therapist = _make_therapist()
+    _make_patient(therapist, "P001", clinic="Inselspital")
+
+    rows = _parse_csv(client.get(EXPORT_URL + "?clinics=NonExistentClinic"))
+
+    assert rows == []
+
+
+def test_export_method_not_allowed(mongo_mock):
+    resp = client.post(EXPORT_URL, {})
+    assert resp.status_code == 405
+
+
+# ===========================================================================
+# Clinics list endpoint
+# ===========================================================================
+
+
+def test_clinics_returns_200(mongo_mock):
+    resp = client.get(CLINICS_URL)
+    assert resp.status_code == 200
+    assert "clinics" in resp.json()
+
+
+def test_clinics_returns_distinct_non_empty_names(mongo_mock):
+    therapist = _make_therapist()
+    _make_patient(therapist, "P001", clinic="Inselspital")
+    _make_patient(therapist, "P002", clinic="Inselspital")
+    _make_patient(therapist, "P003", clinic="Bern")
+
+    data = client.get(CLINICS_URL).json()
+    assert sorted(data["clinics"]) == ["Bern", "Inselspital"]
+
+
+def test_clinics_empty_when_no_patients(mongo_mock):
+    data = client.get(CLINICS_URL).json()
+    assert data["clinics"] == []
+
+
+def test_clinics_method_not_allowed(mongo_mock):
+    resp = client.post(CLINICS_URL, {})
+    assert resp.status_code == 405

--- a/backend/tests/admin_export_views/test_admin_export_views.py
+++ b/backend/tests/admin_export_views/test_admin_export_views.py
@@ -6,21 +6,26 @@ Admin export view tests
 
 Coverage
 --------
-Patient CSV export
-  * Returns 200 with Content-Type text/csv and Content-Disposition attachment.
-  * Includes all patients when no clinic filter is given.
-  * Includes all patients when clinics=all.
-  * Filters correctly to selected clinic(s).
-  * Excludes patients from clinics not in the requested list.
-  * CSV has the expected header row.
-  * CSV rows contain correct field values.
-  * Multi-value fields (diagnosis, function) are semicolon-joined.
+ZIP export (patients endpoint)
+  * Returns 200 with Content-Type application/zip and Content-Disposition attachment.
+  * ZIP contains exactly the expected set of CSV filenames.
+  * Clinic filter: all / single / multiple / unknown clinic.
+  * patients.csv: rows, column headers, semicolon-joined list fields, sorted by clinic.
+  * rehab_calendar.csv: one row per scheduled date per intervention assignment.
+  * intervention_logs.csv: one row per PatientInterventionLog, correct fields.
+  * intervention_feedback.csv: FeedbackEntry rows from intervention logs.
+  * health_vitals.csv: PatientVitals rows, correct fields.
+  * health_fitbit.csv: FitbitData rows resolved via user_id → patient.
+  * questionnaire_answers.csv: PatientICFRating rows with question_key and rating.
+  * thresholds.csv: current PatientThresholds per patient.
+  * threshold_history.csv: PatientThresholdsSnapshot history rows.
+  * activity_logs.csv: Logs documents linked to patients.
   * Returns 405 for non-GET requests.
-  * Returns 200 empty CSV (header only) when no patients match the filter.
+  * Returns 200 empty ZIP (header-only CSVs) when no patients match the filter.
 
 Clinics list endpoint
   * Returns 200 with a ``clinics`` array.
-  * Array contains distinct, non-empty clinic names present in the DB.
+  * Returns distinct, non-empty, sorted clinic names.
   * Returns empty list when no patients exist.
   * Returns 405 for non-GET requests.
 
@@ -32,6 +37,7 @@ in-memory mongomock connection.
 
 import csv
 import io
+import zipfile
 from datetime import datetime
 
 import mongomock
@@ -39,7 +45,23 @@ import pytest
 from django.test import Client
 from mongoengine import connect, disconnect
 
-from core.models import Patient, Therapist, User
+from core.models import (
+    FeedbackEntry,
+    FeedbackQuestion,
+    FitbitData,
+    Logs,
+    Patient,
+    PatientICFRating,
+    PatientInterventionLogs,
+    PatientThresholds,
+    PatientThresholdsSnapshot,
+    PatientVitals,
+    RehabilitationPlan,
+    Therapist,
+    User,
+    Intervention,
+    InterventionAssignment,
+)
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -68,6 +90,19 @@ client = Client()
 
 EXPORT_URL = "/api/admin/export/patients/"
 CLINICS_URL = "/api/admin/export/clinics/"
+
+EXPECTED_CSV_FILES = {
+    "patients.csv",
+    "rehab_calendar.csv",
+    "intervention_logs.csv",
+    "intervention_feedback.csv",
+    "health_vitals.csv",
+    "health_fitbit.csv",
+    "questionnaire_answers.csv",
+    "thresholds.csv",
+    "threshold_history.csv",
+    "activity_logs.csv",
+}
 
 
 # ---------------------------------------------------------------------------
@@ -124,52 +159,83 @@ def _make_patient(
     ).save()
 
 
-def _parse_csv(response):
-    """Return list of dicts from a CSV response."""
-    text = response.content.decode("utf-8")
-    reader = csv.DictReader(io.StringIO(text))
-    return list(reader)
+def _make_intervention(external_id="iv_001", language="en"):
+    return Intervention(
+        external_id=external_id,
+        language=language,
+        title=f"Intervention {external_id}",
+        description="desc",
+        content_type="Video",
+    ).save()
+
+
+def _open_zip(response):
+    """Return a ZipFile object from the HTTP response bytes."""
+    return zipfile.ZipFile(io.BytesIO(response.content))
+
+
+def _read_csv_from_zip(zf, filename):
+    """Return list of dicts for a named CSV inside the ZIP."""
+    with zf.open(filename) as f:
+        text = f.read().decode("utf-8")
+    return list(csv.DictReader(io.StringIO(text)))
 
 
 # ===========================================================================
-# Patient CSV export — happy paths
+# ZIP structure and response headers
 # ===========================================================================
 
 
-def test_export_returns_csv_content_type(mongo_mock):
+def test_export_returns_zip_content_type(mongo_mock):
     resp = client.get(EXPORT_URL)
-
     assert resp.status_code == 200
-    assert "text/csv" in resp["Content-Type"]
+    assert "application/zip" in resp["Content-Type"]
 
 
 def test_export_returns_attachment_header(mongo_mock):
     resp = client.get(EXPORT_URL)
+    disp = resp["Content-Disposition"]
+    assert "attachment" in disp
+    assert "export_" in disp
+    assert ".zip" in disp
 
-    disposition = resp["Content-Disposition"]
-    assert "attachment" in disposition
-    assert "patients_export_" in disposition
-    assert ".csv" in disposition
+
+def test_export_zip_contains_all_expected_csv_files(mongo_mock):
+    resp = client.get(EXPORT_URL)
+    with _open_zip(resp) as zf:
+        names = set(zf.namelist())
+    assert EXPECTED_CSV_FILES == names
 
 
-def test_export_all_returns_all_patients(mongo_mock):
+def test_export_method_not_allowed(mongo_mock):
+    resp = client.post(EXPORT_URL, {})
+    assert resp.status_code == 405
+
+
+# ===========================================================================
+# Clinic filtering
+# ===========================================================================
+
+
+def test_export_all_includes_all_patients(mongo_mock):
     therapist = _make_therapist()
     _make_patient(therapist, "P001", clinic="Inselspital")
     _make_patient(therapist, "P002", clinic="Bern")
 
-    rows = _parse_csv(client.get(EXPORT_URL))
+    with _open_zip(client.get(EXPORT_URL)) as zf:
+        rows = _read_csv_from_zip(zf, "patients.csv")
 
     codes = {r["patient_code"] for r in rows}
-    assert "P001" in codes
-    assert "P002" in codes
+    assert "P001" in codes and "P002" in codes
 
 
-def test_export_clinics_all_param_returns_all_patients(mongo_mock):
+def test_export_clinics_all_param_returns_all(mongo_mock):
     therapist = _make_therapist()
     _make_patient(therapist, "P001", clinic="Inselspital")
     _make_patient(therapist, "P002", clinic="Leuven")
 
-    rows = _parse_csv(client.get(EXPORT_URL + "?clinics=all"))
+    with _open_zip(client.get(EXPORT_URL + "?clinics=all")) as zf:
+        rows = _read_csv_from_zip(zf, "patients.csv")
 
     assert len(rows) == 2
 
@@ -179,11 +245,10 @@ def test_export_filters_by_single_clinic(mongo_mock):
     _make_patient(therapist, "P001", clinic="Inselspital")
     _make_patient(therapist, "P002", clinic="Bern")
 
-    rows = _parse_csv(client.get(EXPORT_URL + "?clinics=Inselspital"))
+    with _open_zip(client.get(EXPORT_URL + "?clinics=Inselspital")) as zf:
+        rows = _read_csv_from_zip(zf, "patients.csv")
 
-    assert len(rows) == 1
-    assert rows[0]["patient_code"] == "P001"
-    assert rows[0]["clinic"] == "Inselspital"
+    assert len(rows) == 1 and rows[0]["patient_code"] == "P001"
 
 
 def test_export_filters_by_multiple_clinics(mongo_mock):
@@ -192,99 +257,371 @@ def test_export_filters_by_multiple_clinics(mongo_mock):
     _make_patient(therapist, "P002", clinic="Bern")
     _make_patient(therapist, "P003", clinic="Leuven")
 
-    rows = _parse_csv(client.get(EXPORT_URL + "?clinics=Inselspital,Bern"))
+    with _open_zip(client.get(EXPORT_URL + "?clinics=Inselspital,Bern")) as zf:
+        rows = _read_csv_from_zip(zf, "patients.csv")
 
     codes = {r["patient_code"] for r in rows}
     assert codes == {"P001", "P002"}
-    assert "P003" not in codes
-
-
-def test_export_csv_has_expected_headers(mongo_mock):
-    resp = client.get(EXPORT_URL)
-    text = resp.content.decode("utf-8")
-    header_line = text.splitlines()[0]
-    headers = [h.strip() for h in header_line.split(",")]
-
-    for expected in [
-        "clinic",
-        "project",
-        "patient_code",
-        "first_name",
-        "last_name",
-        "therapist",
-        "reha_end_date",
-        "preferred_language",
-    ]:
-        assert expected in headers, f"Missing header: {expected}"
-
-
-def test_export_row_contains_correct_field_values(mongo_mock):
-    therapist = _make_therapist("x")
-    _make_patient(
-        therapist,
-        patient_code="PAT999",
-        clinic="Inselspital",
-        project="RehaStudy",
-        first_name="Zara",
-        last_name="Doe",
-        diagnosis=["Stroke"],
-        function=["mobility", "strength"],
-    )
-
-    rows = _parse_csv(client.get(EXPORT_URL))
-    assert len(rows) == 1
-    row = rows[0]
-
-    assert row["patient_code"] == "PAT999"
-    assert row["clinic"] == "Inselspital"
-    assert row["project"] == "RehaStudy"
-    assert row["first_name"] == "Zara"
-    assert row["last_name"] == "Doe"
-    assert row["preferred_language"] == "de"
-    assert row["reha_end_date"] == "2025-12-31"
-    assert row["duration_days"] == "90"
-
-
-def test_export_multivalued_fields_joined_by_semicolon(mongo_mock):
-    therapist = _make_therapist()
-    _make_patient(
-        therapist,
-        patient_code="MULTI01",
-        diagnosis=["Stroke", "Parkinson"],
-        function=["balance", "coordination"],
-    )
-
-    rows = _parse_csv(client.get(EXPORT_URL))
-    row = rows[0]
-
-    assert row["diagnosis"] == "Stroke; Parkinson"
-    assert row["function"] == "balance; coordination"
-
-
-def test_export_grouped_sorted_by_clinic(mongo_mock):
-    therapist = _make_therapist()
-    _make_patient(therapist, "P_Z", clinic="Zurich")
-    _make_patient(therapist, "P_A", clinic="Aachen")
-    _make_patient(therapist, "P_B", clinic="Bern")
-
-    rows = _parse_csv(client.get(EXPORT_URL))
-    clinic_order = [r["clinic"] for r in rows]
-
-    assert clinic_order == sorted(clinic_order), "Rows should be sorted by clinic"
 
 
 def test_export_empty_when_clinic_not_in_db(mongo_mock):
     therapist = _make_therapist()
     _make_patient(therapist, "P001", clinic="Inselspital")
 
-    rows = _parse_csv(client.get(EXPORT_URL + "?clinics=NonExistentClinic"))
+    with _open_zip(client.get(EXPORT_URL + "?clinics=NonExistent")) as zf:
+        rows = _read_csv_from_zip(zf, "patients.csv")
 
     assert rows == []
 
 
-def test_export_method_not_allowed(mongo_mock):
-    resp = client.post(EXPORT_URL, {})
-    assert resp.status_code == 405
+# ===========================================================================
+# patients.csv
+# ===========================================================================
+
+
+def test_patients_csv_has_expected_headers(mongo_mock):
+    resp = client.get(EXPORT_URL)
+    with _open_zip(resp) as zf:
+        rows = _read_csv_from_zip(zf, "patients.csv")
+
+    # Even with no patients, the header row must define the keys
+    with _open_zip(resp) as zf:
+        with zf.open("patients.csv") as f:
+            header = f.read().decode("utf-8").splitlines()[0]
+    for col in ("clinic", "project", "patient_code", "first_name", "last_name",
+                "therapist", "reha_end_date", "preferred_language"):
+        assert col in header
+
+
+def test_patients_csv_correct_field_values(mongo_mock):
+    therapist = _make_therapist("x")
+    _make_patient(
+        therapist, patient_code="PAT999", clinic="Inselspital", project="RehaStudy",
+        first_name="Zara", last_name="Doe",
+        diagnosis=["Stroke"], function=["mobility", "strength"],
+    )
+
+    with _open_zip(client.get(EXPORT_URL)) as zf:
+        rows = _read_csv_from_zip(zf, "patients.csv")
+
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["patient_code"] == "PAT999"
+    assert row["clinic"] == "Inselspital"
+    assert row["first_name"] == "Zara"
+    assert row["last_name"] == "Doe"
+    assert row["diagnosis"] == "Stroke"
+    assert row["function"] == "mobility; strength"
+    assert row["reha_end_date"] == "2025-12-31"
+
+
+def test_patients_csv_sorted_by_clinic(mongo_mock):
+    therapist = _make_therapist()
+    _make_patient(therapist, "P_Z", clinic="Zurich")
+    _make_patient(therapist, "P_A", clinic="Aachen")
+    _make_patient(therapist, "P_B", clinic="Bern")
+
+    with _open_zip(client.get(EXPORT_URL)) as zf:
+        rows = _read_csv_from_zip(zf, "patients.csv")
+
+    clinics = [r["clinic"] for r in rows]
+    assert clinics == sorted(clinics)
+
+
+# ===========================================================================
+# rehab_calendar.csv
+# ===========================================================================
+
+
+def test_rehab_calendar_csv_contains_scheduled_dates(mongo_mock):
+    therapist = _make_therapist()
+    patient = _make_patient(therapist, "P001", clinic="Inselspital")
+    intervention = _make_intervention()
+
+    RehabilitationPlan(
+        patientId=patient,
+        therapistId=therapist,
+        startDate=datetime(2025, 1, 1),
+        endDate=datetime(2025, 3, 31),
+        status="active",
+        interventions=[
+            InterventionAssignment(
+                interventionId=intervention,
+                frequency="daily",
+                dates=[datetime(2025, 1, 5), datetime(2025, 1, 6)],
+                notes="warm up",
+            )
+        ],
+    ).save()
+
+    with _open_zip(client.get(EXPORT_URL)) as zf:
+        rows = _read_csv_from_zip(zf, "rehab_calendar.csv")
+
+    assert len(rows) == 2
+    assert rows[0]["patient_code"] == "P001"
+    assert rows[0]["clinic"] == "Inselspital"
+    assert rows[0]["intervention_external_id"] == "iv_001"
+    assert rows[0]["scheduled_date"] == "2025-01-05"
+    assert rows[0]["frequency"] == "daily"
+    assert rows[0]["notes"] == "warm up"
+
+
+def test_rehab_calendar_empty_without_plans(mongo_mock):
+    therapist = _make_therapist()
+    _make_patient(therapist, "P001")
+
+    with _open_zip(client.get(EXPORT_URL)) as zf:
+        rows = _read_csv_from_zip(zf, "rehab_calendar.csv")
+
+    assert rows == []
+
+
+# ===========================================================================
+# intervention_logs.csv
+# ===========================================================================
+
+
+def test_intervention_logs_csv_contains_log_rows(mongo_mock):
+    therapist = _make_therapist()
+    patient = _make_patient(therapist, "P001", clinic="Inselspital")
+    intervention = _make_intervention()
+    plan = RehabilitationPlan(
+        patientId=patient, therapistId=therapist,
+        startDate=datetime(2025, 1, 1), endDate=datetime(2025, 3, 31),
+        status="active",
+    ).save()
+
+    PatientInterventionLogs(
+        userId=patient,
+        interventionId=intervention,
+        rehabilitationPlanId=plan,
+        date=datetime(2025, 1, 10),
+        status=["completed"],
+        comments="felt good",
+    ).save()
+
+    with _open_zip(client.get(EXPORT_URL)) as zf:
+        rows = _read_csv_from_zip(zf, "intervention_logs.csv")
+
+    assert len(rows) == 1
+    assert rows[0]["patient_code"] == "P001"
+    assert rows[0]["clinic"] == "Inselspital"
+    assert rows[0]["status"] == "completed"
+    assert rows[0]["comments"] == "felt good"
+    assert rows[0]["date"] == "2025-01-10"
+
+
+# ===========================================================================
+# intervention_feedback.csv
+# ===========================================================================
+
+
+def test_intervention_feedback_csv_contains_feedback_entries(mongo_mock):
+    therapist = _make_therapist()
+    patient = _make_patient(therapist, "P001", clinic="Inselspital")
+    intervention = _make_intervention()
+    plan = RehabilitationPlan(
+        patientId=patient, therapistId=therapist,
+        startDate=datetime(2025, 1, 1), endDate=datetime(2025, 3, 31),
+        status="active",
+    ).save()
+
+    question = FeedbackQuestion(
+        questionSubject="Intervention",
+        questionKey="pain_level",
+        answer_type="select",
+    ).save()
+
+    PatientInterventionLogs(
+        userId=patient,
+        interventionId=intervention,
+        rehabilitationPlanId=plan,
+        date=datetime(2025, 1, 10),
+        status=["completed"],
+        feedback=[FeedbackEntry(questionId=question, comment="no pain")],
+    ).save()
+
+    with _open_zip(client.get(EXPORT_URL)) as zf:
+        rows = _read_csv_from_zip(zf, "intervention_feedback.csv")
+
+    assert len(rows) == 1
+    assert rows[0]["patient_code"] == "P001"
+    assert rows[0]["question_key"] == "pain_level"
+    assert rows[0]["comment"] == "no pain"
+
+
+# ===========================================================================
+# health_vitals.csv
+# ===========================================================================
+
+
+def test_health_vitals_csv_contains_vitals_rows(mongo_mock):
+    therapist = _make_therapist()
+    patient = _make_patient(therapist, "P001", clinic="Inselspital")
+
+    PatientVitals(
+        user=patient.userId,
+        patientId=patient,
+        date=datetime(2025, 2, 1),
+        weight_kg=72.5,
+        bp_sys=120,
+        bp_dia=80,
+        source="manual",
+    ).save()
+
+    with _open_zip(client.get(EXPORT_URL)) as zf:
+        rows = _read_csv_from_zip(zf, "health_vitals.csv")
+
+    assert len(rows) == 1
+    assert rows[0]["patient_code"] == "P001"
+    assert rows[0]["clinic"] == "Inselspital"
+    assert rows[0]["weight_kg"] == "72.5"
+    assert rows[0]["bp_sys"] == "120"
+    assert rows[0]["bp_dia"] == "80"
+    assert rows[0]["source"] == "manual"
+
+
+# ===========================================================================
+# health_fitbit.csv
+# ===========================================================================
+
+
+def test_health_fitbit_csv_contains_fitbit_rows(mongo_mock):
+    therapist = _make_therapist()
+    patient = _make_patient(therapist, "P001", clinic="Inselspital")
+
+    FitbitData(
+        user=patient.userId,
+        date=datetime(2025, 3, 1),
+        steps=8500,
+        active_minutes=45,
+        resting_heart_rate=62,
+        calories=2100.0,
+        distance=6.2,
+    ).save()
+
+    with _open_zip(client.get(EXPORT_URL)) as zf:
+        rows = _read_csv_from_zip(zf, "health_fitbit.csv")
+
+    assert len(rows) == 1
+    assert rows[0]["patient_code"] == "P001"
+    assert rows[0]["clinic"] == "Inselspital"
+    assert rows[0]["steps"] == "8500"
+    assert rows[0]["active_minutes"] == "45"
+    assert rows[0]["resting_heart_rate"] == "62"
+
+
+# ===========================================================================
+# questionnaire_answers.csv
+# ===========================================================================
+
+
+def test_questionnaire_answers_csv_contains_icf_ratings(mongo_mock):
+    therapist = _make_therapist()
+    patient = _make_patient(therapist, "P001", clinic="Inselspital")
+
+    question = FeedbackQuestion(
+        questionSubject="Healthstatus",
+        questionKey="mobility_icf",
+        answer_type="select",
+        icfCode="d450",
+    ).save()
+
+    PatientICFRating(
+        questionId=question,
+        patientId=patient,
+        icfCode="d450",
+        date=datetime(2025, 4, 1),
+        rating=2,
+    ).save()
+
+    with _open_zip(client.get(EXPORT_URL)) as zf:
+        rows = _read_csv_from_zip(zf, "questionnaire_answers.csv")
+
+    assert len(rows) == 1
+    assert rows[0]["patient_code"] == "P001"
+    assert rows[0]["clinic"] == "Inselspital"
+    assert rows[0]["icf_code"] == "d450"
+    assert rows[0]["question_key"] == "mobility_icf"
+    assert rows[0]["rating"] == "2"
+
+
+# ===========================================================================
+# thresholds.csv
+# ===========================================================================
+
+
+def test_thresholds_csv_contains_current_thresholds(mongo_mock):
+    therapist = _make_therapist()
+    patient = _make_patient(therapist, "P001", clinic="Inselspital")
+    # Thresholds are an embedded doc with defaults; update a value to verify
+    patient.thresholds.steps_goal = 12000
+    patient.save()
+
+    with _open_zip(client.get(EXPORT_URL)) as zf:
+        rows = _read_csv_from_zip(zf, "thresholds.csv")
+
+    assert len(rows) == 1
+    assert rows[0]["patient_code"] == "P001"
+    assert rows[0]["steps_goal"] == "12000"
+
+
+# ===========================================================================
+# threshold_history.csv
+# ===========================================================================
+
+
+def test_threshold_history_csv_contains_snapshots(mongo_mock):
+    therapist = _make_therapist()
+    patient = _make_patient(therapist, "P001", clinic="Inselspital")
+
+    snap = PatientThresholdsSnapshot(
+        effective_from=datetime(2025, 1, 1),
+        changed_by="Therapist",
+        reason="increased goal",
+        thresholds=PatientThresholds(steps_goal=11000),
+    )
+    patient.thresholds_history = [snap]
+    patient.save()
+
+    with _open_zip(client.get(EXPORT_URL)) as zf:
+        rows = _read_csv_from_zip(zf, "threshold_history.csv")
+
+    assert len(rows) == 1
+    assert rows[0]["patient_code"] == "P001"
+    assert rows[0]["changed_by"] == "Therapist"
+    assert rows[0]["reason"] == "increased goal"
+    assert rows[0]["steps_goal"] == "11000"
+    assert rows[0]["effective_from"].startswith("2025-01-01")
+
+
+# ===========================================================================
+# activity_logs.csv
+# ===========================================================================
+
+
+def test_activity_logs_csv_contains_patient_logs(mongo_mock):
+    therapist = _make_therapist()
+    patient = _make_patient(therapist, "P001", clinic="Inselspital")
+
+    Logs(
+        userId=patient.userId,
+        action="INTERVENTION_COMPLETE",
+        timestamp=datetime(2025, 5, 1),
+        actor_role="Patient",
+        patient=patient,
+        details="completed session",
+    ).save()
+
+    with _open_zip(client.get(EXPORT_URL)) as zf:
+        rows = _read_csv_from_zip(zf, "activity_logs.csv")
+
+    assert len(rows) == 1
+    assert rows[0]["patient_code"] == "P001"
+    assert rows[0]["clinic"] == "Inselspital"
+    assert rows[0]["action"] == "INTERVENTION_COMPLETE"
+    assert rows[0]["actor_role"] == "Patient"
+    assert rows[0]["details"] == "completed session"
 
 
 # ===========================================================================
@@ -298,21 +635,19 @@ def test_clinics_returns_200(mongo_mock):
     assert "clinics" in resp.json()
 
 
-def test_clinics_returns_distinct_non_empty_names(mongo_mock):
+def test_clinics_returns_distinct_sorted_names(mongo_mock):
     therapist = _make_therapist()
     _make_patient(therapist, "P001", clinic="Inselspital")
     _make_patient(therapist, "P002", clinic="Inselspital")
     _make_patient(therapist, "P003", clinic="Bern")
 
     data = client.get(CLINICS_URL).json()
-    assert sorted(data["clinics"]) == ["Bern", "Inselspital"]
+    assert data["clinics"] == ["Bern", "Inselspital"]
 
 
 def test_clinics_empty_when_no_patients(mongo_mock):
-    data = client.get(CLINICS_URL).json()
-    assert data["clinics"] == []
+    assert client.get(CLINICS_URL).json()["clinics"] == []
 
 
 def test_clinics_method_not_allowed(mongo_mock):
-    resp = client.post(CLINICS_URL, {})
-    assert resp.status_code == 405
+    assert client.post(CLINICS_URL, {}).status_code == 405

--- a/backend/tests/admin_intervention_views/TESTING.md
+++ b/backend/tests/admin_intervention_views/TESTING.md
@@ -1,0 +1,139 @@
+# Admin Intervention Views — Test Documentation
+
+This document describes every test in
+[`test_admin_intervention_views.py`](test_admin_intervention_views.py) for
+the two endpoints under `/api/admin/interventions/`.
+
+---
+
+## Endpoints and their test coverage
+
+| Endpoint | HTTP verb | View function | Tests |
+|---|---|---|---|
+| `/api/admin/interventions/` | GET | `admin_interventions → _list_interventions` | 6 |
+| `/api/admin/interventions/<id>/` | DELETE | `admin_interventions → _delete_intervention` | 8 |
+
+**Total: 14 tests**
+
+---
+
+## Feature overview
+
+These endpoints give an Admin a way to browse the full intervention catalogue
+(including private interventions that are hidden from therapists and patients)
+and to permanently delete individual interventions with automatic cascade
+cleanup.
+
+```
+Admin GET /api/admin/interventions/
+  → JSON list of all Intervention documents (public + private)
+  → Optional filters: ?q=<search>, ?lang=<code>, ?content_type=<type>
+
+Admin DELETE /api/admin/interventions/<id>/
+  → Deletes the Intervention document
+  → Cascades to: media files, InterventionTemplate.recommendations,
+                 Therapist.default_recommendations,
+                 RehabilitationPlan.interventions,
+                 PatientInterventionLogs
+```
+
+---
+
+## `_list_interventions` — `GET /api/admin/interventions/`
+
+Returns all interventions regardless of `is_private`.  Supports optional
+filtering by language and title/external_id search.
+
+### Query parameters
+
+| Parameter | Description |
+|---|---|
+| `q` | Case-insensitive substring match against `title` or `external_id` |
+| `lang` | Exact match against `language` (e.g. `en`, `de`) |
+| `content_type` | Exact match against `content_type` (e.g. `Video`) |
+
+### Response shape
+
+```json
+{
+  "interventions": [
+    {
+      "_id": "…",
+      "external_id": "stretch_001",
+      "language": "en",
+      "title": "Stretching",
+      "content_type": "Video",
+      "is_private": false,
+      "provider": null,
+      "preview_img": ""
+    }
+  ]
+}
+```
+
+### Tests
+
+| Test | Scenario | Expected |
+|---|---|---|
+| `test_list_returns_all_interventions` | One public + one private intervention | Both appear in the response |
+| `test_list_empty_when_no_interventions` | Empty DB | `{ "interventions": [] }` |
+| `test_list_response_shape` | One intervention | Each item has `_id`, `external_id`, `language`, `title`, `content_type`, `is_private` |
+| `test_list_filter_by_lang` | Two interventions with different languages, `?lang=de` | Only the `de` intervention returned |
+| `test_list_search_by_title` | Two interventions, `?q=stretch` | Only the intervention with "stretch" in the title returned |
+| `test_list_search_by_external_id` | Three interventions, `?q=cardiac` | Only the two with "cardiac" in `external_id` returned |
+
+---
+
+## `_delete_intervention` — `DELETE /api/admin/interventions/<id>/`
+
+Permanently removes an `Intervention` document and all data that references
+it, in a safe order that avoids orphaned references.
+
+### Cascade order
+
+1. **Media files** — `default_storage.delete()` for each `Intervention.media[].file_path` and `Intervention.preview_img` (errors are logged and skipped, not fatal)
+2. **`InterventionTemplate.recommendations`** — the matching `DefaultInterventions` entry is removed from every template
+3. **`Therapist.default_recommendations`** — the matching entry is removed from every therapist
+4. **`RehabilitationPlan.interventions`** — the matching `InterventionAssignment` is removed from every plan
+5. **`PatientInterventionLogs`** — all log documents referencing the intervention are deleted
+6. **`Intervention`** — the document itself is deleted
+
+### Tests
+
+| Test | Scenario | Expected |
+|---|---|---|
+| `test_delete_removes_intervention` | Valid existing intervention id | 200, `Intervention.objects.count() == 0` |
+| `test_delete_returns_404_for_unknown_id` | Well-formed ObjectId not in DB | 404 |
+| `test_delete_returns_400_for_malformed_id` | Non-ObjectId string | 400 |
+| `test_delete_cascades_intervention_template_recommendations` | Intervention is in one template's `recommendations` | Template's `recommendations` list is empty after delete |
+| `test_delete_cascades_therapist_default_recommendations` | Intervention is in one therapist's `default_recommendations` | Therapist's list is empty after delete |
+| `test_delete_cascades_rehabilitation_plan_assignments` | Intervention is assigned in one rehab plan | Plan's `interventions` list is empty after delete |
+| `test_delete_cascades_patient_intervention_logs` | One `PatientInterventionLogs` document references the intervention | Log document is deleted |
+| `test_delete_get_method_not_allowed_on_single_route` | GET on `/api/admin/interventions/<id>/` | 405 (only DELETE is supported on the id-scoped route) |
+
+---
+
+## Running the tests
+
+```bash
+# From the project root (runs inside the django container)
+docker exec django pytest tests/admin_intervention_views/ -v
+```
+
+---
+
+## Test infrastructure
+
+### `mongo_mock` fixture
+
+Function-scoped `autouse` fixture that connects to an in-memory mongomock
+instance for every test and disconnects after.  Tests are fully isolated —
+no shared state between test functions.
+
+### Factory helpers
+
+| Helper | Creates |
+|---|---|
+| `_make_intervention(external_id, language, is_private, title)` | A single `Intervention` document |
+| `_make_therapist()` | A `User` + `Therapist` document |
+| `_make_patient(therapist)` | A `User` + `Patient` document linked to the given therapist |

--- a/frontend/src/__tests__/pages/AdminDashboard.TESTING.md
+++ b/frontend/src/__tests__/pages/AdminDashboard.TESTING.md
@@ -40,13 +40,20 @@ clinic.
 Both buttons use `apiClient.get` with `responseType: 'blob'` and trigger a
 browser download via a temporary `<a>` element.
 
+### ZIP contents
+
+Each download is a ZIP archive containing one CSV per data type:
+`patients`, `rehab_calendar`, `intervention_logs`, `intervention_feedback`,
+`health_vitals`, `health_fitbit`, `questionnaire_answers`, `thresholds`,
+`threshold_history`, `activity_logs`.
+
 ### Backend endpoints used
 
 | Endpoint                                      | Purpose                                                       |
 | --------------------------------------------- | ------------------------------------------------------------- |
 | `GET /api/admin/export/clinics/`              | Returns `{ clinics: string[] }` — distinct clinic names in DB |
-| `GET /api/admin/export/patients/?clinics=all` | Full export CSV                                               |
-| `GET /api/admin/export/patients/?clinics=A,B` | Partial export CSV                                            |
+| `GET /api/admin/export/patients/?clinics=all` | Full export ZIP |
+| `GET /api/admin/export/patients/?clinics=A,B` | Partial export ZIP |
 
 ---
 

--- a/frontend/src/__tests__/pages/AdminDashboard.TESTING.md
+++ b/frontend/src/__tests__/pages/AdminDashboard.TESTING.md
@@ -52,8 +52,8 @@ Each download is a ZIP archive containing one CSV per data type:
 | Endpoint                                      | Purpose                                                       |
 | --------------------------------------------- | ------------------------------------------------------------- |
 | `GET /api/admin/export/clinics/`              | Returns `{ clinics: string[] }` — distinct clinic names in DB |
-| `GET /api/admin/export/patients/?clinics=all` | Full export ZIP |
-| `GET /api/admin/export/patients/?clinics=A,B` | Partial export ZIP |
+| `GET /api/admin/export/patients/?clinics=all` | Full export ZIP                                               |
+| `GET /api/admin/export/patients/?clinics=A,B` | Partial export ZIP                                            |
 
 ---
 

--- a/frontend/src/__tests__/pages/AdminDashboard.TESTING.md
+++ b/frontend/src/__tests__/pages/AdminDashboard.TESTING.md
@@ -1,0 +1,109 @@
+# Admin Dashboard — Test Documentation
+
+Tests for the `AdminDashboard` page (`src/pages/AdminDashboard.tsx`) live in
+[`AdminDashboard.test.tsx`](AdminDashboard.test.tsx).
+
+---
+
+## Feature description
+
+`AdminDashboard` is the central control panel for users with role `Admin`.
+It is rendered at `/admin` and contains three tabs:
+
+| Tab key | Label | Purpose |
+|---|---|---|
+| `pending` | Pending registrations | Review and accept/decline newly registered users |
+| `access-requests` | Access change requests | Approve or decline therapist requests to change clinic/project assignments |
+| `export` | Export | Download patient data as a CSV file, optionally filtered by clinic |
+
+Non-admin users (or unauthenticated users) are immediately redirected to
+`/unauthorized` by the `AdminDashboardStore.init()` method.
+
+---
+
+## Export tab (feature #238)
+
+The Export tab lets an Admin download patient records as a CSV file grouped by
+clinic.
+
+### User flow
+
+1. On mount, the page fetches `GET /api/admin/export/clinics/` to retrieve the
+   distinct clinic names currently in the database.
+2. All clinics are pre-selected.  The admin can uncheck individual clinics or
+   use the "Select all" / "Deselect all" quick-toggle buttons.
+3. **Export all patients** — downloads `patients_export_<today>.csv` containing
+   every patient regardless of the checkboxes.
+4. **Export selected clinics (N)** — downloads the same CSV scoped to the
+   checked clinics.  The button is disabled when no clinics are selected.
+
+Both buttons use `apiClient.get` with `responseType: 'blob'` and trigger a
+browser download via a temporary `<a>` element.
+
+### Backend endpoints used
+
+| Endpoint | Purpose |
+|---|---|
+| `GET /api/admin/export/clinics/` | Returns `{ clinics: string[] }` — distinct clinic names in DB |
+| `GET /api/admin/export/patients/?clinics=all` | Full export CSV |
+| `GET /api/admin/export/patients/?clinics=A,B` | Partial export CSV |
+
+---
+
+## Tests
+
+### Auth / redirect
+
+| Test | Scenario | Expected |
+|---|---|---|
+| `redirects to unauthorized if user is not authenticated` | `isAuthenticated=false`, `userType=Therapist` | `navigate('/unauthorized')` called |
+
+### Pending registrations tab (Tab 1)
+
+| Test | Scenario | Expected |
+|---|---|---|
+| `renders pending entries correctly` | One pending entry in `adminStore.pendingEntries` | Name and email rendered in the table |
+| `calls acceptEntry when Accept button is clicked` | Entry present; user clicks Accept | `adminStore.acceptEntry` called with the entry id |
+| `calls declineEntry when Decline button is clicked and confirmed` | Entry present; user clicks Decline then confirms | `showDeclineConfirm` set to `true`; after `declineConfirmed()`, `adminStore.declineEntry` called |
+
+### Access change requests tab (Tab 2)
+
+| Test | Scenario | Expected |
+|---|---|---|
+| `fetches access change requests on mount` | Component mounts | `apiClient.get('/admin/access-change-requests/')` called |
+| `shows "Access change requests" tab with badge when requests exist` | One request returned | Tab label visible with badge |
+| `renders therapist name and email in access requests table` | One request with `therapistName: "Jane Doe"` | "Jane Doe" and email rendered after switching to tab |
+| `renders current and requested clinics/projects in access requests table` | Request has current=`Inselspital`, requested=`Berner Reha Centrum` | Both clinic names visible |
+| `calls approve endpoint when Approve button is clicked` | One pending request; Approve clicked | `apiClient.put('/admin/access-change-requests/req-1/', { action: 'approve' })` called |
+| `shows no pending message when change requests list is empty` | Empty requests list | "No pending access change requests" text visible |
+
+---
+
+## Mock strategy
+
+### `apiClient`
+
+`apiClient` is auto-mocked.  The default mock returns `{ data: { requests: [] } }` for
+GET calls (satisfies both `/admin/access-change-requests/` and
+`/admin/export/clinics/`) and `{ data: { ok: true } }` for PUT calls.
+
+### `AdminDashboardStore`
+
+Replaced with a hand-rolled mock that exposes `init`, `setError`,
+`accept`, `openDeclineConfirm`, `closeDeclineConfirm`, and `declineConfirmed`
+as `jest.fn()` stubs.  `init` replicates the real store's guard: it calls
+`authStore.checkAuthentication()` and redirects to `/unauthorized` if the user
+is not an authenticated Admin.
+
+### `adminStore` / `authStore`
+
+Both replaced with plain objects carrying observable-like properties.
+`adminStore.pendingEntries` is set per-test inside `beforeEach`.
+
+---
+
+## Running
+
+```bash
+docker exec react npx jest src/__tests__/pages/AdminDashboard.test.tsx --no-coverage
+```

--- a/frontend/src/__tests__/pages/AdminDashboard.TESTING.md
+++ b/frontend/src/__tests__/pages/AdminDashboard.TESTING.md
@@ -10,11 +10,11 @@ Tests for the `AdminDashboard` page (`src/pages/AdminDashboard.tsx`) live in
 `AdminDashboard` is the central control panel for users with role `Admin`.
 It is rendered at `/admin` and contains three tabs:
 
-| Tab key | Label | Purpose |
-|---|---|---|
-| `pending` | Pending registrations | Review and accept/decline newly registered users |
+| Tab key           | Label                  | Purpose                                                                    |
+| ----------------- | ---------------------- | -------------------------------------------------------------------------- |
+| `pending`         | Pending registrations  | Review and accept/decline newly registered users                           |
 | `access-requests` | Access change requests | Approve or decline therapist requests to change clinic/project assignments |
-| `export` | Export | Download patient data as a CSV file, optionally filtered by clinic |
+| `export`          | Export                 | Download patient data as a CSV file, optionally filtered by clinic         |
 
 Non-admin users (or unauthenticated users) are immediately redirected to
 `/unauthorized` by the `AdminDashboardStore.init()` method.
@@ -30,23 +30,23 @@ clinic.
 
 1. On mount, the page fetches `GET /api/admin/export/clinics/` to retrieve the
    distinct clinic names currently in the database.
-2. All clinics are pre-selected.  The admin can uncheck individual clinics or
+2. All clinics are pre-selected. The admin can uncheck individual clinics or
    use the "Select all" / "Deselect all" quick-toggle buttons.
 3. **Export all patients** — downloads `patients_export_<today>.csv` containing
    every patient regardless of the checkboxes.
 4. **Export selected clinics (N)** — downloads the same CSV scoped to the
-   checked clinics.  The button is disabled when no clinics are selected.
+   checked clinics. The button is disabled when no clinics are selected.
 
 Both buttons use `apiClient.get` with `responseType: 'blob'` and trigger a
 browser download via a temporary `<a>` element.
 
 ### Backend endpoints used
 
-| Endpoint | Purpose |
-|---|---|
-| `GET /api/admin/export/clinics/` | Returns `{ clinics: string[] }` — distinct clinic names in DB |
-| `GET /api/admin/export/patients/?clinics=all` | Full export CSV |
-| `GET /api/admin/export/patients/?clinics=A,B` | Partial export CSV |
+| Endpoint                                      | Purpose                                                       |
+| --------------------------------------------- | ------------------------------------------------------------- |
+| `GET /api/admin/export/clinics/`              | Returns `{ clinics: string[] }` — distinct clinic names in DB |
+| `GET /api/admin/export/patients/?clinics=all` | Full export CSV                                               |
+| `GET /api/admin/export/patients/?clinics=A,B` | Partial export CSV                                            |
 
 ---
 
@@ -54,28 +54,28 @@ browser download via a temporary `<a>` element.
 
 ### Auth / redirect
 
-| Test | Scenario | Expected |
-|---|---|---|
+| Test                                                     | Scenario                                      | Expected                           |
+| -------------------------------------------------------- | --------------------------------------------- | ---------------------------------- |
 | `redirects to unauthorized if user is not authenticated` | `isAuthenticated=false`, `userType=Therapist` | `navigate('/unauthorized')` called |
 
 ### Pending registrations tab (Tab 1)
 
-| Test | Scenario | Expected |
-|---|---|---|
-| `renders pending entries correctly` | One pending entry in `adminStore.pendingEntries` | Name and email rendered in the table |
-| `calls acceptEntry when Accept button is clicked` | Entry present; user clicks Accept | `adminStore.acceptEntry` called with the entry id |
+| Test                                                              | Scenario                                         | Expected                                                                                         |
+| ----------------------------------------------------------------- | ------------------------------------------------ | ------------------------------------------------------------------------------------------------ |
+| `renders pending entries correctly`                               | One pending entry in `adminStore.pendingEntries` | Name and email rendered in the table                                                             |
+| `calls acceptEntry when Accept button is clicked`                 | Entry present; user clicks Accept                | `adminStore.acceptEntry` called with the entry id                                                |
 | `calls declineEntry when Decline button is clicked and confirmed` | Entry present; user clicks Decline then confirms | `showDeclineConfirm` set to `true`; after `declineConfirmed()`, `adminStore.declineEntry` called |
 
 ### Access change requests tab (Tab 2)
 
-| Test | Scenario | Expected |
-|---|---|---|
-| `fetches access change requests on mount` | Component mounts | `apiClient.get('/admin/access-change-requests/')` called |
-| `shows "Access change requests" tab with badge when requests exist` | One request returned | Tab label visible with badge |
-| `renders therapist name and email in access requests table` | One request with `therapistName: "Jane Doe"` | "Jane Doe" and email rendered after switching to tab |
-| `renders current and requested clinics/projects in access requests table` | Request has current=`Inselspital`, requested=`Berner Reha Centrum` | Both clinic names visible |
-| `calls approve endpoint when Approve button is clicked` | One pending request; Approve clicked | `apiClient.put('/admin/access-change-requests/req-1/', { action: 'approve' })` called |
-| `shows no pending message when change requests list is empty` | Empty requests list | "No pending access change requests" text visible |
+| Test                                                                      | Scenario                                                           | Expected                                                                              |
+| ------------------------------------------------------------------------- | ------------------------------------------------------------------ | ------------------------------------------------------------------------------------- |
+| `fetches access change requests on mount`                                 | Component mounts                                                   | `apiClient.get('/admin/access-change-requests/')` called                              |
+| `shows "Access change requests" tab with badge when requests exist`       | One request returned                                               | Tab label visible with badge                                                          |
+| `renders therapist name and email in access requests table`               | One request with `therapistName: "Jane Doe"`                       | "Jane Doe" and email rendered after switching to tab                                  |
+| `renders current and requested clinics/projects in access requests table` | Request has current=`Inselspital`, requested=`Berner Reha Centrum` | Both clinic names visible                                                             |
+| `calls approve endpoint when Approve button is clicked`                   | One pending request; Approve clicked                               | `apiClient.put('/admin/access-change-requests/req-1/', { action: 'approve' })` called |
+| `shows no pending message when change requests list is empty`             | Empty requests list                                                | "No pending access change requests" text visible                                      |
 
 ---
 
@@ -83,7 +83,7 @@ browser download via a temporary `<a>` element.
 
 ### `apiClient`
 
-`apiClient` is auto-mocked.  The default mock returns `{ data: { requests: [] } }` for
+`apiClient` is auto-mocked. The default mock returns `{ data: { requests: [] } }` for
 GET calls (satisfies both `/admin/access-change-requests/` and
 `/admin/export/clinics/`) and `{ data: { ok: true } }` for PUT calls.
 
@@ -91,7 +91,7 @@ GET calls (satisfies both `/admin/access-change-requests/` and
 
 Replaced with a hand-rolled mock that exposes `init`, `setError`,
 `accept`, `openDeclineConfirm`, `closeDeclineConfirm`, and `declineConfirmed`
-as `jest.fn()` stubs.  `init` replicates the real store's guard: it calls
+as `jest.fn()` stubs. `init` replicates the real store's guard: it calls
 `authStore.checkAuthentication()` and redirects to `/unauthorized` if the user
 is not an authenticated Admin.
 

--- a/frontend/src/pages/AdminDashboard.tsx
+++ b/frontend/src/pages/AdminDashboard.tsx
@@ -164,11 +164,11 @@ const AdminDashboard: React.FC = observer(() => {
         responseType: 'blob',
       });
 
-      const url = URL.createObjectURL(new Blob([res.data], { type: 'text/csv' }));
+      const url = URL.createObjectURL(new Blob([res.data], { type: 'application/zip' }));
       const a = document.createElement('a');
       const today = new Date().toISOString().slice(0, 10);
       a.href = url;
-      a.download = `patients_export_${today}.csv`;
+      a.download = `export_${today}.zip`;
       document.body.appendChild(a);
       a.click();
       a.remove();
@@ -583,6 +583,12 @@ const AdminDashboard: React.FC = observer(() => {
                       </>
                     )}
 
+                    <p className="text-muted small mb-2">
+                      {t('The export is a ZIP archive containing:')}
+                      {' '}
+                      {t('patients, rehab calendar, intervention logs, feedback, health vitals, Fitbit data, questionnaire answers, thresholds, threshold history, activity logs.')}
+                    </p>
+
                     <div className="d-flex gap-2 flex-wrap">
                       <Button
                         variant="primary"
@@ -595,7 +601,7 @@ const AdminDashboard: React.FC = observer(() => {
                             {t('Exporting...')}
                           </>
                         ) : (
-                          t('Export all patients')
+                          t('Export all patients (ZIP)')
                         )}
                       </Button>
                       <Button

--- a/frontend/src/pages/AdminDashboard.tsx
+++ b/frontend/src/pages/AdminDashboard.tsx
@@ -539,7 +539,9 @@ const AdminDashboard: React.FC = observer(() => {
                   </div>
                 ) : (
                   <>
-                    <p className="text-muted mb-1">{t('Select clinics to include in the export:')}</p>
+                    <p className="text-muted mb-1">
+                      {t('Select clinics to include in the export:')}
+                    </p>
 
                     {exportClinics.length === 0 ? (
                       <Alert variant="info">{t('No clinics found in the database.')}</Alert>

--- a/frontend/src/pages/AdminDashboard.tsx
+++ b/frontend/src/pages/AdminDashboard.tsx
@@ -117,9 +117,73 @@ const AdminDashboard: React.FC = observer(() => {
     }
   };
 
+  // -------------------------
+  // Export tab
+  // -------------------------
+  const [exportClinics, setExportClinics] = useState<string[]>([]);
+  const [exportClinicsLoading, setExportClinicsLoading] = useState(false);
+  const [exportClinicsError, setExportClinicsError] = useState<string | null>(null);
+  const [selectedExportClinics, setSelectedExportClinics] = useState<string[]>([]);
+  const [exporting, setExporting] = useState(false);
+  const [exportError, setExportError] = useState<string | null>(null);
+
+  const fetchExportClinics = useCallback(async () => {
+    setExportClinicsLoading(true);
+    setExportClinicsError(null);
+    try {
+      const res = await apiClient.get('/admin/export/clinics/');
+      const clinics = Array.isArray(res.data?.clinics) ? res.data.clinics : [];
+      setExportClinics(clinics);
+      setSelectedExportClinics(clinics);
+    } catch (e: any) {
+      setExportClinicsError(e?.response?.data?.error || e?.message || 'Failed to load clinics.');
+    } finally {
+      setExportClinicsLoading(false);
+    }
+  }, []);
+
+  const toggleExportClinic = (clinic: string) => {
+    setSelectedExportClinics((prev) =>
+      prev.includes(clinic) ? prev.filter((c) => c !== clinic) : [...prev, clinic]
+    );
+  };
+
+  const selectAllExportClinics = () => setSelectedExportClinics([...exportClinics]);
+  const deselectAllExportClinics = () => setSelectedExportClinics([]);
+
+  const downloadExport = async (clinicFilter: 'all' | 'selected') => {
+    setExporting(true);
+    setExportError(null);
+    try {
+      const params =
+        clinicFilter === 'all'
+          ? 'clinics=all'
+          : `clinics=${encodeURIComponent(selectedExportClinics.join(','))}`;
+
+      const res = await apiClient.get(`/admin/export/patients/?${params}`, {
+        responseType: 'blob',
+      });
+
+      const url = URL.createObjectURL(new Blob([res.data], { type: 'text/csv' }));
+      const a = document.createElement('a');
+      const today = new Date().toISOString().slice(0, 10);
+      a.href = url;
+      a.download = `patients_export_${today}.csv`;
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      URL.revokeObjectURL(url);
+    } catch (e: any) {
+      setExportError(e?.response?.data?.error || e?.message || 'Export failed.');
+    } finally {
+      setExporting(false);
+    }
+  };
+
   useEffect(() => {
     store.init(navigate, t);
     fetchChangeRequests();
+    fetchExportClinics();
   }, [store, navigate, t]);
 
   const getTherapistIdFromEntry = (entry: any) => {
@@ -306,6 +370,9 @@ const AdminDashboard: React.FC = observer(() => {
                   )}
                 </Nav.Link>
               </Nav.Item>
+              <Nav.Item>
+                <Nav.Link eventKey="export">{t('Export')}</Nav.Link>
+              </Nav.Item>
             </Nav>
 
             <Tab.Content>
@@ -449,6 +516,100 @@ const AdminDashboard: React.FC = observer(() => {
                       ))}
                     </tbody>
                   </Table>
+                )}
+              </Tab.Pane>
+
+              {/* ── Tab 3: export ── */}
+              <Tab.Pane eventKey="export">
+                {exportClinicsError && (
+                  <Alert variant="danger" dismissible onClose={() => setExportClinicsError(null)}>
+                    {exportClinicsError}
+                  </Alert>
+                )}
+                {exportError && (
+                  <Alert variant="danger" dismissible onClose={() => setExportError(null)}>
+                    {exportError}
+                  </Alert>
+                )}
+
+                {exportClinicsLoading ? (
+                  <div className="text-center my-5">
+                    <Spinner animation="border" role="status" />
+                    <div>{t('Loading')}...</div>
+                  </div>
+                ) : (
+                  <>
+                    <p className="text-muted mb-1">{t('Select clinics to include in the export:')}</p>
+
+                    {exportClinics.length === 0 ? (
+                      <Alert variant="info">{t('No clinics found in the database.')}</Alert>
+                    ) : (
+                      <>
+                        <div className="d-flex gap-2 mb-2">
+                          <Button
+                            variant="outline-secondary"
+                            size="sm"
+                            onClick={selectAllExportClinics}
+                            disabled={selectedExportClinics.length === exportClinics.length}
+                          >
+                            {t('Select all')}
+                          </Button>
+                          <Button
+                            variant="outline-secondary"
+                            size="sm"
+                            onClick={deselectAllExportClinics}
+                            disabled={selectedExportClinics.length === 0}
+                          >
+                            {t('Deselect all')}
+                          </Button>
+                        </div>
+
+                        <Form className="mb-4">
+                          <div className="d-flex flex-wrap gap-3">
+                            {exportClinics.map((clinic) => (
+                              <Form.Check
+                                key={clinic}
+                                type="checkbox"
+                                id={`export_clinic_${clinic}`}
+                                label={clinic}
+                                checked={selectedExportClinics.includes(clinic)}
+                                onChange={() => toggleExportClinic(clinic)}
+                              />
+                            ))}
+                          </div>
+                        </Form>
+                      </>
+                    )}
+
+                    <div className="d-flex gap-2 flex-wrap">
+                      <Button
+                        variant="primary"
+                        onClick={() => downloadExport('all')}
+                        disabled={exporting}
+                      >
+                        {exporting ? (
+                          <>
+                            <Spinner animation="border" size="sm" className="me-2" />
+                            {t('Exporting...')}
+                          </>
+                        ) : (
+                          t('Export all patients')
+                        )}
+                      </Button>
+                      <Button
+                        variant="outline-primary"
+                        onClick={() => downloadExport('selected')}
+                        disabled={exporting || selectedExportClinics.length === 0}
+                        title={
+                          selectedExportClinics.length === 0
+                            ? t('Select at least one clinic')
+                            : undefined
+                        }
+                      >
+                        {t('Export selected clinics')} ({selectedExportClinics.length})
+                      </Button>
+                    </div>
+                  </>
                 )}
               </Tab.Pane>
             </Tab.Content>

--- a/frontend/src/pages/AdminDashboard.tsx
+++ b/frontend/src/pages/AdminDashboard.tsx
@@ -584,9 +584,10 @@ const AdminDashboard: React.FC = observer(() => {
                     )}
 
                     <p className="text-muted small mb-2">
-                      {t('The export is a ZIP archive containing:')}
-                      {' '}
-                      {t('patients, rehab calendar, intervention logs, feedback, health vitals, Fitbit data, questionnaire answers, thresholds, threshold history, activity logs.')}
+                      {t('The export is a ZIP archive containing:')}{' '}
+                      {t(
+                        'patients, rehab calendar, intervention logs, feedback, health vitals, Fitbit data, questionnaire answers, thresholds, threshold history, activity logs.'
+                      )}
                     </p>
 
                     <div className="d-flex gap-2 flex-wrap">


### PR DESCRIPTION
## Summary

- Add an **Export** tab to the Admin Dashboard that downloads a complete data snapshot as a ZIP archive, optionally scoped to selected clinics
- The ZIP contains **10 CSV files**, one per data type, all filtered by the same clinic selection and sorted by clinic then patient code
- New backend endpoint `GET /api/admin/export/patients/?clinics=all|A,B` returns the ZIP
- New backend endpoint `GET /api/admin/export/clinics/` returns distinct clinic names from the Patient collection, used to populate the filter checkboxes dynamically
- 26 backend tests — one per sheet plus filter/header/405 coverage

## ZIP contents

| File | Source |
|---|---|
| `patients.csv` | Demographics (name, diagnosis, function, therapist, dates, language) |
| `rehab_calendar.csv` | Scheduled intervention dates from `RehabilitationPlan` |
| `intervention_logs.csv` | `PatientInterventionLogs` execution records (status, comments) |
| `intervention_feedback.csv` | Per-intervention `FeedbackEntry` answers embedded in logs |
| `health_vitals.csv` | `PatientVitals` — manual weight and blood pressure entries |
| `health_fitbit.csv` | `FitbitData` — steps, sleep, HR, calories, wear time |
| `questionnaire_answers.csv` | `PatientICFRating` — ICF health-status questionnaire responses |
| `thresholds.csv` | Current `PatientThresholds` per patient |
| `threshold_history.csv` | `PatientThresholdsSnapshot` history — each change with `changed_by`, `reason`, `effective_from` |
| `activity_logs.csv` | `Logs` — platform events (logins, completions, imports) linked to patients |

## Test plan

- [ ] Log in as Admin → open the **Export** tab
- [ ] Clinic checkboxes load from the database (not hardcoded); all are pre-selected by default
- [ ] **Select all** / **Deselect all** toggles work; "Export selected clinics (N)" is disabled when none checked
- [ ] Click **Export all patients (ZIP)** → `export_<today>.zip` downloads
- [ ] Open the ZIP — all 10 CSV files are present, each with the correct header row
- [ ] Uncheck one clinic, click **Export selected clinics** → that clinic's patients are absent from all CSVs
- [ ] Backend: `docker exec django pytest tests/admin_export_views/ -v` → 26 passed
- [ ] Frontend: `docker exec react npx jest src/__tests__/pages/AdminDashboard.test.tsx --no-coverage` → 10 passed
