### PR TITLE
Fix: slot filenames (_2, _3, …) rejected by frontend media upload validation

### DIFF
--- a/frontend/src/__tests__/components/TherapistIntervention/ImportInterventionsModal.test.tsx
+++ b/frontend/src/__tests__/components/TherapistIntervention/ImportInterventionsModal.test.tsx
@@ -202,6 +202,41 @@ describe('Media file validation', () => {
     expect(screen.getByText('30500_vid')).toBeInTheDocument();
   });
 
+  it('shows ✓ badge and correct external_id for slot-2 mp4 (e.g. 40500_vid_de_2.mp4)', () => {
+    openMediaTab();
+    addFile(new File(['data'], '40500_vid_de_2.mp4', { type: 'video/mp4' }));
+    expect(screen.getByText('✓')).toBeInTheDocument();
+    expect(screen.getByText('40500_vid')).toBeInTheDocument();
+  });
+
+  it('shows ✓ badge for slot-9 file (40500_vid_de_9.mp4)', () => {
+    openMediaTab();
+    addFile(new File(['data'], '40500_vid_de_9.mp4', { type: 'video/mp4' }));
+    expect(screen.getByText('✓')).toBeInTheDocument();
+    expect(screen.getByText('40500_vid')).toBeInTheDocument();
+  });
+
+  it('shows ✓ badge for 5-digit ID with slot suffix (30500_web_fr_3.mp4)', () => {
+    openMediaTab();
+    addFile(new File(['data'], '30500_web_fr_3.mp4', { type: 'video/mp4' }));
+    expect(screen.getByText('✓')).toBeInTheDocument();
+    expect(screen.getByText('30500_web')).toBeInTheDocument();
+  });
+
+  it('shows ✓ badge for slot audio file (3500_aud_de_2.mp3)', () => {
+    openMediaTab();
+    addFile(new File(['data'], '3500_aud_de_2.mp3', { type: 'audio/mpeg' }));
+    expect(screen.getByText('✓')).toBeInTheDocument();
+    expect(screen.getByText('3500_aud')).toBeInTheDocument();
+  });
+
+  it('shows ✓ badge for slot m4a file (3500_aud_de_2.m4a)', () => {
+    openMediaTab();
+    addFile(new File(['data'], '3500_aud_de_2.m4a', { type: 'audio/mp4' }));
+    expect(screen.getByText('✓')).toBeInTheDocument();
+    expect(screen.getByText('3500_aud')).toBeInTheDocument();
+  });
+
   it('Upload button becomes enabled after a valid file is added', () => {
     openMediaTab();
     expect(screen.getByRole('button', { name: /^Upload$/i })).toBeDisabled();

--- a/frontend/src/components/TherapistInterventionPage/ImportInterventionsModal.tsx
+++ b/frontend/src/components/TherapistInterventionPage/ImportInterventionsModal.tsx
@@ -19,12 +19,13 @@ type Props = {
 };
 
 // Client-side filename validation — mirrors backend _FILENAME_RE exactly.
-// Matches: {4-5 digits}_{format}_{lang}.{ext}
-// e.g. 3500_web_de.mp4  → external_id = 3500_web
-//      3500_aud_de.mp3  → external_id = 3500_aud
-//      3500_pdf_de.pdf  → external_id = 3500_pdf
+// Matches: {4-5 digits}_{format}_{lang}[_{slot}].{ext}
+// e.g. 3500_web_de.mp4    → external_id = 3500_web
+//      3500_web_de_2.mp4  → external_id = 3500_web  (slot 2)
+//      3500_aud_de.mp3    → external_id = 3500_aud
+//      3500_pdf_de.pdf    → external_id = 3500_pdf
 const FILE_NAME_RE =
-  /^(\d{4,5}_(?:vid|img|pdf|web|aud|app|br|gfx)_[a-z]{2})\.(mp4|mp3|m4a|wav|pdf|jpg|jpeg|png)$/i;
+  /^(\d{4,5}_(?:vid|img|pdf|web|aud|app|br|gfx)_[a-z]{2}(?:_\d+)?)\.(mp4|mp3|m4a|wav|pdf|jpg|jpeg|png)$/i;
 
 const ACCEPTED_EXTENSIONS = '.mp4,.mp3,.m4a,.wav,.pdf,.jpg,.jpeg,.png';
 const ACCEPTED_MIME =
@@ -54,11 +55,12 @@ function validateMediaFile(file: File): ValidatedFile {
   const tooLarge = file.size > maxSizeMB * 1024 * 1024;
   const m = FILE_NAME_RE.exec(file.name);
   if (!m) return { file, valid: false, externalId: null, tooLarge, maxSizeMB };
-  // Derive external_id: strip trailing _XX language suffix
-  const stem = m[1];
-  const parts = stem.split('_');
-  const externalId = parts.length >= 2 ? parts.slice(0, -1).join('_') : stem;
-  return { file, valid: true, externalId: externalId.toLowerCase(), tooLarge, maxSizeMB };
+  // Derive external_id: strip optional trailing slot number then language suffix
+  // e.g. 40500_vid_de_2 → strip '2' → 40500_vid_de → strip 'de' → 40500_vid
+  const parts = m[1].toLowerCase().split('_');
+  const withoutSlot = /^\d+$/.test(parts[parts.length - 1]) ? parts.slice(0, -1) : parts;
+  const externalId = withoutSlot.length >= 2 ? withoutSlot.slice(0, -1).join('_') : withoutSlot.join('_');
+  return { file, valid: true, externalId, tooLarge, maxSizeMB };
 }
 
 const ImportInterventionsModal: React.FC<Props> = observer(({ show, onHide, onSuccess }) => {

--- a/frontend/src/components/TherapistInterventionPage/ImportInterventionsModal.tsx
+++ b/frontend/src/components/TherapistInterventionPage/ImportInterventionsModal.tsx
@@ -59,7 +59,8 @@ function validateMediaFile(file: File): ValidatedFile {
   // e.g. 40500_vid_de_2 → strip '2' → 40500_vid_de → strip 'de' → 40500_vid
   const parts = m[1].toLowerCase().split('_');
   const withoutSlot = /^\d+$/.test(parts[parts.length - 1]) ? parts.slice(0, -1) : parts;
-  const externalId = withoutSlot.length >= 2 ? withoutSlot.slice(0, -1).join('_') : withoutSlot.join('_');
+  const externalId =
+    withoutSlot.length >= 2 ? withoutSlot.slice(0, -1).join('_') : withoutSlot.join('_');
   return { file, valid: true, externalId, tooLarge, maxSizeMB };
 }
 


### PR DESCRIPTION
# Problem
When uploading media files with slot suffixes (e.g. 40500_vid_de_2.mp4, 40500_vid_de_3.mp4), the client-side filename validator showed "Invalid filename format" for every slot file — only the primary file (40500_vid_de.mp4) was accepted.

The backend regex already supported the optional _N slot suffix since the multi-media feature shipped, but the frontend FILE_NAME_RE was never updated to match. Files like 40500_vid_de_2.mp4 through 40500_vid_de_9.mp4 were silently blocked before ever reaching the server.

A second related issue: the externalId display logic also needed updating — without the fix it would have shown 40500_vid_de instead of 40500_vid for slot files.

## Changes
ImportInterventionsModal.tsx

- FILE_NAME_RE: added (?:_\d+)? before the extension to accept slot suffixes

- validateMediaFile: strip the optional trailing slot number before stripping the language code, so the displayed id: remains 40500_vid for all slots

ImportInterventionsModal.test.tsx

- 5 new tests: slot mp4 (_2), slot high number (_9), 5-digit ID with slot, slot mp3, slot m4a

## Test plan

1.  Upload 40500_vid_de.mp4 — shows ✓ id: 40500_vid
2.  Upload 40500_vid_de_2.mp4 through 40500_vid_de_9.mp4 — all show ✓ id: 40500_vid
3.  Upload a random-named file (random.mp4) — still shows ✗
4.  Upload button becomes enabled when at least one slot file is valid
5.  All 32 existing + 5 new ImportInterventionsModal unit tests pass