### PR TITLE
265 bug data missmatch fitbit and bearny app and missing data in bearny

### DIFF
--- a/backend/core/management/commands/fetch_fitbit_data.py
+++ b/backend/core/management/commands/fetch_fitbit_data.py
@@ -144,14 +144,31 @@ class Command(BaseCommand):
                 # ---------------------------
                 # ACTIVE ZONE MINUTES
                 # ---------------------------
+                # Fitbit returns value as {"totalMinutes": N, ...} for most devices,
+                # but some older accounts return a plain integer.  Handle both.
                 azm_url = f"{FITBIT_API_URL}/activities/active-zone-minutes/date/{date_range}.json"
                 azm_resp = requests.get(azm_url, headers=headers)
                 if azm_resp.status_code == 200:
-                    for item in azm_resp.json().get("activities-activeZoneMinutes", []):
+                    azm_items = azm_resp.json().get("activities-activeZoneMinutes", [])
+                    for item in azm_items:
                         dt = datetime.datetime.strptime(item["dateTime"], "%Y-%m-%d").date()
-                        total = (item.get("value") or {}).get("totalMinutes")
+                        val = item.get("value")
+                        if isinstance(val, dict):
+                            total = val.get("totalMinutes")
+                        elif isinstance(val, (int, float)):
+                            total = int(val)
+                        else:
+                            total = None
                         if total is not None:
                             series["activeZoneMinutes"][dt] = int(total)
+                    if not azm_items:
+                        logger.info(
+                            "[Fitbit Sync] AZM endpoint returned no items for %s — "
+                            "active_minutes will fall back to very+fairly active",
+                            user_token.user,
+                        )
+                else:
+                    logger.warning("[Fitbit Sync] AZM fetch HTTP %s for %s", azm_resp.status_code, user_token.user)
 
                 # ---------------------------
                 # BREATHING RATE
@@ -253,6 +270,19 @@ class Command(BaseCommand):
                     | set(max_hr_map.keys())
                     | set(wear_time_map.keys())
                 )
+
+                # Log any days in the 30-day window where the steps endpoint
+                # returned zero rows — these will be missing from the display.
+                expected_dates = {start_date + datetime.timedelta(days=i) for i in range(31)}
+                step_dates = set(series["steps"].keys())
+                missing_step_dates = sorted(expected_dates - step_dates - {today})
+                if missing_step_dates:
+                    logger.warning(
+                        "[Fitbit Sync] Steps missing for %s on %d day(s): %s",
+                        user_token.user,
+                        len(missing_step_dates),
+                        ", ".join(str(d) for d in missing_step_dates),
+                    )
 
                 def sleep_minutes(dt):
                     sd = sleep_data.get(dt)

--- a/backend/core/views/fitbit_sync.py
+++ b/backend/core/views/fitbit_sync.py
@@ -172,7 +172,11 @@ def fetch_fitbit_today_for_user(user, bypass_cooldown: bool = False) -> int:
             if total is not None:
                 series["activeZoneMinutes"][dt] = int(total)
         if not azm_items:
-            logger.info("[fitbit] AZM endpoint returned no items for user=%s date=%s — falling back to very+fairly active minutes", user, date_str)
+            logger.info(
+                "[fitbit] AZM endpoint returned no items for user=%s date=%s — falling back to very+fairly active minutes",
+                user,
+                date_str,
+            )
 
     # Breathing rate
     br_url = f"{FITBIT_API_URL}/br/date/{date_str}/{date_str}.json"

--- a/backend/core/views/fitbit_sync.py
+++ b/backend/core/views/fitbit_sync.py
@@ -153,15 +153,26 @@ def fetch_fitbit_today_for_user(user, bypass_cooldown: bool = False) -> int:
             series["heart_rate_zones"][dt] = val.get("heartRateZones")
 
     # Active Zone Minutes
+    # Fitbit returns value as {"totalMinutes": N, ...} for most devices, but some
+    # older accounts return a plain integer.  Handle both to avoid silent fallback
+    # to minutesVeryActive+minutesFairlyActive (a different, usually larger metric).
     azm_url = f"{FITBIT_API_URL}/activities/active-zone-minutes/date/{date_str}/{date_str}.json"
     azm_resp = requests.get(azm_url, headers=headers, timeout=15)
     if azm_resp.status_code == 200:
-        for item in azm_resp.json().get("activities-activeZoneMinutes", []):
+        azm_items = azm_resp.json().get("activities-activeZoneMinutes", [])
+        for item in azm_items:
             dt = datetime.datetime.strptime(item["dateTime"], "%Y-%m-%d").date()
