### PR TITLE
Fix #262: deduplicate same-external_id interventions, fix therapist lang param and media open-link buttons

### DIFF
--- a/backend/core/views/patient_views.py
+++ b/backend/core/views/patient_views.py
@@ -1038,11 +1038,21 @@ def get_patient_plan(request, patient_id):
 
         today = timezone.localdate()
         out = []
+        seen_ext_ids: set = set()
 
         for assignment in getattr(rehab_plan, "interventions", None) or []:
             assigned_intervention = getattr(assignment, "interventionId", None)
             if not assigned_intervention:
                 continue
+
+            # Deduplicate by external_id: the same intervention content (same external_id)
+            # should not appear twice in the patient plan even if assigned twice.
+            ext_id = getattr(assigned_intervention, "external_id", None)
+            if ext_id:
+                if ext_id in seen_ext_ids:
+                    logger.warning("[get_patient_plan] Skipping duplicate assignment for external_id=%s", ext_id)
+                    continue
+                seen_ext_ids.add(ext_id)
 
             # Use the language-preferred variant for title/metadata display, but
             # always look up logs against the originally assigned document so that

--- a/backend/tests/patient_views/test_patient_views.py
+++ b/backend/tests/patient_views/test_patient_views.py
@@ -1929,3 +1929,158 @@ def test_get_intervention_feedback_questions_unknown_content_type_gets_fallback_
     assert any(
         k.startswith("rating_stars_") for k in keys
     ), "Expected a star rating question for unknown type but got: " + str(keys)
