### PR TITLE
Fix/sentry bug sweep

### DIFF
--- a/backend/core/management/commands/fetch_fitbit_data.py
+++ b/backend/core/management/commands/fetch_fitbit_data.py
@@ -125,7 +125,9 @@ class Command(BaseCommand):
                     if dataset:
                         max_hr_map[d] = max(x.get("value", 0) for x in dataset)
                         # Wear time: count distinct minute slots with HR > 0
-                        worn_minutes = {entry.get("time", "")[:5] for entry in dataset if entry.get("value", 0) > 0}  # "HH:MM"
+                        worn_minutes = {
+                            entry.get("time", "")[:5] for entry in dataset if entry.get("value", 0) > 0
+                        }  # "HH:MM"
                         wear_time_map[d] = len(worn_minutes)
                         intraday_ok += 1
                     else:

--- a/backend/core/management/commands/fetch_fitbit_data.py
+++ b/backend/core/management/commands/fetch_fitbit_data.py
@@ -125,7 +125,7 @@ class Command(BaseCommand):
                     if dataset:
                         max_hr_map[d] = max(x.get("value", 0) for x in dataset)
                         # Wear time: count distinct minute slots with HR > 0
-                        worn_minutes = {entry["time"][:5] for entry in dataset if entry.get("value", 0) > 0}  # "HH:MM"
+                        worn_minutes = {entry.get("time", "")[:5] for entry in dataset if entry.get("value", 0) > 0}  # "HH:MM"
                         wear_time_map[d] = len(worn_minutes)
                         intraday_ok += 1
                     else:

--- a/backend/core/services/redcap_access.py
+++ b/backend/core/services/redcap_access.py
@@ -4,7 +4,7 @@ from typing import List
 
 from django.utils import timezone
 
-from core.models import Therapist
+from core.models import Therapist, User
 from utils.config import config
 
 logger = logging.getLogger(__name__)
@@ -30,11 +30,13 @@ def get_therapist_for_user(django_user) -> Therapist | None:
     except Exception:
         logger.exception("Failed therapist lookup by request.user.id")
 
-    # ✅ Fallback if you identify by email
+    # Fallback: look up MongoEngine User by email, then find Therapist
     try:
         email = getattr(django_user, "email", None)
         if email:
-            return Therapist.objects(userId__email=email).first()
+            mongo_user = User.objects(email=email).first()
+            if mongo_user:
+                return Therapist.objects(userId=mongo_user).first()
     except Exception:
         logger.exception("Failed therapist lookup by request.user.email")
 

--- a/backend/core/views/fitbit_view.py
+++ b/backend/core/views/fitbit_view.py
@@ -683,8 +683,8 @@ def health_combined_history(request, patient_id):
         to_str = request.GET.get("to")
 
         if from_str and to_str:
-            from_date = datetime.strptime(from_str, "%Y-%m-%d").date()
-            to_date = datetime.strptime(to_str, "%Y-%m-%d").date()
+            from_date = datetime.datetime.strptime(from_str, "%Y-%m-%d").date()
+            to_date = datetime.datetime.strptime(to_str, "%Y-%m-%d").date()
         else:
             to_date = timezone.now().date()
             from_date = to_date - timedelta(days=30)
@@ -728,7 +728,7 @@ def health_combined_history(request, patient_id):
                 # If no FitbitData for that day, create a minimal entry
                 fd = FitbitData(
                     user=patient.userId,
-                    date=datetime.combine(v.date, datetime.min.time()),
+                    date=datetime.datetime.combine(v.date, datetime.time()),
                     weight_kg=v.weight_kg,
                     bp_sys=v.bp_sys,
                     bp_dia=v.bp_dia,

--- a/backend/tests/redcap_access/test_redcap_access.py
+++ b/backend/tests/redcap_access/test_redcap_access.py
@@ -44,13 +44,13 @@ def _make_therapist(email="th@example.com"):
     return user, therapist
 
 
-def test_get_therapist_for_user_by_id_and_email_fallback_none():
+def test_get_therapist_for_user_by_id_and_email_fallback():
     user, therapist = _make_therapist()
     dj_by_id = SimpleNamespace(id=user.id, email=None)
     dj_by_email = SimpleNamespace(id=None, email=user.email)
     assert get_therapist_for_user(dj_by_id).id == therapist.id
-    # current implementation uses userId__email join, which returns None in this DB setup
-    assert get_therapist_for_user(dj_by_email) is None
+    # email fallback performs a two-step lookup (User by email → Therapist by userId)
+    assert get_therapist_for_user(dj_by_email).id == therapist.id
 
 
 def test_get_therapist_for_user_returns_none_when_no_match():


### PR DESCRIPTION

## What broke
Three separate bugs were causing recurring Sentry errors in production:

1. MongoDB cross-document join in redcap_access.py

get_therapist_for_user used Therapist.objects(userId__email=email) — a cross-document join that MongoEngine does not support, silently returning None for every email-based lookup. Affected all REDCap flows that identify the therapist by Django session email rather than by Mongo user ID.

Fixed by replacing with a two-step lookup: User.objects(email=email).first() → Therapist.objects(userId=mongo_user).first().

2. KeyError: 'time' in Fitbit intraday HR processing (fetch_fitbit_data.py)

Fitbit intraday dataset entries were assumed to always have a "time" key. Occasionally entries arrive without it, raising KeyError and aborting wear-time calculation for that day.

Fixed by using .get("time", "") so malformed entries are silently skipped rather than crashing.

3. AttributeError: type object 'datetime' has no attribute 'strptime' in fitbit_view.py

health_combined_history does import datetime at line 622, which shadows the earlier from datetime import datetime, timedelta class import. Any call to datetime.strptime or datetime.combine after that line was operating on the module, not the class.

Fixed by using the fully qualified datetime.datetime.strptime / datetime.datetime.combine / datetime.time() forms, which work correctly regardless of which import is in scope.

## Tests
Updated test_get_therapist_for_user_by_id_and_email_fallback to assert the two-step lookup now returns the correct therapist (previously documented as returning None due to the broken join).
All 877 tests pass.