-            val = item.get("value") or {}
-            total = val.get("totalMinutes")
+            val = item.get("value")
+            if isinstance(val, dict):
+                total = val.get("totalMinutes")
+            elif isinstance(val, (int, float)):
+                total = int(val)
+            else:
+                total = None
             if total is not None:
                 series["activeZoneMinutes"][dt] = int(total)
+        if not azm_items:
+            logger.info("[fitbit] AZM endpoint returned no items for user=%s date=%s — falling back to very+fairly active minutes", user, date_str)
 
     # Breathing rate
     br_url = f"{FITBIT_API_URL}/br/date/{date_str}/{date_str}.json"

--- a/backend/core/views/fitbit_view.py
+++ b/backend/core/views/fitbit_view.py
@@ -21,8 +21,20 @@ from core.views.fitbit_sync import fetch_fitbit_today_for_user
 
 
 def _sleep_minutes(entry: FitbitData) -> int:
+    """Return sleep in minutes, matching what the Fitbit app shows.
+
+    Fitbit app displays *minutes_asleep* (actual sleep, wake phases removed).
+    Legacy records that only have sleep_duration (ms, total time in bed) fall
+    back to duration / 60 000 so existing data is never lost.
+    """
     try:
-        dur_ms = (entry.sleep.sleep_duration or 0) if entry.sleep else 0
+        sleep = entry.sleep if entry else None
+        if not sleep:
+            return 0
+        if sleep.minutes_asleep is not None:
+            return int(sleep.minutes_asleep)
+        # Fallback for records stored before minutes_asleep was populated
+        dur_ms = sleep.sleep_duration or 0
         return int(round(dur_ms / 60000))
     except Exception:
         return 0

--- a/backend/tests/fitbit_views/test_fitbit_views.py
+++ b/backend/tests/fitbit_views/test_fitbit_views.py
@@ -104,12 +104,23 @@ def test_helper_avg_excluding_zero():
 
 def test_helper_sleep_minutes_and_date():
     _, _, patient_user, _ = create_patient_graph()
-    row = FitbitData(
+
+    # minutes_asleep takes priority and matches Fitbit app display (wake phases excluded)
+    row_with_asleep = FitbitData(
+        user=patient_user,
+        date=datetime.now(),
+        sleep=SleepData(sleep_duration=8 * 60 * 60 * 1000, minutes_asleep=435),
+    )
+    assert _sleep_minutes(row_with_asleep) == 435  # 480 min in bed, 435 actually asleep
+
+    # Legacy fallback: only sleep_duration present (no minutes_asleep)
+    row_duration_only = FitbitData(
         user=patient_user,
         date=datetime.now(),
         sleep=SleepData(sleep_duration=90 * 60 * 1000),
     )
-    assert _sleep_minutes(row) == 90
+    assert _sleep_minutes(row_duration_only) == 90
+
     assert _sleep_minutes(SimpleNamespace(sleep="bad")) == 0
     assert _date(datetime(2026, 1, 1, 10, 30)) == "2026-01-01"
 


### PR DESCRIPTION
# Summary:

- **Sleep minutes:** _sleep_minutes() was displaying sleep_duration / 60000 (total time in bed in ms) instead of minutes_asleep (actual sleep, excluding wake phases) — which is what the Fitbit app shows. Fixes values consistently running ~10–20% higher than the Fitbit app. Falls back to duration / 60000 for legacy records that lack minutes_asleep.

- **Active Zone Minutes:** AZM endpoint can return value as either {"totalMinutes": N} (most devices) or a plain integer (older firmware). The old code (value or {}).get("totalMinutes") silently returned None for integer values, causing silent fallback to minutesVeryActive + minutesFairlyActive — a different and usually larger metric. Fixed with explicit isinstance() branching in both fitbit_sync.py (today-only sync) and fetch_fitbit_data.py (30-day batch).

- **Missing data gap detection:** Added warning log when the 30-day batch finds days within the window where the steps endpoint returned no data, making gaps visible in server logs without manual DB inspection. The batch re-run self-corrects by upserting missing days.

## Test plan:

- [ ]  docker exec django pytest tests/fitbit_views/ -v — updated test_helper_sleep_minutes_and_date verifies minutes_asleep is preferred over sleep_duration
- [ ]  On a test account with Fitbit connected: trigger today-only sync and confirm sleep minutes match Fitbit app
- [ ]  Confirm active minutes match Fitbit app for a device that supports AZM
- [ ]  Check server logs after 30-day batch run for any [Fitbit Sync] Steps missing warnings