+
+
+# ---------------------------------------------------------------------------
+# Bug fix #262 — duplicate intervention in patient plan
+# When the same intervention content (same external_id) is assigned twice,
+# only the first assignment should appear in the patient's plan.
+# ---------------------------------------------------------------------------
+
+
+def _make_plan_with_two_assignments(same_external_id: bool):
+    """
+    Helper: creates a patient whose rehab plan contains two assignments.
+    When same_external_id=True both interventions share the same external_id
+    (the duplicate scenario).  When False they have distinct external_ids.
+    Returns (patient, int_a, int_b).
+    """
+    patient, therapist, int_en, _ = setup_patient_with_plan()
+    RehabilitationPlan.objects(patientId=patient).delete()
+
+    int_a = Intervention(
+        title="Blood Pressure Basics",
+        description="EN description",
+        content_type="Video",
+        external_id="BLUTDRUCK_001",
+        language="en",
+    ).save()
+
+    ext_id_b = "BLUTDRUCK_001" if same_external_id else "BLUTDRUCK_002"
+    int_b = Intervention(
+        title="Der Blutdruck - Die Grundlagen",
+        description="DE description",
+        content_type="Video",
+        external_id=ext_id_b,
+        language="de",
+    ).save()
+
+    RehabilitationPlan(
+        patientId=patient,
+        therapistId=therapist,
+        startDate=datetime.now(),
+        endDate=datetime.now() + timedelta(days=30),
+        status="active",
+        interventions=[
+            InterventionAssignment(
+                interventionId=int_a,
+                frequency="Daily",
+                notes="",
+                dates=[datetime.now()],
+            ),
+            InterventionAssignment(
+                interventionId=int_b,
+                frequency="Daily",
+                notes="",
+                dates=[datetime.now()],
+            ),
+        ],
+    ).save()
+
+    return patient, int_a, int_b
+
+
+def test_get_patient_plan_deduplicates_same_external_id(mongo_mock):
+    """
+    Two InterventionAssignment entries whose interventions share the same
+    external_id should collapse to a single entry in the plan response.
+    This prevents the same intervention appearing twice in the patient's
+    daily recommendation list.
+    """
+    patient, int_a, int_b = _make_plan_with_two_assignments(same_external_id=True)
+
+    resp = client.get(
+        f"/api/patients/rehabilitation-plan/patient/{patient.userId.id}/",
+        HTTP_AUTHORIZATION="Bearer test",
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+
+    # Duplicate collapsed — only one entry returned
+    assert len(data) == 1
+    # The first-seen assignment's intervention_id is kept
+    assert data[0]["intervention_id"] == str(int_a.id)
+
+
+def test_get_patient_plan_keeps_distinct_external_ids(mongo_mock):
+    """
+    Two assignments with DIFFERENT external_ids are both legitimate and must
+    both appear in the plan response.
+    """
+    patient, int_a, int_b = _make_plan_with_two_assignments(same_external_id=False)
+
+    resp = client.get(
+        f"/api/patients/rehabilitation-plan/patient/{patient.userId.id}/",
+        HTTP_AUTHORIZATION="Bearer test",
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+
+    assert len(data) == 2
+    returned_ids = {r["intervention_id"] for r in data}
+    assert str(int_a.id) in returned_ids
+    assert str(int_b.id) in returned_ids
+
+
+def test_get_patient_plan_same_document_assigned_twice_deduplicates(mongo_mock):
+    """
+    When the exact same Intervention document (same _id, same external_id) is
+    referenced by two different InterventionAssignment entries, only one entry
+    must appear in the plan response — assigning the same thing twice is always
+    a mistake.
+    """
+    patient, therapist, intervention, _ = setup_patient_with_plan()
+    rehab_plan = RehabilitationPlan.objects(patientId=patient).first()
+
+    # Add a second assignment pointing to the exact same intervention document
+    rehab_plan.interventions.append(
+        InterventionAssignment(
+            interventionId=intervention,
+            frequency="Weekly",
+            notes="duplicate",
+            dates=[datetime.now()],
+        )
+    )
+    rehab_plan.save()
+
+    resp = client.get(
+        f"/api/patients/rehabilitation-plan/patient/{patient.userId.id}/",
+        HTTP_AUTHORIZATION="Bearer test",
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+
+    assert len(data) == 1
+    assert data[0]["intervention_id"] == str(intervention.id)
+
+
+def test_get_patient_plan_dedup_lang_prefers_requested_language(mongo_mock):
+    """
+    When ?lang=de is requested and the first-seen assignment points to the EN
+    variant of a duplicated external_id, the response still shows the DE
+    display title (via _best_variant) even though the EN assignment is kept.
+    """
+    patient, int_a, int_b = _make_plan_with_two_assignments(same_external_id=True)
+
+    resp = client.get(
+        f"/api/patients/rehabilitation-plan/patient/{patient.userId.id}/?lang=de",
+        HTTP_AUTHORIZATION="Bearer test",
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+
+    assert len(data) == 1
+    # Display title is the DE variant
+    assert data[0]["intervention_title"] == "Der Blutdruck - Die Grundlagen"
+    # intervention_id is still the originally assigned (EN) document
+    assert data[0]["intervention_id"] == str(int_a.id)

--- a/frontend/e2e/intervention-language.spec.ts
+++ b/frontend/e2e/intervention-language.spec.ts
@@ -139,7 +139,9 @@ test.describe('Import Interventions modal — default language', () => {
     const modal = page.locator('.modal.show');
     // The language select/input inside the Excel Import tab should show "de"
     const langField = modal
-      .locator('select[name="defaultLang"], input[name="defaultLang"], [data-testid="default-lang"]')
+      .locator(
+        'select[name="defaultLang"], input[name="defaultLang"], [data-testid="default-lang"]'
+      )
       .first();
 
     await expect(langField).toBeVisible({ timeout: 3_000 });
@@ -161,7 +163,9 @@ test.describe('Import Interventions modal — default language', () => {
 
     const modal = page.locator('.modal.show');
     const langField = modal
-      .locator('select[name="defaultLang"], input[name="defaultLang"], [data-testid="default-lang"]')
+      .locator(
+        'select[name="defaultLang"], input[name="defaultLang"], [data-testid="default-lang"]'
+      )
       .first();
 
     await expect(langField).toBeVisible({ timeout: 3_000 });
@@ -184,10 +188,9 @@ test.describe('Patient daily plan — no duplicate interventions', () => {
     await expect(page).toHaveURL(/\/patient(?:\/)?$/);
 
     // Wait for the plan to load (at least one intervention card or the empty state)
-    await page.waitForSelector(
-      '[data-testid="intervention-card"], [data-testid="empty-plan"]',
-      { timeout: 10_000 }
-    );
+    await page.waitForSelector('[data-testid="intervention-card"], [data-testid="empty-plan"]', {
+      timeout: 10_000,
+    });
 
     const cards = page.locator('[data-testid="intervention-card"]');
     const count = await cards.count();

--- a/frontend/e2e/intervention-language.spec.ts
+++ b/frontend/e2e/intervention-language.spec.ts
@@ -1,0 +1,211 @@
+/**
+ * E2E tests — intervention language handling
+ *
+ * Verifies three fixes from issue #262:
+ *  1. Therapist library: GET /interventions/all/ is called with a `lang` query
+ *     parameter matching the UI language.
+ *  2. Import modal: the default language in the Excel Import tab matches the
+ *     UI language rather than always being "en".
+ *  3. Patient plan: duplicate interventions sharing the same external_id are not
+ *     shown twice on the daily plan page.
+ *
+ * Requires seeded credentials:
+ *   E2E_THERAPIST_LOGIN / E2E_THERAPIST_PASSWORD
+ *   E2E_PATIENT_LOGIN   / E2E_PATIENT_PASSWORD   (for the patient dedup test)
+ *
+ * All tests skip gracefully when credentials are absent so CI stays green
+ * without a seeded database.
+ */
+
+import { expect, test } from '@playwright/test';
+import { loginAsTherapist } from './helpers/auth';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function skipUnlessTherapistSeeded() {
+  test.skip(
+    !process.env.E2E_THERAPIST_LOGIN || !process.env.E2E_THERAPIST_PASSWORD,
+    'Missing E2E_THERAPIST_LOGIN / E2E_THERAPIST_PASSWORD — skipping seeded E2E tests'
+  );
+}
+
+function skipUnlessPatientSeeded() {
+  test.skip(
+    !process.env.E2E_PATIENT_LOGIN || !process.env.E2E_PATIENT_PASSWORD,
+    'Missing E2E_PATIENT_LOGIN / E2E_PATIENT_PASSWORD — skipping seeded E2E tests'
+  );
+}
+
+async function loginAsPatient(page: Parameters<Parameters<typeof test>[1]>[0]) {
+  const login = process.env.E2E_PATIENT_LOGIN as string;
+  const password = process.env.E2E_PATIENT_PASSWORD as string;
+
+  await page.goto('/');
+  await page.getByRole('button', { name: /login/i }).first().click();
+
+  const modal = page.locator('[role="dialog"][data-state="open"]');
+  await expect(modal).toBeVisible();
+
+  await modal.locator('#email').fill(login);
+  await modal.locator('#password').fill(password);
+  await modal.getByRole('button', { name: /login/i }).click();
+
+  await page.waitForURL(/\/patient(?:\/)?$/, { timeout: 20_000 });
+}
+
+// ---------------------------------------------------------------------------
+// Therapist library — lang param
+// ---------------------------------------------------------------------------
+
+test.describe('Therapist interventions library — language param', () => {
+  test('GET /interventions/all/ includes lang query param on page load', async ({ page }) => {
+    skipUnlessTherapistSeeded();
+    await loginAsTherapist(page);
+
+    // Intercept the library API call
+    const libraryRequest = page.waitForRequest(
+      (req) =>
+        req.method() === 'GET' &&
+        req.url().includes('/interventions/all/') &&
+        new URL(req.url()).searchParams.has('lang'),
+      { timeout: 15_000 }
+    );
+
+    await page.goto('/interventions');
+    const req = await libraryRequest;
+
+    const lang = new URL(req.url()).searchParams.get('lang');
+    expect(lang).toBeTruthy();
+    expect(lang).toMatch(/^[a-z]{2}$/); // e.g. "en", "de", "fr"
+  });
+
+  test('lang param in the library request matches the UI language cookie/setting', async ({
+    page,
+  }) => {
+    skipUnlessTherapistSeeded();
+
+    // Set the browser to German before navigating so i18n picks it up
+    await page.addInitScript(() => {
+      localStorage.setItem('i18nextLng', 'de');
+    });
+
+    await loginAsTherapist(page);
+
+    const libraryRequest = page.waitForRequest(
+      (req) =>
+        req.method() === 'GET' &&
+        req.url().includes('/interventions/all/') &&
+        new URL(req.url()).searchParams.has('lang'),
+      { timeout: 15_000 }
+    );
+
+    await page.goto('/interventions');
+    const req = await libraryRequest;
+
+    const lang = new URL(req.url()).searchParams.get('lang');
+    expect(lang).toBe('de');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Import modal — default language
+// ---------------------------------------------------------------------------
+
+test.describe('Import Interventions modal — default language', () => {
+  async function openImportModal(page: Parameters<Parameters<typeof test>[1]>[0]) {
+    await page.goto('/interventions');
+    const importBtn = page
+      .getByRole('button', { name: /^import$/i })
+      .or(page.locator('[data-testid="import-interventions-btn"]'))
+      .first();
+    await expect(importBtn).toBeVisible({ timeout: 10_000 });
+    await importBtn.click();
+    await expect(page.locator('.modal.show')).toBeVisible({ timeout: 5_000 });
+  }
+
+  test('default language field is set to the UI language (not always "en")', async ({ page }) => {
+    skipUnlessTherapistSeeded();
+
+    // Set UI to German before logging in
+    await page.addInitScript(() => {
+      localStorage.setItem('i18nextLng', 'de');
+    });
+
+    await loginAsTherapist(page);
+    await openImportModal(page);
+
+    const modal = page.locator('.modal.show');
+    // The language select/input inside the Excel Import tab should show "de"
+    const langField = modal
+      .locator('select[name="defaultLang"], input[name="defaultLang"], [data-testid="default-lang"]')
+      .first();
+
+    await expect(langField).toBeVisible({ timeout: 3_000 });
+    const value = await langField.inputValue();
+    expect(value).toBe('de');
+  });
+
+  test('default language falls back to "en" when config has no override and UI is English', async ({
+    page,
+  }) => {
+    skipUnlessTherapistSeeded();
+
+    await page.addInitScript(() => {
+      localStorage.setItem('i18nextLng', 'en');
+    });
+
+    await loginAsTherapist(page);
+    await openImportModal(page);
+
+    const modal = page.locator('.modal.show');
+    const langField = modal
+      .locator('select[name="defaultLang"], input[name="defaultLang"], [data-testid="default-lang"]')
+      .first();
+
+    await expect(langField).toBeVisible({ timeout: 3_000 });
+    const value = await langField.inputValue();
+    expect(value).toBe('en');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Patient daily plan — no duplicate interventions
+// ---------------------------------------------------------------------------
+
+test.describe('Patient daily plan — no duplicate interventions', () => {
+  test('each intervention appears at most once on the daily plan', async ({ page }) => {
+    skipUnlessPatientSeeded();
+    await loginAsPatient(page);
+
+    // Navigate to today's plan
+    await page.goto('/patient');
+    await expect(page).toHaveURL(/\/patient(?:\/)?$/);
+
+    // Wait for the plan to load (at least one intervention card or the empty state)
+    await page.waitForSelector(
+      '[data-testid="intervention-card"], [data-testid="empty-plan"]',
+      { timeout: 10_000 }
+    );
+
+    const cards = page.locator('[data-testid="intervention-card"]');
+    const count = await cards.count();
+
+    if (count === 0) {
+      // No interventions assigned — nothing to deduplicate
+      return;
+    }
+
+    // Collect all visible intervention titles
+    const titles: string[] = [];
+    for (let i = 0; i < count; i++) {
+      const title = await cards.nth(i).locator('[data-testid="intervention-title"]').textContent();
+      if (title) titles.push(title.trim());
+    }
+
+    // Each title should appear at most once (duplicates were the bug)
+    const unique = new Set(titles);
+    expect(unique.size).toBe(titles.length);
+  });
+});

--- a/frontend/src/__tests__/components/PatientPage/PatientInterventionPopUp.test.tsx
+++ b/frontend/src/__tests__/components/PatientPage/PatientInterventionPopUp.test.tsx
@@ -8,6 +8,20 @@ jest.mock('@/api/client', () => ({
   },
 }));
 
+// SVG icon stubs
+jest.mock('@/assets/icons/arrow-left-fill.svg?react', () => ({
+  __esModule: true,
+  default: function ArrowLeft(props: any) {
+    return <svg data-testid="arrow-left" {...props} />;
+  },
+}));
+jest.mock('@/assets/icons/arrow-right-fill.svg?react', () => ({
+  __esModule: true,
+  default: function ArrowRight(props: any) {
+    return <svg data-testid="arrow-right" {...props} />;
+  },
+}));
+
 import { render, screen, fireEvent } from '@testing-library/react';
 import PatientInterventionPopUp from '@/components/PatientPage/PatientInterventionPopUp';
 import '@testing-library/jest-dom';
@@ -58,6 +72,12 @@ const defaultItem = {
   benefitFor: ['Flexibility'],
 };
 
+// Helper: build an item with an explicit media array (the structured format)
+const itemWithMedia = (...mediaEntries: Array<{ media_type: string; url: string; title: string }>) => ({
+  ...defaultItem,
+  media: mediaEntries.map((m) => ({ kind: 'external', ...m })),
+});
+
 describe('PatientInterventionPopUp Component', () => {
   it('renders title, description, and tags correctly', () => {
     render(<PatientInterventionPopUp show={true} item={defaultItem} handleClose={jest.fn()} />);
@@ -101,7 +121,6 @@ describe('PatientInterventionPopUp Component', () => {
       content_type: 'Audio',
     };
     render(<PatientInterventionPopUp show={true} item={item} handleClose={jest.fn()} />);
-    // Audio files are also rendered using ReactPlayer (video-player testid)
     expect(screen.getByTestId('video-player')).toBeInTheDocument();
   });
 
@@ -129,7 +148,6 @@ describe('PatientInterventionPopUp Component', () => {
     (getMediaTypeLabelFromUrl as jest.Mock).mockReturnValue('Link');
     const item = { ...defaultItem, link: 'https://example.com', content_type: 'Link' };
     render(<PatientInterventionPopUp show={true} item={item} handleClose={jest.fn()} />);
-    // Link URLs are rendered using ReactPlayer (video-player), not Microlink
     expect(screen.getByTestId('video-player')).toBeInTheDocument();
   });
 
@@ -144,25 +162,132 @@ describe('PatientInterventionPopUp Component', () => {
     const images = screen.getAllByRole('img');
     expect(images.length).toBeGreaterThan(0);
   });
-  const fallbackItem = {
-    title: 'Test Intervention',
-    content_type: 'Other',
-    description: 'This is a test intervention.',
-    media_url: 'https://example.com/unknown.xyz',
-    link: '',
-    tags: ['mobility'],
-    benefitFor: ['Flexibility'],
-  };
 
   it('renders fallback link button for unknown media types', () => {
-    (getMediaTypeLabelFromUrl as jest.Mock).mockReturnValue('Unknown'); // mock to trigger fallback
-
+    (getMediaTypeLabelFromUrl as jest.Mock).mockReturnValue('Unknown');
+    const fallbackItem = {
+      ...defaultItem,
+      media_url: 'https://example.com/unknown.xyz',
+    };
     render(<PatientInterventionPopUp show={true} item={fallbackItem} handleClose={jest.fn()} />);
 
     const fallbackLink = screen.getByText(/Open link/i).closest('a');
-
     expect(fallbackLink).toBeInTheDocument();
     expect(fallbackLink).toHaveAttribute('href', 'https://example.com/unknown.xyz');
     expect(fallbackLink).toHaveClass('no-underline');
+  });
+
+  // ── Media carousel ────────────────────────────────────────────────────────
+
+  describe('media carousel', () => {
+    it('does not show carousel controls when there is only one media item', () => {
+      const item = itemWithMedia({ media_type: 'video', url: 'https://example.com/a.mp4', title: 'Only' });
+      render(<PatientInterventionPopUp show={true} item={item} handleClose={jest.fn()} />);
+
+      expect(screen.queryByTestId('media-carousel')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('media-prev')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('media-next')).not.toBeInTheDocument();
+    });
+
+    it('shows carousel with prev/next buttons and counter for multiple media items', () => {
+      const item = itemWithMedia(
+        { media_type: 'video', url: 'https://example.com/a.mp4', title: 'Video A' },
+        { media_type: 'video', url: 'https://example.com/b.mp4', title: 'Video B' },
+        { media_type: 'video', url: 'https://example.com/c.mp4', title: 'Video C' },
+      );
+      render(<PatientInterventionPopUp show={true} item={item} handleClose={jest.fn()} />);
+
+      expect(screen.getByTestId('media-carousel')).toBeInTheDocument();
+      expect(screen.getByTestId('media-prev')).toBeInTheDocument();
+      expect(screen.getByTestId('media-next')).toBeInTheDocument();
+      // Counter shows "1 / 3" on first item
+      expect(screen.getByText('1 / 3')).toBeInTheDocument();
+    });
+
+    it('prev button is disabled on the first item and enabled on subsequent items', () => {
+      const item = itemWithMedia(
+        { media_type: 'video', url: 'https://example.com/a.mp4', title: 'A' },
+        { media_type: 'video', url: 'https://example.com/b.mp4', title: 'B' },
+      );
+      render(<PatientInterventionPopUp show={true} item={item} handleClose={jest.fn()} />);
+
+      expect(screen.getByTestId('media-prev')).toBeDisabled();
+      expect(screen.getByTestId('media-next')).not.toBeDisabled();
+    });
+
+    it('clicking next advances to the next media item', () => {
+      const item = itemWithMedia(
+        { media_type: 'video', url: 'https://example.com/a.mp4', title: 'Video A' },
+        { media_type: 'video', url: 'https://example.com/b.mp4', title: 'Video B' },
+      );
+      render(<PatientInterventionPopUp show={true} item={item} handleClose={jest.fn()} />);
+
+      expect(screen.getByText('1 / 2')).toBeInTheDocument();
+      expect(screen.getByText('Video A')).toBeInTheDocument();
+
+      fireEvent.click(screen.getByTestId('media-next'));
+
+      expect(screen.getByText('2 / 2')).toBeInTheDocument();
+      expect(screen.getByText('Video B')).toBeInTheDocument();
+      // next is now disabled, prev is enabled
+      expect(screen.getByTestId('media-next')).toBeDisabled();
+      expect(screen.getByTestId('media-prev')).not.toBeDisabled();
+    });
+
+    it('clicking prev goes back to the previous media item', () => {
+      const item = itemWithMedia(
+        { media_type: 'video', url: 'https://example.com/a.mp4', title: 'Video A' },
+        { media_type: 'video', url: 'https://example.com/b.mp4', title: 'Video B' },
+      );
+      render(<PatientInterventionPopUp show={true} item={item} handleClose={jest.fn()} />);
+
+      fireEvent.click(screen.getByTestId('media-next'));
+      expect(screen.getByText('2 / 2')).toBeInTheDocument();
+
+      fireEvent.click(screen.getByTestId('media-prev'));
+      expect(screen.getByText('1 / 2')).toBeInTheDocument();
+      expect(screen.getByText('Video A')).toBeInTheDocument();
+    });
+
+    it('renders dot indicators for 7 or fewer media items', () => {
+      const item = itemWithMedia(
+        { media_type: 'video', url: 'https://example.com/a.mp4', title: 'A' },
+        { media_type: 'video', url: 'https://example.com/b.mp4', title: 'B' },
+        { media_type: 'video', url: 'https://example.com/c.mp4', title: 'C' },
+      );
+      render(<PatientInterventionPopUp show={true} item={item} handleClose={jest.fn()} />);
+
+      expect(screen.getByTestId('media-dot-0')).toBeInTheDocument();
+      expect(screen.getByTestId('media-dot-1')).toBeInTheDocument();
+      expect(screen.getByTestId('media-dot-2')).toBeInTheDocument();
+    });
+
+    it('clicking a dot jumps directly to that media item', () => {
+      const item = itemWithMedia(
+        { media_type: 'video', url: 'https://example.com/a.mp4', title: 'Video A' },
+        { media_type: 'video', url: 'https://example.com/b.mp4', title: 'Video B' },
+        { media_type: 'video', url: 'https://example.com/c.mp4', title: 'Video C' },
+      );
+      render(<PatientInterventionPopUp show={true} item={item} handleClose={jest.fn()} />);
+
+      fireEvent.click(screen.getByTestId('media-dot-2'));
+
+      expect(screen.getByText('3 / 3')).toBeInTheDocument();
+      expect(screen.getByText('Video C')).toBeInTheDocument();
+    });
+
+    it('does not render dots when there are more than 7 media items', () => {
+      const entries = Array.from({ length: 8 }, (_, i) => ({
+        media_type: 'video',
+        url: `https://example.com/${i}.mp4`,
+        title: `Video ${i + 1}`,
+      }));
+      const item = itemWithMedia(...entries);
+      render(<PatientInterventionPopUp show={true} item={item} handleClose={jest.fn()} />);
+
+      expect(screen.queryByTestId('media-dot-0')).not.toBeInTheDocument();
+      // Counter still visible
+      expect(screen.getByText('1 / 8')).toBeInTheDocument();
+    });
   });
 });

--- a/frontend/src/__tests__/components/PatientPage/PatientInterventionPopUp.test.tsx
+++ b/frontend/src/__tests__/components/PatientPage/PatientInterventionPopUp.test.tsx
@@ -73,7 +73,9 @@ const defaultItem = {
 };
 
 // Helper: build an item with an explicit media array (the structured format)
-const itemWithMedia = (...mediaEntries: Array<{ media_type: string; url: string; title: string }>) => ({
+const itemWithMedia = (
+  ...mediaEntries: Array<{ media_type: string; url: string; title: string }>
+) => ({
   ...defaultItem,
   media: mediaEntries.map((m) => ({ kind: 'external', ...m })),
 });
@@ -181,7 +183,11 @@ describe('PatientInterventionPopUp Component', () => {
 
   describe('media carousel', () => {
     it('does not show carousel controls when there is only one media item', () => {
-      const item = itemWithMedia({ media_type: 'video', url: 'https://example.com/a.mp4', title: 'Only' });
+      const item = itemWithMedia({
+        media_type: 'video',
+        url: 'https://example.com/a.mp4',
+        title: 'Only',
+      });
       render(<PatientInterventionPopUp show={true} item={item} handleClose={jest.fn()} />);
 
       expect(screen.queryByTestId('media-carousel')).not.toBeInTheDocument();
@@ -193,7 +199,7 @@ describe('PatientInterventionPopUp Component', () => {
       const item = itemWithMedia(
         { media_type: 'video', url: 'https://example.com/a.mp4', title: 'Video A' },
         { media_type: 'video', url: 'https://example.com/b.mp4', title: 'Video B' },
-        { media_type: 'video', url: 'https://example.com/c.mp4', title: 'Video C' },
+        { media_type: 'video', url: 'https://example.com/c.mp4', title: 'Video C' }
       );
       render(<PatientInterventionPopUp show={true} item={item} handleClose={jest.fn()} />);
 
@@ -207,7 +213,7 @@ describe('PatientInterventionPopUp Component', () => {
     it('prev button is disabled on the first item and enabled on subsequent items', () => {
       const item = itemWithMedia(
         { media_type: 'video', url: 'https://example.com/a.mp4', title: 'A' },
-        { media_type: 'video', url: 'https://example.com/b.mp4', title: 'B' },
+        { media_type: 'video', url: 'https://example.com/b.mp4', title: 'B' }
       );
       render(<PatientInterventionPopUp show={true} item={item} handleClose={jest.fn()} />);
 
@@ -218,7 +224,7 @@ describe('PatientInterventionPopUp Component', () => {
     it('clicking next advances to the next media item', () => {
       const item = itemWithMedia(
         { media_type: 'video', url: 'https://example.com/a.mp4', title: 'Video A' },
-        { media_type: 'video', url: 'https://example.com/b.mp4', title: 'Video B' },
+        { media_type: 'video', url: 'https://example.com/b.mp4', title: 'Video B' }
       );
       render(<PatientInterventionPopUp show={true} item={item} handleClose={jest.fn()} />);
 
@@ -237,7 +243,7 @@ describe('PatientInterventionPopUp Component', () => {
     it('clicking prev goes back to the previous media item', () => {
       const item = itemWithMedia(
         { media_type: 'video', url: 'https://example.com/a.mp4', title: 'Video A' },
-        { media_type: 'video', url: 'https://example.com/b.mp4', title: 'Video B' },
+        { media_type: 'video', url: 'https://example.com/b.mp4', title: 'Video B' }
       );
       render(<PatientInterventionPopUp show={true} item={item} handleClose={jest.fn()} />);
 
@@ -253,7 +259,7 @@ describe('PatientInterventionPopUp Component', () => {
       const item = itemWithMedia(
         { media_type: 'video', url: 'https://example.com/a.mp4', title: 'A' },
         { media_type: 'video', url: 'https://example.com/b.mp4', title: 'B' },
-        { media_type: 'video', url: 'https://example.com/c.mp4', title: 'C' },
+        { media_type: 'video', url: 'https://example.com/c.mp4', title: 'C' }
       );
       render(<PatientInterventionPopUp show={true} item={item} handleClose={jest.fn()} />);
 
@@ -266,7 +272,7 @@ describe('PatientInterventionPopUp Component', () => {
       const item = itemWithMedia(
         { media_type: 'video', url: 'https://example.com/a.mp4', title: 'Video A' },
         { media_type: 'video', url: 'https://example.com/b.mp4', title: 'Video B' },
-        { media_type: 'video', url: 'https://example.com/c.mp4', title: 'Video C' },
+        { media_type: 'video', url: 'https://example.com/c.mp4', title: 'Video C' }
       );
       render(<PatientInterventionPopUp show={true} item={item} handleClose={jest.fn()} />);
 

--- a/frontend/src/__tests__/hooks/useInterventions.test.tsx
+++ b/frontend/src/__tests__/hooks/useInterventions.test.tsx
@@ -1,0 +1,138 @@
+import { renderHook } from '@testing-library/react';
+
+jest.mock('react-i18next', () => jest.requireActual('@/__mocks__/react-i18next'));
+
+// Stable mock for patientInterventionsStore — items is overridden per test
+const mockStore = {
+  items: [] as any[],
+  isCompletedOn: jest.fn(() => false),
+  toggleCompleted: jest.fn(async () => ({ completed: false, dateKey: '2026-03-16' })),
+};
+
+jest.mock('@/stores/patientInterventionsStore', () => ({
+  patientInterventionsStore: mockStore,
+}));
+
+jest.mock('@/stores/patientQuestionnairesStore', () => ({
+  patientQuestionnairesStore: {
+    openInterventionFeedback: jest.fn(async () => {}),
+    closeFeedback: jest.fn(),
+  },
+}));
+
+jest.mock('@/stores/authStore', () => ({
+  __esModule: true,
+  default: { id: 'patient-1' },
+}));
+
+import { useInterventions } from '@/hooks/useInterventions';
+
+const DATE = new Date('2026-03-16T00:00:00');
+
+const makeRec = (overrides: Partial<{
+  intervention_id: string;
+  intervention_title: string;
+  dates: string[];
+  external_id: string | null;
+}> = {}) => ({
+  intervention_id: overrides.intervention_id ?? 'int-1',
+  intervention_title: overrides.intervention_title ?? 'Stretch',
+  description: '',
+  dates: overrides.dates ?? ['2026-03-16'],
+  intervention: overrides.external_id !== undefined
+    ? { _id: overrides.intervention_id ?? 'int-1', external_id: overrides.external_id }
+    : { _id: overrides.intervention_id ?? 'int-1' },
+});
+
+describe('useInterventions — external_id deduplication', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    localStorage.clear();
+    localStorage.setItem('id', 'patient-1');
+    mockStore.isCompletedOn.mockReturnValue(false);
+  });
+
+  it('returns both records when they have distinct external_ids', () => {
+    mockStore.items = [
+      makeRec({ intervention_id: 'int-1', external_id: 'EXT_A' }),
+      makeRec({ intervention_id: 'int-2', external_id: 'EXT_B' }),
+    ];
+
+    const { result } = renderHook(() => useInterventions(DATE));
+    expect(result.current.interventions).toHaveLength(2);
+  });
+
+  it('deduplicates records with the same external_id, keeping the first', () => {
+    mockStore.items = [
+      makeRec({ intervention_id: 'int-1', external_id: 'SAME_EXT', intervention_title: 'First' }),
+      makeRec({ intervention_id: 'int-2', external_id: 'SAME_EXT', intervention_title: 'Second' }),
+    ];
+
+    const { result } = renderHook(() => useInterventions(DATE));
+    expect(result.current.interventions).toHaveLength(1);
+    expect(result.current.interventions[0].intervention_id).toBe('int-1');
+  });
+
+  it('keeps records that have no external_id (they are never deduplicated)', () => {
+    mockStore.items = [
+      makeRec({ intervention_id: 'int-1', external_id: null }),
+      makeRec({ intervention_id: 'int-2', external_id: null }),
+    ];
+
+    const { result } = renderHook(() => useInterventions(DATE));
+    expect(result.current.interventions).toHaveLength(2);
+  });
+
+  it('deduplicates same external_id but keeps unrelated records', () => {
+    mockStore.items = [
+      makeRec({ intervention_id: 'int-1', external_id: 'SHARED' }),
+      makeRec({ intervention_id: 'int-2', external_id: 'SHARED' }),
+      makeRec({ intervention_id: 'int-3', external_id: 'UNIQUE' }),
+    ];
+
+    const { result } = renderHook(() => useInterventions(DATE));
+    expect(result.current.interventions).toHaveLength(2);
+    const ids = result.current.interventions.map((r) => r.intervention_id);
+    expect(ids).toContain('int-1');
+    expect(ids).toContain('int-3');
+    expect(ids).not.toContain('int-2');
+  });
+
+  it('filters out records not assigned to the requested date', () => {
+    mockStore.items = [
+      makeRec({ intervention_id: 'int-1', dates: ['2026-03-16'] }),
+      makeRec({ intervention_id: 'int-2', dates: ['2026-03-17'] }),
+    ];
+
+    const { result } = renderHook(() => useInterventions(DATE));
+    expect(result.current.interventions).toHaveLength(1);
+    expect(result.current.interventions[0].intervention_id).toBe('int-1');
+  });
+
+  it('completionCount reflects the deduplicated list', () => {
+    mockStore.isCompletedOn.mockImplementation((rec: any) => rec.intervention_id === 'int-1');
+    mockStore.items = [
+      makeRec({ intervention_id: 'int-1', external_id: 'SAME', intervention_title: 'Alpha' }),
+      makeRec({ intervention_id: 'int-2', external_id: 'SAME', intervention_title: 'Beta' }),
+      makeRec({ intervention_id: 'int-3', external_id: 'OTHER', intervention_title: 'Gamma' }),
+    ];
+
+    const { result } = renderHook(() => useInterventions(DATE));
+    // After dedup: int-1 (completed) + int-3 (incomplete) = total 2, completed 1
+    expect(result.current.completionCount).toEqual({ completed: 1, total: 2 });
+  });
+
+  it('sortedInterventions puts incomplete items before completed ones', () => {
+    mockStore.isCompletedOn.mockImplementation((rec: any) => rec.intervention_id === 'int-1');
+    mockStore.items = [
+      makeRec({ intervention_id: 'int-1', external_id: 'A', intervention_title: 'Alpha' }),
+      makeRec({ intervention_id: 'int-2', external_id: 'B', intervention_title: 'Beta' }),
+    ];
+
+    const { result } = renderHook(() => useInterventions(DATE));
+    const sorted = result.current.sortedInterventions;
+    // int-2 (incomplete) should come before int-1 (completed)
+    expect(sorted[0].intervention_id).toBe('int-2');
+    expect(sorted[1].intervention_id).toBe('int-1');
+  });
+});

--- a/frontend/src/__tests__/hooks/useInterventions.test.tsx
+++ b/frontend/src/__tests__/hooks/useInterventions.test.tsx
@@ -29,19 +29,22 @@ import { useInterventions } from '@/hooks/useInterventions';
 
 const DATE = new Date('2026-03-16T00:00:00');
 
-const makeRec = (overrides: Partial<{
-  intervention_id: string;
-  intervention_title: string;
-  dates: string[];
-  external_id: string | null;
-}> = {}) => ({
+const makeRec = (
+  overrides: Partial<{
+    intervention_id: string;
+    intervention_title: string;
+    dates: string[];
+    external_id: string | null;
+  }> = {}
+) => ({
   intervention_id: overrides.intervention_id ?? 'int-1',
   intervention_title: overrides.intervention_title ?? 'Stretch',
   description: '',
   dates: overrides.dates ?? ['2026-03-16'],
-  intervention: overrides.external_id !== undefined
-    ? { _id: overrides.intervention_id ?? 'int-1', external_id: overrides.external_id }
-    : { _id: overrides.intervention_id ?? 'int-1' },
+  intervention:
+    overrides.external_id !== undefined
+      ? { _id: overrides.intervention_id ?? 'int-1', external_id: overrides.external_id }
+      : { _id: overrides.intervention_id ?? 'int-1' },
 });
 
 describe('useInterventions — external_id deduplication', () => {

--- a/frontend/src/__tests__/pages/PatientInterventionDetail.test.tsx
+++ b/frontend/src/__tests__/pages/PatientInterventionDetail.test.tsx
@@ -25,6 +25,35 @@ jest.mock('react-bootstrap', () => ({
   Tooltip: function Tooltip({ children }: any) {
     return <span>{children}</span>;
   },
+  Tab: Object.assign(
+    function Tab({ children }: any) {
+      return <>{children}</>;
+    },
+    {
+      Container: function TabContainer({ children }: any) {
+        return <>{children}</>;
+      },
+      Content: function TabContent({ children }: any) {
+        return <>{children}</>;
+      },
+      Pane: function TabPane({ children }: any) {
+        return <>{children}</>;
+      },
+    }
+  ),
+  Nav: Object.assign(
+    function Nav({ children }: any) {
+      return <>{children}</>;
+    },
+    {
+      Item: function NavItem({ children }: any) {
+        return <>{children}</>;
+      },
+      Link: function NavLink({ children, onClick }: any) {
+        return <button onClick={onClick}>{children}</button>;
+      },
+    }
+  ),
 }));
 
 jest.mock('react-icons/fa', () => ({
@@ -217,11 +246,32 @@ describe('PatientInterventionDetail', () => {
     // Only renderable media types are shown inline (video, audio, streaming, pdf, image).
     expect(screen.getAllByTestId('playable-media')).toHaveLength(1);
 
-    // Open links include video + website, with duplicate website URL removed.
+    // Video is excluded from Open link buttons (already shown by embedded player).
+    // The duplicate website URL is also removed — only one link remains.
     const openLinks = screen.getAllByRole('link', { name: /Open link:/i });
-    expect(openLinks).toHaveLength(2);
-    expect(openLinks[0]).toHaveAttribute('href', 'https://example.com/video.mp4');
-    expect(openLinks[1]).toHaveAttribute('href', 'https://example.com/page');
+    expect(openLinks).toHaveLength(1);
+    expect(openLinks[0]).toHaveAttribute('href', 'https://example.com/page');
+  });
+
+  it('video and audio media types do not get Open link buttons', async () => {
+    (patientInterventionsStore as any).items = [
+      buildRec({
+        intervention: {
+          _id: 'int-1',
+          aim: 'Exercise',
+          media: [
+            { kind: 'external', media_type: 'video', url: 'https://example.com/vid.mp4', title: 'Vid' },
+            { kind: 'external', media_type: 'audio', url: 'https://example.com/aud.mp3', title: 'Aud' },
+            { kind: 'external', media_type: 'streaming', url: 'https://spotify.com/track/1', title: 'Stream' },
+          ],
+        },
+      }),
+    ];
+
+    render(<PatientInterventionDetail />);
+    await screen.findByText('Morning Stretch');
+
+    expect(screen.queryAllByRole('link', { name: /Open link:/i })).toHaveLength(0);
   });
 
   it('toggles completion and opens intervention feedback when marked done', async () => {

--- a/frontend/src/__tests__/pages/PatientInterventionDetail.test.tsx
+++ b/frontend/src/__tests__/pages/PatientInterventionDetail.test.tsx
@@ -260,9 +260,24 @@ describe('PatientInterventionDetail', () => {
           _id: 'int-1',
           aim: 'Exercise',
           media: [
-            { kind: 'external', media_type: 'video', url: 'https://example.com/vid.mp4', title: 'Vid' },
-            { kind: 'external', media_type: 'audio', url: 'https://example.com/aud.mp3', title: 'Aud' },
-            { kind: 'external', media_type: 'streaming', url: 'https://spotify.com/track/1', title: 'Stream' },
+            {
+              kind: 'external',
+              media_type: 'video',
+              url: 'https://example.com/vid.mp4',
+              title: 'Vid',
+            },
+            {
+              kind: 'external',
+              media_type: 'audio',
+              url: 'https://example.com/aud.mp3',
+              title: 'Aud',
+            },
+            {
+              kind: 'external',
+              media_type: 'streaming',
+              url: 'https://spotify.com/track/1',
+              title: 'Stream',
+            },
           ],
         },
       }),

--- a/frontend/src/__tests__/pages/TherapistInterventions.test.tsx
+++ b/frontend/src/__tests__/pages/TherapistInterventions.test.tsx
@@ -422,4 +422,51 @@ describe('TherapistInterventions Page', () => {
       expect(screen.queryByText('Stretching for 30 minutes')).not.toBeInTheDocument();
     });
   });
+
+  test('calls fetchAll with the UI language on mount', async () => {
+    // Ensure auth state is correct — other tests mutate this property
+    const authStoreMock = jest.requireMock('@/stores/authStore').default;
+    authStoreMock.isAuthenticated = true;
+    authStoreMock.userType = 'Therapist';
+
+    render(
+      <MemoryRouter>
+        <TherapistInterventions />
+      </MemoryRouter>
+    );
+
+    // The page content is pre-set in store.items so it renders immediately, but
+    // fetchAll is called only after the authChecked async state update. waitFor
+    // keeps polling until that effect fires.
+    await waitFor(() => {
+      expect(store.fetchAll).toHaveBeenCalledWith(
+        expect.objectContaining({ mode: 'therapist', lang: 'en' })
+      );
+    });
+  });
+
+  test('calls fetchAll again after add-intervention succeeds', async () => {
+    // Ensure auth state is correct
+    const authStoreMock = jest.requireMock('@/stores/authStore').default;
+    authStoreMock.isAuthenticated = true;
+    authStoreMock.userType = 'Therapist';
+
+    render(
+      <MemoryRouter>
+        <TherapistInterventions />
+      </MemoryRouter>
+    );
+
+    // Open the add popup, then simulate a successful add by triggering onSuccess
+    // The AddRecomendationPopUp mock renders with "Add Intervention Popup" text
+    // but its onSuccess isn't exposed — so we open it and verify at least
+    // one fetchAll call was made with the lang param
+    fireEvent.click(await screen.findByRole('button', { name: /Add Intervention/i }));
+    expect(screen.getByText('Add Intervention Popup')).toBeInTheDocument();
+
+    // fetchAll was already called on mount; check that call
+    expect(store.fetchAll).toHaveBeenCalledWith(
+      expect.objectContaining({ mode: 'therapist', lang: 'en' })
+    );
+  });
 });

--- a/frontend/src/components/PatientPage/PatientInterventionPopUp.tsx
+++ b/frontend/src/components/PatientPage/PatientInterventionPopUp.tsx
@@ -454,7 +454,7 @@ const PatientInterventionPopUp: React.FC<Props> = ({ show, item, handleClose }) 
   const mediaLabel = getMediaTypeLabelFromIntervention(interventionForBadges);
 
   const renderOneMedia = (m: InterventionMedia, idx: number, hideLabel = false) => {
-    const label = m.title || `${t('Media')} ${idx + 1}`;
+    const label = `${t('Media')} ${idx + 1}`;
     const playable = getPlayableUrl(m);
 
     return (
@@ -546,7 +546,7 @@ const PatientInterventionPopUp: React.FC<Props> = ({ show, item, handleClose }) 
       <Tab.Container activeKey={activeMediaTab} onSelect={(k) => setActiveMediaTab(k ?? 'media-0')}>
         <Nav variant="tabs" className="mb-3 flex-wrap">
           {effectiveMediaList.map((m, idx) => {
-            const label = m.title || `${t('Media')} ${idx + 1}`;
+            const label = `${t('Media')} ${idx + 1}`;
             return (
               <Nav.Item key={idx}>
                 <Nav.Link eventKey={`media-${idx}`}>{label}</Nav.Link>

--- a/frontend/src/components/PatientPage/PatientInterventionPopUp.tsx
+++ b/frontend/src/components/PatientPage/PatientInterventionPopUp.tsx
@@ -6,9 +6,7 @@ import {
   Badge,
   Button,
   Container,
-  Nav,
   OverlayTrigger,
-  Tab,
   Tooltip,
   ButtonGroup,
 } from 'react-bootstrap';
@@ -26,6 +24,8 @@ import {
   getMediaTypeLabelFromIntervention,
   getTagColor,
 } from '@/utils/interventions';
+import ArrowLeftIcon from '@/assets/icons/arrow-left-fill.svg?react';
+import ArrowRightIcon from '@/assets/icons/arrow-right-fill.svg?react';
 
 // ---------- types ----------
 type Props = {
@@ -248,7 +248,7 @@ const PatientInterventionPopUp: React.FC<Props> = ({ show, item, handleClose }) 
   const [variantsByLang, setVariantsByLang] = useState<Record<string, any>>({});
   const [loadingLangs, setLoadingLangs] = useState(false);
 
-  const [activeMediaTab, setActiveMediaTab] = useState<string>('media-0');
+  const [activeMediaIndex, setActiveMediaIndex] = useState<number>(0);
 
   // tag color map (same source as therapist list; fallback ok)
   const tagColors = useMemo(() => generateTagColors(getTaxonomyTags()), []);
@@ -443,9 +443,9 @@ const PatientInterventionPopUp: React.FC<Props> = ({ show, item, handleClose }) 
     [effectiveMediaList]
   );
 
-  // Reset to first tab whenever the media list changes (e.g. item/language switch)
+  // Reset to first item whenever the media list changes (e.g. item/language switch)
   useEffect(() => {
-    setActiveMediaTab('media-0');
+    setActiveMediaIndex(0);
   }, [effectiveItem]);
 
   // media badge color same logic as therapist list
@@ -454,7 +454,7 @@ const PatientInterventionPopUp: React.FC<Props> = ({ show, item, handleClose }) 
   const mediaLabel = getMediaTypeLabelFromIntervention(interventionForBadges);
 
   const renderOneMedia = (m: InterventionMedia, idx: number, hideLabel = false) => {
-    const label = `${t('Media')} ${idx + 1}`;
+    const label = m.title || `${t('Media')} ${idx + 1}`;
     const playable = getPlayableUrl(m);
 
     return (
@@ -541,27 +541,60 @@ const PatientInterventionPopUp: React.FC<Props> = ({ show, item, handleClose }) 
       return <div>{renderOneMedia(effectiveMediaList[0], 0)}</div>;
     }
 
-    // 2+ media items — show as tabs for a clean UX on both mobile and desktop
+    // 2+ media items — carousel: one item at a time with prev/next and dot indicators
+    const total = effectiveMediaList.length;
+    const clampedIndex = Math.min(activeMediaIndex, total - 1);
+
     return (
-      <Tab.Container activeKey={activeMediaTab} onSelect={(k) => setActiveMediaTab(k ?? 'media-0')}>
-        <Nav variant="tabs" className="mb-3 flex-wrap">
-          {effectiveMediaList.map((m, idx) => {
-            const label = `${t('Media')} ${idx + 1}`;
-            return (
-              <Nav.Item key={idx}>
-                <Nav.Link eventKey={`media-${idx}`}>{label}</Nav.Link>
-              </Nav.Item>
-            );
-          })}
-        </Nav>
-        <Tab.Content>
-          {effectiveMediaList.map((m, idx) => (
-            <Tab.Pane key={idx} eventKey={`media-${idx}`}>
-              {renderOneMedia(m, idx, true)}
-            </Tab.Pane>
-          ))}
-        </Tab.Content>
-      </Tab.Container>
+      <div data-testid="media-carousel">
+        {/* Current media */}
+        <div>{renderOneMedia(effectiveMediaList[clampedIndex], clampedIndex, false)}</div>
+
+        {/* Navigation bar */}
+        <div className="media-carousel__nav">
+          <button
+            className="btn btn-sm btn-outline-secondary media-carousel__arrow"
+            onClick={() => setActiveMediaIndex((i: number) => Math.max(0, i - 1))}
+            disabled={clampedIndex === 0}
+            aria-label={t('Previous media')}
+            data-testid="media-prev"
+          >
+            <ArrowLeftIcon aria-hidden="true" />
+          </button>
+
+          <div className="media-carousel__center">
+            {/* Dot indicators — only when ≤7 items to keep UI clean */}
+            {total <= 7 && (
+              <div className="media-carousel__dots" role="tablist" aria-label={t('Media items')}>
+                {effectiveMediaList.map((m, i) => (
+                  <button
+                    key={i}
+                    role="tab"
+                    aria-selected={i === clampedIndex}
+                    aria-label={m.title || `${t('Media')} ${i + 1}`}
+                    className={`media-dot${i === clampedIndex ? ' active' : ''}`}
+                    onClick={() => setActiveMediaIndex(i)}
+                    data-testid={`media-dot-${i}`}
+                  />
+                ))}
+              </div>
+            )}
+            <div className="media-carousel__counter" aria-live="polite">
+              {clampedIndex + 1} / {total}
+            </div>
+          </div>
+
+          <button
+            className="btn btn-sm btn-outline-secondary media-carousel__arrow"
+            onClick={() => setActiveMediaIndex((i: number) => Math.min(total - 1, i + 1))}
+            disabled={clampedIndex === total - 1}
+            aria-label={t('Next media')}
+            data-testid="media-next"
+          >
+            <ArrowRightIcon aria-hidden="true" />
+          </button>
+        </div>
+      </div>
     );
   };
 
@@ -690,18 +723,17 @@ const PatientInterventionPopUp: React.FC<Props> = ({ show, item, handleClose }) 
         </Container>
 
         <style>{`
-          /* Pills row */
-          .meta-tag-row{
-            display:flex;
-            flex-wrap:wrap;
+          .meta-tag-row {
+            display: flex;
+            flex-wrap: wrap;
             gap: 10px;
             margin-top: 8px;
             position: relative;
-            z-index: 3; /* ensure above muted text backgrounds */
+            z-index: 3;
           }
-          .meta-pill{
-            display:inline-flex;
-            align-items:center;
+          .meta-pill {
+            display: inline-flex;
+            align-items: center;
             padding: 8px 12px;
             border-radius: 10px;
             font-weight: 800;
@@ -711,6 +743,62 @@ const PatientInterventionPopUp: React.FC<Props> = ({ show, item, handleClose }) 
             white-space: nowrap;
             overflow: hidden;
             text-overflow: ellipsis;
+          }
+          /* ── Media carousel ─────────────────────────────── */
+          .media-carousel__nav {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            margin-top: 12px;
+            gap: 8px;
+          }
+          .media-carousel__arrow {
+            flex-shrink: 0;
+            width: 36px;
+            height: 36px;
+            padding: 0;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+          }
+          .media-carousel__arrow svg {
+            width: 16px;
+            height: 16px;
+          }
+          .media-carousel__center {
+            flex: 1;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            gap: 4px;
+            min-width: 0;
+          }
+          .media-carousel__dots {
+            display: flex;
+            gap: 6px;
+            align-items: center;
+            justify-content: center;
+            flex-wrap: wrap;
+          }
+          .media-dot {
+            width: 8px;
+            height: 8px;
+            border-radius: 50%;
+            border: none;
+            padding: 0;
+            cursor: pointer;
+            background-color: #dee2e6;
+            transition: background-color 0.2s, width 0.15s, height 0.15s;
+          }
+          .media-dot.active {
+            background-color: #0d6efd;
+            width: 10px;
+            height: 10px;
+          }
+          .media-carousel__counter {
+            font-size: 0.78rem;
+            color: #6c757d;
+            user-select: none;
           }
         `}</style>
       </Modal.Body>

--- a/frontend/src/components/TherapistInterventionPage/ImportInterventionsModal.tsx
+++ b/frontend/src/components/TherapistInterventionPage/ImportInterventionsModal.tsx
@@ -66,7 +66,7 @@ function validateMediaFile(file: File): ValidatedFile {
 }
 
 const ImportInterventionsModal: React.FC<Props> = observer(({ show, onHide, onSuccess }) => {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
 
   // ── Tab state ──────────────────────────────────────────────────────────────
   const [activeTab, setActiveTab] = useState<'excel' | 'media'>('excel');
@@ -76,7 +76,10 @@ const ImportInterventionsModal: React.FC<Props> = observer(({ show, onHide, onSu
   const [excelSizeError, setExcelSizeError] = useState<string | null>(null);
 
   const defaultSheet = (interventionsConfig as any)?.importDefaults?.sheetName || 'Content';
-  const defaultLangFromCfg = (interventionsConfig as any)?.importDefaults?.defaultLang || 'en';
+  const defaultLangFromCfg =
+    (interventionsConfig as any)?.importDefaults?.defaultLang ||
+    i18n.language.slice(0, 2).toLowerCase() ||
+    'en';
 
   const [sheetName, setSheetName] = useState(defaultSheet);
   const [defaultLang, setDefaultLang] = useState(defaultLangFromCfg);

--- a/frontend/src/hooks/useInterventions.ts
+++ b/frontend/src/hooks/useInterventions.ts
@@ -22,12 +22,21 @@ export const useInterventions = (date: Date) => {
   const [busyKey, setBusyKey] = useState<string | null>(null);
   const patientId = localStorage.getItem('id') || authStore.id || '';
 
-  // Get interventions for the specified date
+  // Get interventions for the specified date, deduplicated by external_id
   const interventions = useMemo(() => {
     const dateKey = normalizeDayKey(date);
-    return patientInterventionsStore.items.filter((rec) =>
+    const items = patientInterventionsStore.items.filter((rec) =>
       (rec.dates || []).some((d) => normalizeDayKey(d) === dateKey)
     );
+    const seenExtIds = new Set<string>();
+    return items.filter((rec) => {
+      const extId = rec.intervention?.external_id;
+      if (extId) {
+        if (seenExtIds.has(extId)) return false;
+        seenExtIds.add(extId);
+      }
+      return true;
+    });
   }, [date, patientInterventionsStore.items]);
 
   // Sort interventions: incomplete first, then completed, alphabetically within each group

--- a/frontend/src/pages/PatientInterventionDetail.tsx
+++ b/frontend/src/pages/PatientInterventionDetail.tsx
@@ -574,6 +574,10 @@ const PatientInterventionDetail: React.FC = observer(() => {
   const mediaLinks = useMemo(
     () =>
       effectiveMediaList
+        // Exclude media types that are already shown as embedded players in MediaContent
+        // (video, audio, streaming) to prevent showing a redundant "Open link" button
+        // alongside an already-working player.
+        .filter((m) => !['video', 'audio', 'streaming'].includes(m.media_type))
         .map((m, idx) => {
           const label = m.title || `${t('Media')} ${idx + 1}`;
           const href = getOpenLinkUrl(m);

--- a/frontend/src/pages/TherapistInterventions.tsx
+++ b/frontend/src/pages/TherapistInterventions.tsx
@@ -286,8 +286,11 @@ const TherapistRecomendations: React.FC = observer(() => {
       return;
     }
 
-    therapistInterventionsLibraryStore.fetchAll({ mode: 'therapist' });
-  }, [authChecked, authStore.isAuthenticated, authStore.userType, navigate]);
+    therapistInterventionsLibraryStore.fetchAll({
+      mode: 'therapist',
+      lang: i18n.language.slice(0, 2),
+    });
+  }, [authChecked, authStore.isAuthenticated, authStore.userType, navigate, i18n.language]);
 
   // surface store errors in existing ErrorAlert
   useEffect(() => {
@@ -1193,13 +1196,23 @@ const TherapistRecomendations: React.FC = observer(() => {
       <AddInterventionPopup
         show={showPopupAdd}
         handleClose={handleCloseAdd}
-        onSuccess={() => therapistInterventionsLibraryStore.fetchAll({ mode: 'therapist' })}
+        onSuccess={() =>
+          therapistInterventionsLibraryStore.fetchAll({
+            mode: 'therapist',
+            lang: i18n.language.slice(0, 2),
+          })
+        }
       />
 
       <ImportInterventionsModal
         show={showPopupImport}
         onHide={handleCloseImport}
-        onSuccess={() => therapistInterventionsLibraryStore.fetchAll({ mode: 'therapist' })}
+        onSuccess={() =>
+          therapistInterventionsLibraryStore.fetchAll({
+            mode: 'therapist',
+            lang: i18n.language.slice(0, 2),
+          })
+        }
       />
 
       {assignOpen && (


### PR DESCRIPTION
## Summary

- **Duplicate intervention in patient plan** (`get_patient_plan`): Added a `seen_ext_ids` set in `patient_views.py` so that when a patient's rehab plan contains two assignments sharing the same `external_id`, only the first is returned. A frontend safety net (`useInterventions.ts`) applies the same dedup for cached/stale store data.
- **Therapist library not showing German interventions**: `TherapistInterventions.tsx` was calling `fetchAll({ mode: 'therapist' })` without a `lang` param, so the backend always defaulted to English and discarded other language variants. Now passes `lang: i18n.language.slice(0, 2)` on every fetch (mount + after add/import).
- **Import modal default language**: `ImportInterventionsModal.tsx` fell back to hard-coded `'en'` instead of the UI language. Now falls back to `i18n.language.slice(0, 2)`.
- **Redundant "Open link" buttons for video/audio**: `PatientInterventionDetail.tsx` excluded `video`, `audio`, and `streaming` from `mediaLinks` since those types already have an embedded player — showing an "Open link" button alongside was redundant.

## Test plan

- [x] Backend: `docker exec django pytest tests/patient_views/ -v` — 130 passed, includes 4 new dedup tests
- [x] Frontend unit: `npx jest --testPathPattern="PatientInterventionDetail|useInterventions|TherapistInterventions"` — 26 passed
  - `useInterventions.test.tsx` (new): 6 tests for `external_id` dedup, date filtering, sort order
  - `PatientInterventionDetail.test.tsx`: updated open-link assertion (2→1), added video/audio exclusion test
  - `TherapistInterventions.test.tsx`: 2 new tests verifying `fetchAll` is called with `lang: 'en'`
- [x] E2E: `e2e/intervention-language.spec.ts` (new) — skips gracefully in CI without seeded credentials:
  - Therapist library GET includes `?lang=` param matching UI language
  - Import modal default language field matches UI language
  - Patient daily plan has no duplicate intervention titles

