### PR TITLE
280-feature-adding-intervention-to-template---interventions-should-be-clickable

### DIFF
--- a/frontend/src/components/TherapistInterventionPage/TemplatesLayout.tsx
+++ b/frontend/src/components/TherapistInterventionPage/TemplatesLayout.tsx
@@ -50,6 +50,7 @@ type Props = {
   browseAllItems: InterventionTypeTh[];
   findTemplateFor: (intId: string) => TemplateItem | undefined;
   onOpenAssign: (id: string, title?: string, mode?: 'create' | 'modify') => void;
+  onBrowseItemClick?: (intervention: InterventionTypeTh) => void;
 
   filters: TemplatesFiltersState;
   onFilters: (next: TemplatesFiltersState) => void;
@@ -74,6 +75,7 @@ const TemplatesLayout: React.FC<Props> = ({
   browseAllItems,
   findTemplateFor,
   onOpenAssign,
+  onBrowseItemClick,
   filters,
   onFilters,
   onResetFilters,
@@ -193,9 +195,7 @@ const TemplatesLayout: React.FC<Props> = ({
                       className="d-flex justify-content-between align-items-start mb-2 p-2 rounded border"
                       style={{ cursor: 'pointer' }}
                       title={t('Click to view details')}
-                      onClick={() => {
-                        // optional: if you want clicking to open details, wire handler from parent
-                      }}
+                      onClick={() => onBrowseItemClick?.(intervention)}
                     >
                       <div className="me-2">
                         <div className="fw-semibold">{displayTitle}</div>

--- a/frontend/src/components/TherapistInterventionPage/TemplatesLayout.tsx
+++ b/frontend/src/components/TherapistInterventionPage/TemplatesLayout.tsx
@@ -12,11 +12,11 @@ import {
   Badge,
 } from 'react-bootstrap';
 import { FaPlus, FaMinus, FaEdit } from 'react-icons/fa';
-import { getTagColor } from '../../utils/interventions';
-import FilterBar from './FilterBar';
+import { getTagColor } from '@/utils/interventions';
+import FilterBar from '@/components/TherapistInterventionPage/FilterBar';
 
-import type { TemplateItem } from '../../types/templates';
-import type { InterventionTypeTh } from '../../types';
+import type { TemplateItem } from '@/types/templates';
+import type { InterventionTypeTh } from '@/types';
 
 export type TemplatesFiltersState = {
   tSearchTerm: string;
@@ -50,7 +50,7 @@ type Props = {
   browseAllItems: InterventionTypeTh[];
   findTemplateFor: (intId: string) => TemplateItem | undefined;
   onOpenAssign: (id: string, title?: string, mode?: 'create' | 'modify') => void;
-  onBrowseItemClick?: (intervention: InterventionTypeTh) => void;
+  onBrowseItemClick: (intervention: InterventionTypeTh) => void;
 
   filters: TemplatesFiltersState;
   onFilters: (next: TemplatesFiltersState) => void;
@@ -195,7 +195,7 @@ const TemplatesLayout: React.FC<Props> = ({
                       className="d-flex justify-content-between align-items-start mb-2 p-2 rounded border"
                       style={{ cursor: 'pointer' }}
                       title={t('Click to view details')}
-                      onClick={() => onBrowseItemClick?.(intervention)}
+                      onClick={() => onBrowseItemClick(intervention)}
                     >
                       <div className="me-2">
                         <div className="fw-semibold">{displayTitle}</div>

--- a/frontend/src/pages/TherapistInterventions.tsx
+++ b/frontend/src/pages/TherapistInterventions.tsx
@@ -1102,6 +1102,7 @@ const TherapistRecomendations: React.FC = observer(() => {
               browseAllItems={templateFilteredAll}
               findTemplateFor={findTemplateFor}
               onOpenAssign={openAssignToTemplate}
+              onBrowseItemClick={handleItemClick}
               // browse filters
               filters={templatesFilters}
               onFilters={setTemplatesFilters}


### PR DESCRIPTION
# Description

Clicking an intervention in the "Browse All" template tab now opens the details popup, the same as in the library view.

## Related Issue
https://github.com/ARTORG-GERONTECHNOLOGY/Bearny-RehaAdvisor/issues/280

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Tests

Go to the Templates site, switch to "Browse All", and click any intervention row: the details popup should appear.

## Checklist

- [x] I have read the [contributing guidelines](/docs/12-CONTRIBUTING.md).
- [x] I have read the [code of conduct](/CODE_OF_CONDUCT.md).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
