### PR TITLE
Feature/celery cert renewal

### DIFF
--- a/backend/Dockerfile.dev
+++ b/backend/Dockerfile.dev
@@ -3,7 +3,7 @@ WORKDIR /app
 
 # Install necessary system packages
 RUN apt-get update && \
-    apt-get -y install build-essential wget curl bzip2 libpq-dev gcc && \
+    apt-get -y install build-essential wget curl bzip2 libpq-dev gcc docker.io && \
     apt-get clean
 
 # Download and install Miniconda

--- a/backend/Dockerfile.prod
+++ b/backend/Dockerfile.prod
@@ -3,6 +3,9 @@ WORKDIR /app
 
 ENV PATH=/opt/conda/bin:$PATH
 
+# Install Docker CLI so the Celery cert-renewal task can call certbot via the Docker socket
+RUN apt-get update && apt-get install -y --no-install-recommends docker.io && apt-get clean && rm -rf /var/lib/apt/lists/*
+
 
 COPY ./environment.yml .
 

--- a/backend/api/settings/base.py
+++ b/backend/api/settings/base.py
@@ -28,6 +28,12 @@ CELERY_BEAT_SCHEDULE = {
         "task": "core.tasks.sync_wearables_to_redcap_all",
         "schedule": crontab(hour=2, minute=30),
     },
+    # Renew Let's Encrypt certificates daily at 03:00 UTC.
+    # No-op unless CERTBOT_ENABLED=true is set in the environment.
+    "renew_certificates": {
+        "task": "core.tasks.renew_certificates",
+        "schedule": crontab(hour=3, minute=0),
+    },
 }
 
 

--- a/backend/core/tasks.py
+++ b/backend/core/tasks.py
@@ -1,6 +1,7 @@
 # core/tasks.py
 import logging
 import os
+import subprocess
 import time
 
 from celery import shared_task
@@ -132,3 +133,93 @@ def sync_wearables_to_redcap_all():
 
     logger.info("[sync_wearables_all] Done: %d synced, %d errors/skipped", synced, errors)
     return {"synced": synced, "errors": errors}
+
+
+@shared_task(
+    name="core.tasks.renew_certificates",
+    autoretry_for=(Exception,),
+    retry_backoff=300,
+    max_retries=3,
+)
+def renew_certificates():
+    """
+    Renew Let's Encrypt certificates via certbot and reload the nginx gateway.
+
+    Requires the following environment variables:
+      CERTBOT_ENABLED=true           — set to enable; skipped if absent/false
+      CERTBOT_CONF_PATH              — host path to ./nginx/certbot/conf (default: /etc/letsencrypt inside container)
+      CERTBOT_WWW_PATH               — host path to ./nginx/certbot/www
+      CERTBOT_NGINX_CONTAINER        — name of the container running gateway nginx (default: gateway)
+
+    The task runs certbot via `docker run certbot/certbot renew` using the
+    Docker socket mounted at /var/run/docker.sock. This avoids installing
+    certbot inside the backend image and lets the dedicated certbot image
+    handle OS-level certificate operations.
+
+    Add the following to celery services in docker-compose:
+      volumes:
+        - /var/run/docker.sock:/var/run/docker.sock
+        - ./nginx/certbot/conf:/etc/letsencrypt
+        - ./nginx/certbot/www:/var/www/certbot
+      environment:
+        - CERTBOT_ENABLED=true
+        - CERTBOT_CONF_PATH=<host-absolute-path>/nginx/certbot/conf
+        - CERTBOT_WWW_PATH=<host-absolute-path>/nginx/certbot/www
+        - CERTBOT_NGINX_CONTAINER=gateway
+    """
+    enabled = os.environ.get("CERTBOT_ENABLED", "").strip().lower()
+    if enabled not in ("true", "1", "yes"):
+        logger.info("[renew_certificates] skipped (CERTBOT_ENABLED not set)")
+        return "skipped"
+
+    conf_path = os.environ.get("CERTBOT_CONF_PATH", "").strip()
+    www_path = os.environ.get("CERTBOT_WWW_PATH", "").strip()
+    nginx_container = os.environ.get("CERTBOT_NGINX_CONTAINER", "gateway").strip()
+
+    if not conf_path or not www_path:
+        logger.error(
+            "[renew_certificates] CERTBOT_CONF_PATH and CERTBOT_WWW_PATH must be set"
+        )
+        raise ValueError("CERTBOT_CONF_PATH and CERTBOT_WWW_PATH are required")
+
+    logger.info("[renew_certificates] starting renewal (conf=%s, nginx=%s)", conf_path, nginx_container)
+    t0 = time.time()
+
+    cmd = [
+        "docker", "run", "--rm",
+        "-v", f"{conf_path}:/etc/letsencrypt",
+        "-v", f"{www_path}:/var/www/certbot",
+        "certbot/certbot", "renew", "--non-interactive", "--quiet",
+    ]
+
+    result = subprocess.run(cmd, capture_output=True, text=True, timeout=300)
+    elapsed = time.time() - t0
+
+    if result.stdout:
+        logger.info("[renew_certificates] certbot stdout:\n%s", result.stdout.strip())
+    if result.stderr:
+        logger.warning("[renew_certificates] certbot stderr:\n%s", result.stderr.strip())
+
+    if result.returncode != 0:
+        logger.error(
+            "[renew_certificates] certbot exited with code %d after %.1fs",
+            result.returncode, elapsed,
+        )
+        raise RuntimeError(f"certbot renew failed (exit {result.returncode})")
+
+    logger.info("[renew_certificates] certbot finished in %.1fs — reloading %s", elapsed, nginx_container)
+
+    reload = subprocess.run(
+        ["docker", "exec", nginx_container, "nginx", "-s", "reload"],
+        capture_output=True, text=True, timeout=30,
+    )
+
+    if reload.returncode != 0:
+        logger.error(
+            "[renew_certificates] nginx reload failed: %s",
+            reload.stderr.strip() or reload.stdout.strip(),
+        )
+        raise RuntimeError(f"nginx reload failed (exit {reload.returncode})")
+
+    logger.info("[renew_certificates] ✅ certificates renewed and nginx reloaded")
+    return "renewed"

--- a/backend/core/tasks.py
+++ b/backend/core/tasks.py
@@ -177,19 +177,24 @@ def renew_certificates():
     nginx_container = os.environ.get("CERTBOT_NGINX_CONTAINER", "gateway").strip()
 
     if not conf_path or not www_path:
-        logger.error(
-            "[renew_certificates] CERTBOT_CONF_PATH and CERTBOT_WWW_PATH must be set"
-        )
+        logger.error("[renew_certificates] CERTBOT_CONF_PATH and CERTBOT_WWW_PATH must be set")
         raise ValueError("CERTBOT_CONF_PATH and CERTBOT_WWW_PATH are required")
 
     logger.info("[renew_certificates] starting renewal (conf=%s, nginx=%s)", conf_path, nginx_container)
     t0 = time.time()
 
     cmd = [
-        "docker", "run", "--rm",
-        "-v", f"{conf_path}:/etc/letsencrypt",
-        "-v", f"{www_path}:/var/www/certbot",
-        "certbot/certbot", "renew", "--non-interactive", "--quiet",
+        "docker",
+        "run",
+        "--rm",
+        "-v",
+        f"{conf_path}:/etc/letsencrypt",
+        "-v",
+        f"{www_path}:/var/www/certbot",
+        "certbot/certbot",
+        "renew",
+        "--non-interactive",
+        "--quiet",
     ]
 
     result = subprocess.run(cmd, capture_output=True, text=True, timeout=300)
@@ -203,7 +208,8 @@ def renew_certificates():
     if result.returncode != 0:
         logger.error(
             "[renew_certificates] certbot exited with code %d after %.1fs",
-            result.returncode, elapsed,
+            result.returncode,
+            elapsed,
         )
         raise RuntimeError(f"certbot renew failed (exit {result.returncode})")
 
@@ -211,7 +217,9 @@ def renew_certificates():
 
     reload = subprocess.run(
         ["docker", "exec", nginx_container, "nginx", "-s", "reload"],
-        capture_output=True, text=True, timeout=30,
+        capture_output=True,
+        text=True,
+        timeout=30,
     )
 
     if reload.returncode != 0:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -69,6 +69,9 @@ services:
     volumes:
       - ./backend:/app
       - ./mongo/tls/ca.crt:/etc/ssl/mongo/ca.crt:ro
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ./nginx/certbot/conf:/etc/letsencrypt
+      - ./nginx/certbot/www:/var/www/certbot
     env_file:
       - ./.env.dev
     depends_on:
@@ -82,6 +85,10 @@ services:
       - CELERY_RESULT_BACKEND=redis://redis:6379/0
       - CELERY_WORKER_PREFETCH_MULTIPLIER=1
       - CELERY_WORKER_STATE_DB=/app/celery_worker.state
+      # Certificate renewal — set CERTBOT_ENABLED=true in .env.dev to activate
+      - CERTBOT_CONF_PATH=${CERTBOT_CONF_PATH:-/home/ubuntu/repos/telerehabapp/nginx/certbot/conf}
+      - CERTBOT_WWW_PATH=${CERTBOT_WWW_PATH:-/home/ubuntu/repos/telerehabapp/nginx/certbot/www}
+      - CERTBOT_NGINX_CONTAINER=${CERTBOT_NGINX_CONTAINER:-gateway}
     networks:
       - telereha
 
@@ -103,9 +110,16 @@ services:
       - CELERY_BROKER_URL=redis://redis:6379/0
       - CELERY_RESULT_BACKEND=redis://redis:6379/0
       - DJANGO_CELERY_BEAT_DISABLE_SOLAR_SCHEDULE=True
+      # Certificate renewal — set CERTBOT_ENABLED=true in .env.dev to activate
+      - CERTBOT_CONF_PATH=${CERTBOT_CONF_PATH:-/home/ubuntu/repos/telerehabapp/nginx/certbot/conf}
+      - CERTBOT_WWW_PATH=${CERTBOT_WWW_PATH:-/home/ubuntu/repos/telerehabapp/nginx/certbot/www}
+      - CERTBOT_NGINX_CONTAINER=${CERTBOT_NGINX_CONTAINER:-gateway}
     volumes:
       - ./backend:/app
       - ./mongo/tls/ca.crt:/etc/ssl/mongo/ca.crt:ro
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ./nginx/certbot/conf:/etc/letsencrypt
+      - ./nginx/certbot/www:/var/www/certbot
     depends_on:
       - django-dev
       - redis

--- a/docker-compose.prod.reha-advisor.yml
+++ b/docker-compose.prod.reha-advisor.yml
@@ -100,6 +100,9 @@ services:
     command: python -m celery -A api.celery:app worker --loglevel=info --statedb=/app/celery_worker.state -c 4
     volumes:
       - ./mongo/tls/ca.crt:/etc/ssl/mongo/ca.crt:ro
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ./nginx/certbot/conf:/etc/letsencrypt
+      - ./nginx/certbot/www:/var/www/certbot
     env_file:
       - ./.env.prod
     environment:
@@ -109,6 +112,10 @@ services:
       - CELERY_RESULT_BACKEND=redis://:${REDIS_PASSWORD:-changeme}@redis-prod:6379/0
       - CELERY_WORKER_PREFETCH_MULTIPLIER=4
       - CELERY_WORKER_STATE_DB=/app/celery_worker.state
+      # Certificate renewal — set CERTBOT_ENABLED=true in .env.prod to activate
+      - CERTBOT_CONF_PATH=${CERTBOT_CONF_PATH:-/home/ubuntu/repos/telerehabapp-prod/nginx/certbot/conf}
+      - CERTBOT_WWW_PATH=${CERTBOT_WWW_PATH:-/home/ubuntu/repos/telerehabapp-prod/nginx/certbot/www}
+      - CERTBOT_NGINX_CONTAINER=${CERTBOT_NGINX_CONTAINER:-gateway}
     working_dir: /app
     depends_on:
       redis-prod:
@@ -135,9 +142,16 @@ services:
       - CELERY_BROKER_URL=redis://:${REDIS_PASSWORD:-changeme}@redis-prod:6379/0
       - CELERY_RESULT_BACKEND=redis://:${REDIS_PASSWORD:-changeme}@redis-prod:6379/0
       - DJANGO_CELERY_BEAT_DISABLE_SOLAR_SCHEDULE=True
+      # Certificate renewal — set CERTBOT_ENABLED=true in .env.prod to activate
+      - CERTBOT_CONF_PATH=${CERTBOT_CONF_PATH:-/home/ubuntu/repos/telerehabapp-prod/nginx/certbot/conf}
+      - CERTBOT_WWW_PATH=${CERTBOT_WWW_PATH:-/home/ubuntu/repos/telerehabapp-prod/nginx/certbot/www}
+      - CERTBOT_NGINX_CONTAINER=${CERTBOT_NGINX_CONTAINER:-gateway}
     volumes:
       - ./data/db.sqlite3:/app/api/db.sqlite3
       - ./mongo/tls/ca.crt:/etc/ssl/mongo/ca.crt:ro
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ./nginx/certbot/conf:/etc/letsencrypt
+      - ./nginx/certbot/www:/var/www/certbot
     depends_on:
       redis-prod:
         condition: service_healthy

--- a/docs/06-DEPLOYMENT_GUIDE.md
+++ b/docs/06-DEPLOYMENT_GUIDE.md
@@ -429,31 +429,79 @@ EOF
 
 ## SSL/TLS Certificate Management
 
-### Using Let's Encrypt with Auto-Renewal
+Certificates for `dev.reha-advisor.ch` and `reha-advisor.ch` are issued by Let's Encrypt and expire every 90 days. Renewal is handled automatically by a **Celery beat task** (`core.tasks.renew_certificates`) that runs daily at 03:00 UTC.
 
-```bash
-# Install Certbot
-sudo apt-get install certbot -y
+### How it works
 
-# Obtain certificate
-sudo certbot certonly --standalone \
-  -d yourdomain.com \
-  -d www.yourdomain.com
+The task runs inside the `celery` / `celery-prod` container and calls certbot via the Docker socket — no certbot installation is required in the backend image:
 
-# Auto-renew
-sudo certbot renew --dry-run
-sudo systemctl enable certbot.timer
-```
+1. `docker run certbot/certbot renew --non-interactive --quiet` — attempts renewal for all configured domains; certbot skips certs that still have more than 30 days left.
+2. `docker exec gateway nginx -s reload` — reloads the gateway nginx to serve the new certificate.
+3. On failure the task retries up to 3 times with a 5-minute backoff, then raises so Celery logs a failure and Sentry captures it.
 
-### Certificate Mounting in Docker
+### Required environment variables
+
+Add these to `.env.dev` and `.env.prod`:
+
+| Variable | Dev value | Prod value |
+|---|---|---|
+| `CERTBOT_ENABLED` | `true` | `true` |
+| `CERTBOT_CONF_PATH` | `/home/ubuntu/repos/telerehabapp/nginx/certbot/conf` | `/home/ubuntu/repos/telerehabapp-prod/nginx/certbot/conf` |
+| `CERTBOT_WWW_PATH` | `/home/ubuntu/repos/telerehabapp/nginx/certbot/www` | `/home/ubuntu/repos/telerehabapp-prod/nginx/certbot/www` |
+| `CERTBOT_NGINX_CONTAINER` | `gateway` | `gateway` |
+
+> **Important:** `CERTBOT_CONF_PATH` and `CERTBOT_WWW_PATH` must be **host-absolute paths**, not container paths. When the Celery task calls `docker run -v <path>:...`, Docker resolves the paths on the host, not inside the Celery container.
+
+### Required compose volumes
+
+The celery services in both `docker-compose.dev.yml` and `docker-compose.prod.reha-advisor.yml` already declare:
 
 ```yaml
-# docker-compose.prod.yml
-services:
-  nginx:
-    volumes:
-      - /etc/letsencrypt/live/yourdomain.com:/etc/nginx/ssl:ro
+volumes:
+  - /var/run/docker.sock:/var/run/docker.sock   # allows calling docker run / exec
+  - ./nginx/certbot/conf:/etc/letsencrypt        # certbot reads/writes cert storage
+  - ./nginx/certbot/www:/var/www/certbot         # certbot writes ACME challenges
 ```
+
+### Triggering renewal manually
+
+```bash
+# Dev
+docker exec celery python -m celery -A api.celery:app call core.tasks.renew_certificates
+
+# Prod
+docker exec celery-prod python -m celery -A api.celery:app call core.tasks.renew_certificates
+```
+
+### Verifying the certificate
+
+```bash
+openssl s_client -connect dev.reha-advisor.ch:443 -servername dev.reha-advisor.ch </dev/null 2>&1 \
+  | grep -E "notAfter|Verify return code"
+# Expected: Verify return code: 0 (ok)
+```
+
+### Emergency manual renewal (if Celery is down)
+
+```bash
+docker run --rm \
+  -v /home/ubuntu/repos/telerehabapp/nginx/certbot/conf:/etc/letsencrypt \
+  -v /home/ubuntu/repos/telerehabapp/nginx/certbot/www:/var/www/certbot \
+  certbot/certbot renew --non-interactive
+docker exec gateway nginx -s reload
+```
+
+### Gateway nginx and the ACME challenge
+
+The gateway nginx serves `/.well-known/acme-challenge/` on HTTP port 80 for all domains — this is what certbot uses to prove domain ownership during webroot validation. The relevant block in `nginx/gateway.nginx.conf`:
+
+```nginx
+location /.well-known/acme-challenge/ {
+    root /var/www/certbot;
+}
+```
+
+This block must remain in the HTTP server blocks for all domains. Do not add an HTTPS redirect that catches ACME challenge paths.
 
 ## Monitoring and Logging
 

--- a/docs/07-ENVIRONMENT_CONFIG.md
+++ b/docs/07-ENVIRONMENT_CONFIG.md
@@ -533,6 +533,41 @@ validate_required_env_vars()
 
 ---
 
+## Certificate Renewal
+
+Automatic Let's Encrypt renewal is handled by the Celery beat task `core.tasks.renew_certificates`, which runs daily at 03:00 UTC. It is opt-in: set `CERTBOT_ENABLED=true` to activate.
+
+### Variables (add to `.env.dev` and `.env.prod`)
+
+| Variable | Required | Description |
+|---|---|---|
+| `CERTBOT_ENABLED` | Yes (to activate) | Set to `true` to enable automatic renewal. Task silently skips if absent or false. |
+| `CERTBOT_CONF_PATH` | Yes | **Host-absolute** path to `nginx/certbot/conf` — e.g. `/home/ubuntu/repos/telerehabapp/nginx/certbot/conf`. Must be the host path, not the container path, because certbot is launched via `docker run`. |
+| `CERTBOT_WWW_PATH` | Yes | **Host-absolute** path to `nginx/certbot/www` — the webroot used by certbot for ACME challenges. |
+| `CERTBOT_NGINX_CONTAINER` | No | Name of the gateway nginx container to reload after renewal. Defaults to `gateway`. |
+
+### Dev example (`.env.dev`)
+
+```env
+CERTBOT_ENABLED=true
+CERTBOT_CONF_PATH=/home/ubuntu/repos/telerehabapp/nginx/certbot/conf
+CERTBOT_WWW_PATH=/home/ubuntu/repos/telerehabapp/nginx/certbot/www
+CERTBOT_NGINX_CONTAINER=gateway
+```
+
+### Prod example (`.env.prod`)
+
+```env
+CERTBOT_ENABLED=true
+CERTBOT_CONF_PATH=/home/ubuntu/repos/telerehabapp-prod/nginx/certbot/conf
+CERTBOT_WWW_PATH=/home/ubuntu/repos/telerehabapp-prod/nginx/certbot/www
+CERTBOT_NGINX_CONTAINER=gateway
+```
+
+See [Deployment Guide — SSL/TLS Certificate Management](./06-DEPLOYMENT_GUIDE.md#ssltls-certificate-management) for the full operational guide.
+
+---
+
 ## LibreTranslate Service
 
 RehaAdvisor bundles a self-hosted [LibreTranslate](https://github.com/LibreTranslate/LibreTranslate) container for machine translation of intervention content. It is **not optional** — the backend calls it whenever a therapist requests translation of an intervention.

--- a/docs/PRODUCTION_DEPLOY_RUNBOOK.md
+++ b/docs/PRODUCTION_DEPLOY_RUNBOOK.md
@@ -144,6 +144,14 @@ curl -s -o /dev/null -w "%{http_code}\n" https://reha-advisor.ch/health
 
 # 4) Backend migration command sanity check
 docker exec django-prod conda run --no-capture-output -n teleRehabApp python manage.py showmigrations --plan | head -n 30
+
+# 5) TLS certificate validity
+openssl s_client -connect reha-advisor.ch:443 -servername reha-advisor.ch </dev/null 2>&1 | grep -E "notAfter|Verify return code"
+# Expected: Verify return code: 0 (ok)
+
+# 6) Cert renewal task registered in celery-beat
+docker exec celery-beat-prod python -m celery -A api.celery:app inspect registered | grep renew_certificates
+# Expected: core.tasks.renew_certificates
 ```
 
 Frontend smoke-check:


### PR DESCRIPTION
# Description
Certificates for dev.reha-advisor.ch and reha-advisor.ch are issued by Let's Encrypt and expire every 90 days. There was no automation — renewal had to be done by hand. On 2026-05-10 the dev cert expired, taking down the live dev environment and breaking all CI e2e tests for several hours.

This PR adds a Celery beat task that renews both certs automatically every day at 03:00 UTC. The task uses the Docker socket to call docker run certbot/certbot renew (no certbot install in the backend image) and reloads the gateway nginx on success. It is opt-in: it does nothing unless CERTBOT_ENABLED=true is set in the environment.

## Dependencies / setup required after merge:

1. Add CERTBOT_ENABLED=true + CERTBOT_CONF_PATH / CERTBOT_WWW_PATH / CERTBOT_NGINX_CONTAINER to .env.dev and .env.prod (values documented in the task docstring and the linked issue).
2. Restart celery and celery-beat containers so the new volumes and env vars take effect.

Related Issue
[Automate Let's Encrypt certificate renewal via Celery](#245 )

## Type of change
 New feature (non-breaking change which adds functionality)
## Tests
Triggered the task manually from the running dev celery container:


`docker exec celery python -m celery -A api.celery:app call core.tasks.renew_certificates`
Result: task ran in 2.5 s, certbot completed (no-op — certs renewed today), gateway nginx reloaded. Worker logs:


```
[renew_certificates] starting renewal (conf=…/nginx/certbot/conf, nginx=gateway)
[renew_certificates] certbot finished in 2.5s — reloading gateway
[renew_certificates] ✅ certificates renewed and nginx reloaded
Task core.tasks.renew_certificates[…] succeeded in 2.590s: 'renewed'
Verified cert is valid after reload:
```


```
openssl s_client -connect dev.reha-advisor.ch:443 </dev/null 2>&1 | grep "Verify return code"
# Verify return code: 0 (ok)
```
Test Configuration: dev stack (docker-compose.dev.yml), celery container rebuilt with docker.io added to apt-get.

Checklist
 I have read the contributing guidelines.
 I have read the code of conduct.
 I have commented my code, particularly in hard-to-understand areas.
 I have made corresponding changes to the documentation.
 My changes generate no new warnings.
 I have added tests that prove my fix is effective or that my feature works.