### PR TITLE
Fix: delete FitbitUserToken on invalid_grant to stop retry noise

### DIFF
--- a/backend/core/views/fitbit_sync.py
+++ b/backend/core/views/fitbit_sync.py
@@ -48,6 +48,18 @@ def get_valid_access_token(user):
                 logger.error(
                     f"[get_valid_access_token] Failed to refresh token. Status: {response.status_code}, Body: {response.text}"
                 )
+                try:
+                    body = response.json()
+                except Exception:
+                    body = {}
+                errors = body.get("errors", [])
+                if any(e.get("errorType") == "invalid_grant" for e in errors):
+                    logger.warning(
+                        "[get_valid_access_token] Refresh token permanently revoked (invalid_grant) "
+                        "for user %s — deleting FitbitUserToken so future syncs skip this user",
+                        user.id,
+                    )
+                    token.delete()
                 raise Exception("Failed to refresh Fitbit token")
         except Exception as e:
             logger.exception(f"[get_valid_access_token] Exception while refreshing token: {e}")

--- a/backend/tests/fitbit_sync/test_fitbit_sync.py
+++ b/backend/tests/fitbit_sync/test_fitbit_sync.py
@@ -124,10 +124,51 @@ def test_get_valid_access_token_refresh_failure_raises(mock_post):
     resp = Mock()
     resp.status_code = 401
     resp.text = "unauthorized"
+    resp.json.return_value = {}
     mock_post.return_value = resp
 
     with pytest.raises(Exception):
         get_valid_access_token(user)
+
+
+@patch("core.views.fitbit_sync.requests.post")
+def test_get_valid_access_token_invalid_grant_deletes_token(mock_post):
+    """invalid_grant means Fitbit permanently revoked the refresh token — delete the record."""
+    user, _ = make_user_with_token(expired=True)
+
+    resp = Mock()
+    resp.status_code = 400
+    resp.text = '{"errors":[{"errorType":"invalid_grant","message":"Refresh token invalid"}],"success":false}'
+    resp.json.return_value = {
+        "errors": [{"errorType": "invalid_grant", "message": "Refresh token invalid"}],
+        "success": False,
+    }
+    mock_post.return_value = resp
+
+    with pytest.raises(Exception, match="Failed to refresh Fitbit token"):
+        get_valid_access_token(user)
+
+    assert FitbitUserToken.objects(user=user).count() == 0
+
+
+@patch("core.views.fitbit_sync.requests.post")
+def test_get_valid_access_token_non_invalid_grant_400_keeps_token(mock_post):
+    """Other 400 errors (e.g. expired_token) should NOT delete the token."""
+    user, _ = make_user_with_token(expired=True)
+
+    resp = Mock()
+    resp.status_code = 400
+    resp.text = '{"errors":[{"errorType":"expired_token","message":"Access token expired"}],"success":false}'
+    resp.json.return_value = {
+        "errors": [{"errorType": "expired_token", "message": "Access token expired"}],
+        "success": False,
+    }
+    mock_post.return_value = resp
+
+    with pytest.raises(Exception, match="Failed to refresh Fitbit token"):
+        get_valid_access_token(user)
+
+    assert FitbitUserToken.objects(user=user).count() == 1
 
 
 def test_fetch_fitbit_today_for_user_no_token_returns_zero():


### PR DESCRIPTION
When Fitbit returns 400 invalid_grant the refresh token is permanently revoked. Delete the token record so future sync cycles skip the user and the frontend shows "not connected", prompting reconnect via OAuth.

## The fix
detect `invalid_grant` specifically in `get_valid_access_token` and **delete the `FitbitUserToken` record**, which has two downstream effects:
1. Future sync cycles skip the user entirely (they're no longer in `FitbitUserToken.objects.all()`).
2. The frontend's "connected" check (`FitbitUserToken.objects(user=user).count() > 0`) returns False → the patient/therapist sees "not connected" and can trigger the OAuth reconnect flow.

Reconnecting via the Fitbit OAuth callback uses `upsert=True`, so it creates a fresh token record cleanly.

---

## Critical file

| File | Action |
|---|---|
| `backend/core/views/fitbit_sync.py` | **Edit** — detect `invalid_grant`, delete token |

No model changes. No frontend changes. No migration.

---

## Implementation

### `backend/core/views/fitbit_sync.py` — `get_valid_access_token`

In the `else` branch (non-200 refresh response), **before** the generic `raise Exception(...)`:

```python
else:
    logger.error(
        "[get_valid_access_token] Failed to refresh token. Status: %s, Body: %s",
        response.status_code, response.text,
    )
    # Permanently revoked — delete the token so future syncs skip this user
    # and the UI shows "not connected".
    try:
        body = response.json()
    except Exception:
        body = {}
    errors = body.get("errors", [])
    if any(e.get("errorType") == "invalid_grant" for e in errors):
        logger.warning(
            "[get_valid_access_token] Refresh token permanently revoked (invalid_grant) "
            "for user %s — deleting FitbitUserToken",
            user.id,
        )
        token.delete()
    raise Exception("Failed to refresh Fitbit token")
```

The existing `except Exception` block re-raises, so the per-user handler in `fetch_fitbit_data.py` still catches it and continues to the next user — no changes needed there.

---

## How it flows after the fix

1. Sync runs → `get_valid_access_token(user)` gets HTTP 400 `invalid_grant`
2. Logs the error (unchanged), parses JSON, finds `invalid_grant` → `token.delete()`
3. Raises → caught per-user in `fetch_fitbit_data.py` → logged → next user
4. Next sync cycle: `FitbitUserToken.objects.all()` no longer includes this user → silent skip
5. Patient opens app → `GET /fitbit/status/<patient_id>/` returns `{"connected": false}` → "Connect Fitbit" button shown

---

## Verification

```bash
# Before fix: count tokens with stale refresh tokens in logs
docker logs django 2>&1 | grep "invalid_grant" | wc -l

# After deploying: these users should have no FitbitUserToken
docker exec django python -c "
from core.models import FitbitUserToken, User
for uid in ['69e5f12a5617aedbaac97855', '69df4c71d13880cb0410d4fd']:
    print(uid, FitbitUserToken.objects(user=uid).count())
"

# Confirm next sync produces no invalid_grant errors for those users
docker logs django -f --since=1m | grep "invalid_grant"
```

