### PR TITLE
CI: add Playwright E2E job to production deployment workflow

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -14,6 +14,9 @@ name: Production Deployment
 #   PROD_SSH_KEY         — private SSH key (PEM)
 #   VITE_SENTRY_DSN      — baked into the frontend image at build time
 #   SLACK_WEBHOOK_URL    — optional Slack notifications
+#   E2E_PATIENT_PASSWORD — Playwright E2E credentials (same as tests.yml)
+#   E2E_ADMIN_PASSWORD   — Playwright E2E credentials
+#   E2E_THERAPIST_PASSWORD — Playwright E2E credentials
 #
 # GitHub Environment: "production"
 #   Recommended: add required reviewers so every release needs approval
@@ -108,13 +111,186 @@ jobs:
           npm test -- --watchAll=false --testTimeout=10000 --forceExit
 
   # ---------------------------------------------------------------------------
-  # 2. Build — push versioned images to GHCR
+  # 2. E2E — Playwright browser tests against a live Django dev server
+  # ---------------------------------------------------------------------------
+  frontend-e2e:
+    name: Frontend E2E (Playwright)
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    needs: [test]
+    continue-on-error: true
+
+    env:
+      E2E_API_URL: http://127.0.0.1:8001/api
+      E2E_EMAIL_DIR: /tmp/django-e2e-emails
+      USE_E2E_FILE_EMAIL_BACKEND: "1"
+      E2E_PATIENT_LOGIN: ${{ vars.E2E_PATIENT_LOGIN }}
+      E2E_PATIENT_ID: ${{ vars.E2E_PATIENT_ID }}
+      E2E_ADMIN_LOGIN: ${{ vars.E2E_ADMIN_LOGIN }}
+      E2E_THERAPIST_LOGIN: ${{ vars.E2E_THERAPIST_LOGIN }}
+      E2E_PATIENT_PASSWORD: ${{ secrets.E2E_PATIENT_PASSWORD }}
+      E2E_ADMIN_PASSWORD: ${{ secrets.E2E_ADMIN_PASSWORD }}
+      E2E_THERAPIST_PASSWORD: ${{ secrets.E2E_THERAPIST_PASSWORD }}
+
+    services:
+      mongo:
+        image: mongo:8.0
+        options: >-
+          --health-cmd "mongosh --eval 'db.adminCommand(\"ping\")'"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 27017:27017
+
+      redis:
+        image: redis:7-alpine
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 6379:6379
+
+    steps:
+      - name: Checkout release tag
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.release.tag_name || inputs.tag || github.ref }}
+
+      - name: Write env file
+        run: echo "${{ secrets.ENV_FILE_DEV }}" > .env
+
+      - name: Load env file and apply CI overrides
+        run: |
+          while IFS= read -r line; do
+            [[ "$line" =~ ^\s*# ]] && continue
+            [[ -z "${line//[[:space:]]/}" ]] && continue
+            echo "$line" >> "$GITHUB_ENV"
+          done < .env
+          echo "DB_HOST=localhost"                       >> "$GITHUB_ENV"
+          echo "MONGO_INITDB_ROOT_USERNAME="             >> "$GITHUB_ENV"
+          echo "MONGO_INITDB_ROOT_PASSWORD="             >> "$GITHUB_ENV"
+          echo "MONGO_TLS=false"                         >> "$GITHUB_ENV"
+          echo "REDIS_URL=redis://localhost:6379/0"      >> "$GITHUB_ENV"
+          echo "CORS_ALLOW_ALL_ORIGINS=true"             >> "$GITHUB_ENV"
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.13'
+          cache: 'pip'
+          cache-dependency-path: 'backend/requirements.txt'
+
+      - name: Install backend dependencies
+        working-directory: backend
+        run: |
+          python -m pip install --upgrade pip setuptools wheel
+          pip install -r requirements.txt
+
+      - name: Seed E2E test users
+        working-directory: backend
+        run: python manage.py seed_e2e
+
+      - name: Start backend server
+        working-directory: backend
+        run: |
+          mkdir -p /tmp/django-e2e-emails
+          nohup python manage.py runserver 127.0.0.1:8001 >/tmp/django-e2e.log 2>&1 &
+          for i in {1..45}; do
+            status_code="$(curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:8001/api/auth/login/ || true)"
+            if [[ "$status_code" != "000" ]]; then
+              echo "Backend is ready"
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "Backend did not start in time"
+          tail -n 200 /tmp/django-e2e.log || true
+          exit 1
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: 'npm'
+          cache-dependency-path: 'frontend/package-lock.json'
+
+      - name: Install frontend dependencies
+        working-directory: frontend
+        run: npm ci
+
+      - name: Install Playwright browsers
+        working-directory: frontend
+        run: npx playwright install --with-deps
+
+      - name: Run base E2E login flow
+        working-directory: frontend
+        run: npm run test:e2e -- e2e/home-login.spec.ts
+
+      - name: Run seeded redirect E2E flow
+        if: ${{ vars.E2E_PATIENT_LOGIN != '' }}
+        working-directory: frontend
+        run: npm run test:e2e -- e2e/home-login-success-redirects.spec.ts
+
+      - name: Run seeded therapist 2FA E2E flow
+        if: ${{ vars.E2E_THERAPIST_LOGIN != '' }}
+        working-directory: frontend
+        run: npm run test:e2e -- e2e/home-login-therapist.spec.ts
+
+      - name: Run seeded patient page E2E flow
+        if: ${{ vars.E2E_PATIENT_LOGIN != '' }}
+        working-directory: frontend
+        run: npm run test:e2e -- e2e/patient-page.spec.ts
+
+      - name: Run seeded patient interventions page E2E flow
+        if: ${{ vars.E2E_PATIENT_LOGIN != '' }}
+        working-directory: frontend
+        run: npm run test:e2e -- e2e/patient-interventions-page.spec.ts
+
+      - name: Run seeded therapist rehab-table questionnaires E2E flow
+        if: ${{ vars.E2E_THERAPIST_LOGIN != '' && vars.E2E_PATIENT_ID != '' }}
+        working-directory: frontend
+        run: npm run test:e2e -- e2e/therapist-rehabtable-questionnaires.spec.ts
+
+      - name: Run seeded patient assigned questionnaires API E2E flow
+        if: ${{ vars.E2E_PATIENT_LOGIN != '' && vars.E2E_THERAPIST_LOGIN != '' }}
+        working-directory: frontend
+        run: npm run test:e2e -- e2e/patient-assigned-questionnaires.spec.ts
+
+      - name: Run seeded therapist questionnaire builder UI E2E flow
+        if: ${{ vars.E2E_THERAPIST_LOGIN != '' && vars.E2E_PATIENT_ID != '' }}
+        working-directory: frontend
+        run: npm run test:e2e -- e2e/therapist-questionnaire-builder-flow.spec.ts
+
+      - name: Skip note when E2E seeded secrets are missing
+        if: ${{ vars.E2E_PATIENT_LOGIN == '' }}
+        run: echo "Seeded E2E tests skipped — E2E_PATIENT_LOGIN not set."
+
+      - name: Skip note when therapist E2E secrets are missing
+        if: ${{ vars.E2E_THERAPIST_LOGIN == '' }}
+        run: echo "Therapist 2FA E2E test skipped — E2E_THERAPIST_LOGIN not set."
+
+      - name: Upload Playwright artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-deploy-e2e-artifacts
+          path: |
+            frontend/playwright-report
+            frontend/test-results
+            /tmp/django-e2e.log
+          if-no-files-found: ignore
+
+  # ---------------------------------------------------------------------------
+  # 3. Build — push versioned images to GHCR
   # ---------------------------------------------------------------------------
   build:
     name: Build & Push Docker Images
     runs-on: ubuntu-latest
     timeout-minutes: 60
-    needs: test
+    needs: [test, frontend-e2e]
     if: always()
     permissions:
       contents: read
@@ -203,7 +379,7 @@ jobs:
           cache-to: type=gha,mode=max
 
   # ---------------------------------------------------------------------------
-  # 3. Deploy to production
+  # 4. Deploy to production
   #    Uses the GitHub "production" environment — add required reviewers there
   #    to gate every deploy behind a manual approval step.
   # ---------------------------------------------------------------------------
@@ -390,7 +566,7 @@ jobs:
             fi
 
   # ---------------------------------------------------------------------------
-  # 4. Notify
+  # 5. Notify
   # ---------------------------------------------------------------------------
   notify:
     name: Notify Deployment Status


### PR DESCRIPTION
# Description
Runs the full Playwright browser suite between the unit-test job and the Docker build, so E2E regressions are caught before images are pushed.

Job structure: test → frontend-e2e → build → deploy-production → notify

- Spins up MongoDB + Redis services (same config as tests.yml)
- Seeds E2E users, starts Django dev server, runs all spec files
- Uses continue-on-error so a flaky E2E test doesn't block a release; build still proceeds but the failure is visible in the workflow summary
- Uploads playwright-deploy-e2e-artifacts (report + logs) on every run
- Requires same E2E_* vars/secrets already used by tests.yml

## Related Issue


## Type of change

For a new feature, please create an issue first to discuss it with us before submitting a pull request.
- [x] Other (CI)

## Tests

Added a new test for workflow to ensure everything is tested before deployment.

## Checklist

- [x] I have read the [contributing guidelines](/docs/12-CONTRIBUTING.md).
- [x] I have read the [code of conduct](/CODE_OF_CONDUCT.md).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
