### PR TITLE
Fix: reduce Sentry noise — 5 mislogged error cases

### DIFF
--- a/backend/core/services/redcap_service.py
+++ b/backend/core/services/redcap_service.py
@@ -154,7 +154,7 @@ def export_record_by_pat_id(project_name: str, pat_id: str) -> List[Dict[str, An
                 raise ValueError("JSON is not a list")
             return data
         except Exception as e:
-            logger.exception("Failed parsing REDCap JSON")
+            logger.warning("Failed parsing REDCap JSON: %s — raw: %.200s", e, text)
             raise RedcapError("REDCap returned invalid JSON.", detail=text[:500]) from e
 
     # 1) Try filter by pat_id

--- a/backend/core/services/wearables_redcap_service.py
+++ b/backend/core/services/wearables_redcap_service.py
@@ -352,7 +352,7 @@ def export_wearables_to_redcap(
             results[period] = f"error: {e}"
             payloads[period]["status"] = "error"
             payloads[period]["error"] = str(e)
-            logger.error(
+            logger.warning(
                 "Failed to export wearables [%s] for %s: %s | detail=%s",
                 period,
                 patient.patient_code,

--- a/backend/core/views/template_views.py
+++ b/backend/core/views/template_views.py
@@ -896,11 +896,10 @@ def apply_named_template(request, template_id):
                 patients_affected += 1
         except MongoValidationError as e:
             reason = _describe_validation_error(e)
-            logger.error(
-                "apply_named_template: error applying to patient %s: %s",
+            logger.warning(
+                "apply_named_template: validation error for patient %s: %s",
                 patient_code,
-                str(e),
-                exc_info=True,
+                reason,
             )
             patient_errors.append({"patient": patient_code, "reason": reason})
         except Exception as e:

--- a/backend/core/views/therapist_views.py
+++ b/backend/core/views/therapist_views.py
@@ -697,7 +697,11 @@ def get_patients_by_therapist(request, therapist_id):
 @permission_classes([IsAuthenticated])
 def create_log(request):
     try:
-        data = json.loads(request.body)
+        data = json.loads(request.body or b"{}")
+    except json.JSONDecodeError:
+        return JsonResponse({"error": "Invalid JSON body"}, status=400)
+
+    try:
         user = data.get("user")
 
         # Parse datetime safely
@@ -722,6 +726,9 @@ def create_log(request):
         logger.info(f"[i13n] Log saved for user {user.id} with action {log.action}")
         return JsonResponse({"status": "ok", "log_id": str(log.id)}, status=201)
 
+    except (User.DoesNotExist, Patient.DoesNotExist) as e:
+        logger.warning("[i13n] Failed to save log — referenced entity not found: %s", e)
+        return JsonResponse({"error": "Referenced user or patient not found"}, status=404)
     except Exception as e:
         logger.error(f"[i13n] Failed to save log: {e}", exc_info=True)
         return JsonResponse({"error": "Failed to create log"}, status=500)

--- a/backend/core/views/user_views.py
+++ b/backend/core/views/user_views.py
@@ -254,8 +254,7 @@ def user_profile_view(request, user_id):
             patient = Patient.objects.get(pk=ObjectId(user_id))
             user = patient.userId
         except Patient.DoesNotExist:
-            logger.exception("Error fetching profile")
-            return JsonResponse({"error": "Error fetching profile"}, status=500)
+            return JsonResponse({"error": "User not found"}, status=404)
 
     target_role = getattr(user, "role", "Patient")
 

--- a/backend/tests/activity_logs/test_activity_logs.py
+++ b/backend/tests/activity_logs/test_activity_logs.py
@@ -532,24 +532,24 @@ def test_create_log_returns_log_id_in_response(mongo_mock):
     assert body["log_id"] == str(Logs.objects.first().id)
 
 
-def test_create_log_unknown_user_returns_500(mongo_mock):
-    """A non-existent user ObjectId must return 500 (existing documented behaviour)."""
+def test_create_log_unknown_user_returns_404(mongo_mock):
+    """A non-existent user ObjectId must return 404."""
     resp = client.post(
         "/api/analytics/log",
         data=json.dumps({"user": str(ObjectId()), "action": "REHATABLE"}),
         content_type="application/json",
     )
-    assert resp.status_code == 500
+    assert resp.status_code == 404
 
 
-def test_create_log_invalid_json_returns_500(mongo_mock):
-    """Malformed JSON body must return 500."""
+def test_create_log_invalid_json_returns_400(mongo_mock):
+    """Malformed JSON body must return 400."""
     resp = client.post(
         "/api/analytics/log",
         data="not-json",
         content_type="application/json",
     )
-    assert resp.status_code == 500
+    assert resp.status_code == 400
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/therapist_views/test_therapist_views.py
+++ b/backend/tests/therapist_views/test_therapist_views.py
@@ -19,7 +19,7 @@ Input validation / branch coverage
   * Non-existent therapist returns HTTP 404.
   * Wrong method on patient list returns HTTP 405.
   * Inactive patients are excluded from therapist list.
-  * Invalid analytics payloads return HTTP 500 with error response.
+  * Invalid analytics payloads return HTTP 400/404 with error response.
 
 Test setup
 ----------
@@ -321,7 +321,7 @@ def test_create_log_with_patient_reference():
     assert str(log.patient.id) == str(patient.id)
 
 
-def test_create_log_invalid_json_returns_500():
+def test_create_log_invalid_json_returns_400():
     resp = client.post(
         "/api/analytics/log",
         data="not-json",
@@ -329,11 +329,11 @@ def test_create_log_invalid_json_returns_500():
         HTTP_AUTHORIZATION="Bearer test",
     )
 
-    assert resp.status_code == 500
-    assert resp.json()["error"] == "Failed to create log"
+    assert resp.status_code == 400
+    assert "error" in resp.json()
 
 
-def test_create_log_unknown_user_returns_500():
+def test_create_log_unknown_user_returns_404():
     resp = client.post(
         "/api/analytics/log",
         data=json.dumps(
@@ -347,8 +347,8 @@ def test_create_log_unknown_user_returns_500():
         HTTP_AUTHORIZATION="Bearer test",
     )
 
-    assert resp.status_code == 500
-    assert resp.json()["error"] == "Failed to create log"
+    assert resp.status_code == 404
+    assert "error" in resp.json()
 
 
 def _build_q(question_key):

--- a/backend/tests/user_views/test_user_views.py
+++ b/backend/tests/user_views/test_user_views.py
@@ -312,12 +312,10 @@ def test_user_profile_view_therapist_profile_not_found():
 
 def test_user_profile_view_user_not_found():
     """
-    GET with an ObjectId that matches no User document returns an error
-    response.  The view catches both User.DoesNotExist and Patient.DoesNotExist
-    and returns HTTP 500.
+    GET with an ObjectId that matches no User or Patient document returns 404.
     """
     resp = client.get(f"/api/users/{ObjectId()}/profile/", HTTP_AUTHORIZATION="Bearer test")
-    assert resp.status_code == 500
+    assert resp.status_code == 404
     assert "error" in resp.json()
 
 


### PR DESCRIPTION
Closes #257 

## Summary

- `user_views.py`: Profile endpoint returned 500 + `logger.exception` when
  user/patient ID not found. Changed to 404 with no exception logging.
- `therapist_views.py`: Guard `json.loads` against empty body (→ 400);
  catch `User.DoesNotExist` explicitly returning 404 without a stacktrace.
- `template_views.py`: MongoValidationError for missing patient `endDate`
  downgraded from `logger.error(exc_info=True)` to `logger.warning` — the
  error is already returned to the caller as a user-visible message.
- `redcap_service.py`: `logger.exception` for invalid REDCap JSON response
  → `logger.warning` (expected upstream quirk, not a code bug).
- `wearables_redcap_service.py`: `logger.error` inside `except RedcapError`
  block → `logger.warning` to stop Sentry capturing every REDCap outage.

## Test plan

- [ ] 157 existing tests pass (`pytest tests/patient_views/ tests/redcap_views/ tests/redcap_patient_views/`)
- [ ] Profile endpoint with unknown ID returns 404 (not 500)
- [ ] POST `/api/analytics/log` with empty body returns 400
- [ ] POST `/api/analytics/log` with unknown user ID returns 404
- [ ] Sentry issue count for the above IDs stops growing after deploy
