### PR TITLE
Fix/intervention visibility language

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,15 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+### Fixed
+- **Intervention library ignoring patient's preferred language**: `list_all_interventions` now resolves the patient document from the URL's `patient_id` and uses their `Patient.preferred_language` as the variant-selection language. Previously the endpoint used only the `?lang` query param (the therapist's UI language), so patients with a non-default content language always received English variants.
+- **Patient rehab plan using UI language instead of patient language**: `get_patient_plan` now overrides the UI `?lang` param with `Patient.preferred_language` after resolving the patient, so the best language variant is picked from the patient's profile rather than the therapist's browser language.
+
 ### Added
+- **`preferred_language` editable via patient profile**: The `user_profile_view` PUT endpoint now accepts `preferred_language` in the patient field whitelist. Valid values are the 10 language codes supported by the model (`en`, `es`, `fr`, `de`, `it`, `nl`, `sv`, `zh`, `ja`, `ko`). Invalid codes return HTTP 400.
+- **Intervention language selector in patient profile popup** (`PatientPopup.tsx`): Therapists can now set the patient's content language directly from the patient detail popup without needing a separate admin tool.
+
+### Changed
 - Open source governance baseline files at repository root:
   - `CODE_OF_CONDUCT.md`
   - `SECURITY.md`

--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -6,5 +6,13 @@ env
 # Django 
 db.sqlite3
 
-# Docker 
+# Docker
 Dockerfile
+
+# Celery runtime files (must not be baked into the image)
+celery_worker.state
+celery_worker.state-wal
+celery_worker.state-shm
+celerybeat-schedule
+celerybeat-schedule-wal
+celerybeat-schedule-shm

--- a/backend/core/views/patient_views.py
+++ b/backend/core/views/patient_views.py
@@ -1001,6 +1001,8 @@ def get_patient_plan(request, patient_id):
         return JsonResponse({"error": "Method not allowed"}, status=405)
 
     ui_lang = (request.GET.get("lang") or "").strip().lower()[:5]
+    # After resolving the patient we will override ui_lang with their profile language if set.
+    # The override is applied below after _resolve_patient_flexible().
 
     def _lang_chain(lang: str):
         chain, seen = [], set()
@@ -1028,6 +1030,12 @@ def get_patient_plan(request, patient_id):
         if not patient:
             logger.warning("[get_patient_plan] Patient not found")
             return JsonResponse({"error": "Patient not found"}, status=404)
+
+        # Patient's profile language takes priority over the UI lang param.
+        patient_lang = (getattr(patient, "preferred_language", None) or "").strip().lower()
+        if patient_lang:
+            ui_lang = patient_lang
+
         rehab_plan = RehabilitationPlan.objects(patientId=patient).first()
 
         if not rehab_plan:

--- a/backend/core/views/patient_views.py
+++ b/backend/core/views/patient_views.py
@@ -1000,9 +1000,10 @@ def get_patient_plan(request, patient_id):
     if request.method != "GET":
         return JsonResponse({"error": "Method not allowed"}, status=405)
 
-    ui_lang = (request.GET.get("lang") or "").strip().lower()[:5]
-    # After resolving the patient we will override ui_lang with their profile language if set.
-    # The override is applied below after _resolve_patient_flexible().
+    explicit_lang = (request.GET.get("lang") or "").strip().lower()[:5]
+    # When ?lang is absent the patient's preferred_language acts as the default.
+    # An explicit ?lang param (e.g. therapist switching language) always wins.
+    # ui_lang is resolved after the patient is loaded below.
 
     def _lang_chain(lang: str):
         chain, seen = [], set()
@@ -1031,10 +1032,13 @@ def get_patient_plan(request, patient_id):
             logger.warning("[get_patient_plan] Patient not found")
             return JsonResponse({"error": "Patient not found"}, status=404)
 
-        # Patient's profile language takes priority over the UI lang param.
-        patient_lang = (getattr(patient, "preferred_language", None) or "").strip().lower()
-        if patient_lang:
-            ui_lang = patient_lang
+        # Use the patient's profile language when no explicit ?lang was given.
+        # An explicit ?lang param takes priority so therapists can still request
+        # a specific variant (e.g. ?lang=de) without changing the patient profile.
+        if explicit_lang:
+            ui_lang = explicit_lang
+        else:
+            ui_lang = (getattr(patient, "preferred_language", None) or "").strip().lower()
 
         rehab_plan = RehabilitationPlan.objects(patientId=patient).first()
 

--- a/backend/core/views/recomendation_views.py
+++ b/backend/core/views/recomendation_views.py
@@ -956,9 +956,24 @@ def list_all_interventions(request, patient_id=None):
     GET /api/interventions/all/(<patient_id>/)?lang=de
     - Private interventions: returned as-is
     - Public interventions: grouped by external_id and only best language variant returned
+    When patient_id is provided, the patient's preferred_language takes priority over
+    the ?lang query param so the patient sees content in their profile language.
     """
     try:
-        preferred_lang = (request.GET.get("lang") or "en").lower().strip()
+        request_lang = (request.GET.get("lang") or "").lower().strip()
+
+        # When a patient_id is given, use that patient's preferred_language as the
+        # primary language preference. The ?lang param (UI language) is the fallback
+        # so that the therapist can still override manually when needed.
+        preferred_lang = request_lang or "en"
+        if patient_id:
+            try:
+                patient_obj = Patient.objects.get(id=ObjectId(patient_id))
+                patient_lang = (getattr(patient_obj, "preferred_language", None) or "").lower().strip()
+                if patient_lang:
+                    preferred_lang = patient_lang
+            except Exception:
+                pass  # unknown patient_id — fall through to request_lang default
 
         q_external_id = (request.GET.get("external_id") or "").strip()
         q_lang = (request.GET.get("lang") or "").lower().strip()

--- a/backend/core/views/user_views.py
+++ b/backend/core/views/user_views.py
@@ -321,7 +321,10 @@ def user_profile_view(request, user_id):
         "personal_goals": list,
         "social_support": list,
         "initial_questionnaire_enabled": bool,
+        "preferred_language": str,
     }
+
+    PATIENT_PREFERRED_LANGUAGE_CHOICES = {"en", "es", "fr", "de", "it", "nl", "sv", "zh", "ja", "ko"}
 
     TH_ALLOWED_USER = {"username": str, "email": str, "phone": str}
     TH_ALLOWED_TH = {
@@ -548,6 +551,18 @@ def user_profile_view(request, user_id):
 
                     raw_val = raw[field]
                     if not valid_update_value(raw_val):
+                        continue
+
+                    if field == "preferred_language":
+                        lang_val = str(raw_val).lower().strip()
+                        if lang_val not in PATIENT_PREFERRED_LANGUAGE_CHOICES:
+                            return JsonResponse(
+                                {"error": f"Invalid preferred_language '{lang_val}'"},
+                                status=400,
+                            )
+                        old[field] = getattr(patient, field)
+                        patient.preferred_language = lang_val
+                        updated[field] = lang_val
                         continue
 
                     if expected_type == "date":

--- a/backend/tests/recomendation_views/TESTING.md
+++ b/backend/tests/recomendation_views/TESTING.md
@@ -6,6 +6,7 @@
 |---|---|
 | [`test_recomendation_views_extra.py`](test_recomendation_views_extra.py) | Validation branches for template apply/preview, intervention creation, diagnosis listing |
 | [`test_list_all_interventions_ratings.py`](test_list_all_interventions_ratings.py) | `avg_rating` / `rating_count` aggregation on `GET /api/interventions/all/` |
+| [`test_list_all_interventions_lang.py`](test_list_all_interventions_lang.py) | `preferred_language` variant selection on `GET /api/interventions/all/<patient_id>/` |
 
 ---
 
@@ -29,6 +30,23 @@ The results are merged back into the serialized items as:
 | `test_list_all_interventions_non_rating_feedback_excluded_from_average` | Only `difficulty_scale` answer submitted | `avg_rating: null`, `rating_count: 0` |
 | `test_list_all_interventions_independent_avg_per_intervention` | Two interventions, only one rated | Rated: `avg_rating: 5.0`; Unrated: `avg_rating: null` |
 | `test_list_all_interventions_avg_rating_rounded_to_one_decimal` | Three ratings: 1, 2, 4 (mean = 2.333…) | `avg_rating: 2.3`, `rating_count: 3` |
+
+---
+
+## `list_all_interventions` — patient `preferred_language`
+
+`GET /api/interventions/all/<patient_id>/`
+
+When a `patient_id` is supplied, the endpoint resolves the patient document and uses `Patient.preferred_language` as the primary variant-selection language instead of the `?lang` query param (the therapist's UI language). The `?lang` param remains the fallback when no patient language is set. If no variant exists for the patient language, the standard `en → de → any` chain applies.
+
+### Tests (`test_list_all_interventions_lang.py`)
+
+| Test | Scenario | Expected |
+|---|---|---|
+| `test_list_all_uses_lang_param_when_no_patient_id` | No patient_id in URL, `?lang=de` | German variant returned |
+| `test_list_all_uses_patient_preferred_language_when_patient_id_given` | `patient.preferred_language='de'`, `?lang=en` | German variant returned (patient overrides UI lang) |
+| `test_list_all_falls_back_to_lang_param_when_patient_has_no_preferred_language` | `patient.preferred_language='en'`, `?lang=en` | English variant returned |
+| `test_list_all_falls_back_when_preferred_language_has_no_variant` | `patient.preferred_language='fr'`, only en/de exist | English or German variant returned (not null) |
 
 ---
 

--- a/backend/tests/recomendation_views/test_list_all_interventions_lang.py
+++ b/backend/tests/recomendation_views/test_list_all_interventions_lang.py
@@ -155,9 +155,9 @@ def test_list_all_uses_patient_preferred_language_when_patient_id_given(mongo_mo
     assert resp.status_code == 200
     data = resp.json()
     titles = [item["title"] for item in data]
-    assert any("German title" in t for t in titles), (
-        f"Expected German title (patient preferred_language='de') but got: {titles}"
-    )
+    assert any(
+        "German title" in t for t in titles
+    ), f"Expected German title (patient preferred_language='de') but got: {titles}"
 
 
 def test_list_all_falls_back_to_lang_param_when_patient_has_no_preferred_language(mongo_mock):

--- a/backend/tests/recomendation_views/test_list_all_interventions_lang.py
+++ b/backend/tests/recomendation_views/test_list_all_interventions_lang.py
@@ -1,0 +1,199 @@
+"""
+list_all_interventions — patient preferred_language tests
+=========================================================
+
+When a ``patient_id`` is present in the URL the endpoint must use the
+patient's ``preferred_language`` from their Profile document as the variant
+selection language, overriding the ``?lang`` query parameter.
+
+When ``patient_id`` is absent (plain library fetch) the ``?lang`` param is
+used as before.
+"""
+
+from datetime import datetime, timedelta
+
+import mongomock
+import pytest
+from bson import ObjectId
+from django.test import Client
+
+from core.models import (
+    Intervention,
+    Patient,
+    Therapist,
+    User,
+)
+
+client = Client()
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True, scope="function")
+def mongo_mock():
+    from mongoengine import connect, disconnect
+    from mongoengine.connection import _connections
+
+    alias = "default"
+    if alias in _connections:
+        disconnect(alias)
+
+    conn = connect(
+        "mongoenginetest",
+        alias=alias,
+        host="mongodb://localhost",
+        mongo_client_class=mongomock.MongoClient,
+    )
+    yield conn
+    disconnect(alias)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_patient(preferred_language="de"):
+    therapist_user = User(
+        username=f"th-{ObjectId()}",
+        createdAt=datetime.now(),
+        isActive=True,
+    )
+    therapist_user.save()
+    therapist = Therapist(userId=therapist_user, default_recommendations=[])
+    therapist.save()
+
+    patient_user = User(
+        username=f"p-{ObjectId()}",
+        createdAt=datetime.now(),
+        isActive=True,
+        role="Patient",
+    )
+    patient_user.save()
+    patient = Patient(
+        userId=patient_user,
+        patient_code=f"PAT-{ObjectId()}",
+        name="Patient",
+        first_name="Test",
+        access_word="pass",
+        age="30",
+        therapist=therapist,
+        sex="Male",
+        diagnosis=["Stroke"],
+        function=["Cardiology"],
+        level_of_education="High School",
+        professional_status="Employed Full-Time",
+        marital_status="Single",
+        lifestyle=[],
+        personal_goals=[],
+        reha_end_date=datetime.now() + timedelta(days=30),
+        preferred_language=preferred_language,
+    )
+    patient.save()
+    return patient
+
+
+def _make_intervention_pair(external_id, en_title="English title", de_title="German title"):
+    """Create English and German variants for the same external_id."""
+    en = Intervention(
+        external_id=external_id,
+        language="en",
+        title=en_title,
+        description="desc",
+        content_type="Video",
+        is_private=False,
+    )
+    en.save()
+    de = Intervention(
+        external_id=external_id,
+        language="de",
+        title=de_title,
+        description="desc",
+        content_type="Video",
+        is_private=False,
+    )
+    de.save()
+    return en, de
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_list_all_uses_lang_param_when_no_patient_id(mongo_mock):
+    """Without patient_id the ?lang param drives variant selection."""
+    ext_id = str(ObjectId())
+    _make_intervention_pair(ext_id, en_title="EN title", de_title="DE title")
+
+    resp = client.get(
+        "/api/interventions/all/?lang=de",
+        HTTP_AUTHORIZATION="Bearer test",
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    titles = [item["title"] for item in data]
+    assert any("DE title" in t for t in titles), f"Expected German title, got: {titles}"
+
+
+def test_list_all_uses_patient_preferred_language_when_patient_id_given(mongo_mock):
+    """
+    With patient_id in the URL and the patient's preferred_language='de',
+    the German variant is returned even if ?lang=en is supplied.
+    """
+    patient = _make_patient(preferred_language="de")
+    ext_id = str(ObjectId())
+    _make_intervention_pair(ext_id, en_title="English title", de_title="German title")
+
+    resp = client.get(
+        f"/api/interventions/all/{patient.id}/?lang=en",
+        HTTP_AUTHORIZATION="Bearer test",
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    titles = [item["title"] for item in data]
+    assert any("German title" in t for t in titles), (
+        f"Expected German title (patient preferred_language='de') but got: {titles}"
+    )
+
+
+def test_list_all_falls_back_to_lang_param_when_patient_has_no_preferred_language(mongo_mock):
+    """
+    If the patient's preferred_language is empty the ?lang param is used
+    as the fallback (existing behaviour preserved).
+    """
+    patient = _make_patient(preferred_language="en")
+    ext_id = str(ObjectId())
+    _make_intervention_pair(ext_id, en_title="English title", de_title="German title")
+
+    resp = client.get(
+        f"/api/interventions/all/{patient.id}/?lang=en",
+        HTTP_AUTHORIZATION="Bearer test",
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    titles = [item["title"] for item in data]
+    assert any("English title" in t for t in titles), f"Expected English title, got: {titles}"
+
+
+def test_list_all_falls_back_when_preferred_language_has_no_variant(mongo_mock):
+    """
+    If no variant exists for the patient's preferred_language the fallback
+    chain (en → de) still returns a variant rather than dropping the item.
+    """
+    patient = _make_patient(preferred_language="fr")
+    ext_id = str(ObjectId())
+    # Only English and German variants exist; no French
+    _make_intervention_pair(ext_id, en_title="English title", de_title="German title")
+
+    resp = client.get(
+        f"/api/interventions/all/{patient.id}/",
+        HTTP_AUTHORIZATION="Bearer test",
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data) == 1, f"Expected 1 grouped intervention, got {len(data)}"
+    assert data[0]["title"] in ("English title", "German title")

--- a/backend/tests/user_views/test_user_views.py
+++ b/backend/tests/user_views/test_user_views.py
@@ -1527,3 +1527,52 @@ def test_patient_profile_get_created_by_null_when_not_set():
     data = resp.json()
     assert "created_by" in data
     assert data["created_by"] is None
+
+
+# ---------------------------------------------------------------------------
+# preferred_language tests
+# ---------------------------------------------------------------------------
+
+
+def test_patient_profile_get_returns_preferred_language():
+    """GET /api/users/<id>/profile/ returns ``preferred_language`` from the Patient document."""
+    user, patient = create_patient()
+    patient.preferred_language = "de"
+    patient.save()
+
+    resp = client.get(
+        f"/api/users/{str(user.id)}/profile/",
+        HTTP_AUTHORIZATION="Bearer test",
+    )
+    assert resp.status_code == 200
+    assert resp.json().get("preferred_language") == "de"
+
+
+def test_patient_profile_put_updates_preferred_language():
+    """PUT /api/users/<id>/profile/ with a valid language code persists the value."""
+    user, patient = create_patient()
+
+    resp = client.put(
+        f"/api/users/{str(user.id)}/profile/",
+        data=json.dumps({"preferred_language": "fr"}),
+        content_type="application/json",
+        HTTP_AUTHORIZATION="Bearer test",
+    )
+    assert resp.status_code == 200
+    assert "preferred_language" in resp.json().get("updated", {})
+    patient.reload()
+    assert patient.preferred_language == "fr"
+
+
+def test_patient_profile_put_rejects_invalid_preferred_language():
+    """PUT /api/users/<id>/profile/ with an unknown language code returns 400."""
+    user, patient = create_patient()
+
+    resp = client.put(
+        f"/api/users/{str(user.id)}/profile/",
+        data=json.dumps({"preferred_language": "xx"}),
+        content_type="application/json",
+        HTTP_AUTHORIZATION="Bearer test",
+    )
+    assert resp.status_code == 400
+    assert "preferred_language" in resp.json().get("error", "").lower() or "invalid" in resp.json().get("error", "").lower()

--- a/backend/tests/user_views/test_user_views.py
+++ b/backend/tests/user_views/test_user_views.py
@@ -1575,4 +1575,7 @@ def test_patient_profile_put_rejects_invalid_preferred_language():
         HTTP_AUTHORIZATION="Bearer test",
     )
     assert resp.status_code == 400
-    assert "preferred_language" in resp.json().get("error", "").lower() or "invalid" in resp.json().get("error", "").lower()
+    assert (
+        "preferred_language" in resp.json().get("error", "").lower()
+        or "invalid" in resp.json().get("error", "").lower()
+    )

--- a/docker-compose.prod.reha-advisor.yml
+++ b/docker-compose.prod.reha-advisor.yml
@@ -97,7 +97,10 @@ services:
     image: ${GHCR_IMAGE}-backend:${IMAGE_TAG:-latest}
     container_name: celery-prod
     restart: always
-    command: python -m celery -A api.celery:app worker --loglevel=info --statedb=/app/celery_worker.state -c 4
+    command: >
+      sh -c "rm -f /app/celery_worker.state /app/celery_worker.state-wal /app/celery_worker.state-shm &&
+      conda run --no-capture-output -n teleRehabApp
+      python -m celery -A api.celery:app worker --loglevel=info -c 4"
     volumes:
       - ./mongo/tls/ca.crt:/etc/ssl/mongo/ca.crt:ro
       - /var/run/docker.sock:/var/run/docker.sock
@@ -132,6 +135,7 @@ services:
     restart: always
     working_dir: /app
     command: >
+      conda run --no-capture-output -n teleRehabApp
       python -m celery -A api.celery:app beat -l info
       --scheduler django_celery_beat.schedulers:DatabaseScheduler
     env_file:

--- a/frontend/src/__tests__/patientDataService.test.ts
+++ b/frontend/src/__tests__/patientDataService.test.ts
@@ -54,7 +54,7 @@ describe('initPatientData', () => {
     expect(mockFetchSummary).toHaveBeenCalledWith('patient-1', 7);
     expect(mockFetchSummary).toHaveBeenCalledWith('patient-1', 30);
     expect(mockFetchPlan).toHaveBeenCalledWith('patient-1', 'de');
-    expect(mockFetchAll).toHaveBeenCalledWith({ mode: 'patient', lang: 'de' });
+    expect(mockFetchAll).toHaveBeenCalledWith({ mode: 'patient', lang: 'de', patientId: 'patient-1' });
     expect(mockFetchCombinedHistoryForPatient).toHaveBeenCalledWith(
       'patient-1',
       '2026-04-05',
@@ -70,7 +70,7 @@ describe('initPatientData', () => {
   it('slices lang to 2 chars for fetchAll', () => {
     initPatientData('patient-1', 'de-CH');
 
-    expect(mockFetchAll).toHaveBeenCalledWith({ mode: 'patient', lang: 'de' });
+    expect(mockFetchAll).toHaveBeenCalledWith({ mode: 'patient', lang: 'de', patientId: 'patient-1' });
     // fetchPlan and loadHealthQuestionnaire receive the full lang string
     expect(mockFetchPlan).toHaveBeenCalledWith('patient-1', 'de-CH');
   });

--- a/frontend/src/__tests__/patientDataService.test.ts
+++ b/frontend/src/__tests__/patientDataService.test.ts
@@ -54,7 +54,11 @@ describe('initPatientData', () => {
     expect(mockFetchSummary).toHaveBeenCalledWith('patient-1', 7);
     expect(mockFetchSummary).toHaveBeenCalledWith('patient-1', 30);
     expect(mockFetchPlan).toHaveBeenCalledWith('patient-1', 'de');
-    expect(mockFetchAll).toHaveBeenCalledWith({ mode: 'patient', lang: 'de', patientId: 'patient-1' });
+    expect(mockFetchAll).toHaveBeenCalledWith({
+      mode: 'patient',
+      lang: 'de',
+      patientId: 'patient-1',
+    });
     expect(mockFetchCombinedHistoryForPatient).toHaveBeenCalledWith(
       'patient-1',
       '2026-04-05',
@@ -70,7 +74,11 @@ describe('initPatientData', () => {
   it('slices lang to 2 chars for fetchAll', () => {
     initPatientData('patient-1', 'de-CH');
 
-    expect(mockFetchAll).toHaveBeenCalledWith({ mode: 'patient', lang: 'de', patientId: 'patient-1' });
+    expect(mockFetchAll).toHaveBeenCalledWith({
+      mode: 'patient',
+      lang: 'de',
+      patientId: 'patient-1',
+    });
     // fetchPlan and loadHealthQuestionnaire receive the full lang string
     expect(mockFetchPlan).toHaveBeenCalledWith('patient-1', 'de-CH');
   });

--- a/frontend/src/components/TherapistPatientPage/PatientPopup.tsx
+++ b/frontend/src/components/TherapistPatientPage/PatientPopup.tsx
@@ -577,6 +577,42 @@ const PatientPopup: React.FC<PatientPopupProps> = observer(({ patient_id, show, 
                     </Col>
 
                     <Col xs={12} md={6}>
+                      <Form.Group controlId="preferred_language">
+                        <Form.Label>{t('Intervention language')}</Form.Label>
+                        {store.isEditing ? (
+                          <Form.Select
+                            id="preferred_language"
+                            value={store.formData.preferred_language || 'en'}
+                            onChange={(e) => store.setField('preferred_language', e.target.value)}
+                          >
+                            {[
+                              { code: 'en', label: 'English' },
+                              { code: 'de', label: 'Deutsch' },
+                              { code: 'fr', label: 'Français' },
+                              { code: 'it', label: 'Italiano' },
+                              { code: 'nl', label: 'Nederlands' },
+                              { code: 'es', label: 'Español' },
+                              { code: 'sv', label: 'Svenska' },
+                              { code: 'zh', label: '中文' },
+                              { code: 'ja', label: '日本語' },
+                              { code: 'ko', label: '한국어' },
+                            ].map(({ code, label }) => (
+                              <option key={code} value={code}>
+                                {label}
+                              </option>
+                            ))}
+                          </Form.Select>
+                        ) : (
+                          <Form.Control
+                            plaintext
+                            readOnly
+                            value={store.getDisplayValue('preferred_language') || 'en'}
+                          />
+                        )}
+                      </Form.Group>
+                    </Col>
+
+                    <Col xs={12} md={6}>
                       <Form.Group controlId="reha_end_date">
                         <Form.Label>
                           {t('Rehabilitation End Date')} <SourceBadge fieldKey="reha_end_date" />

--- a/frontend/src/services/patientDataService.ts
+++ b/frontend/src/services/patientDataService.ts
@@ -18,7 +18,9 @@ export function initPatientData(patientId: string, lang: string): void {
   patientFitbitStore.fetchSummary(patientId, 7);
   patientFitbitStore.fetchSummary(patientId, 30);
   patientInterventionsStore.fetchPlan(patientId, lang);
-  patientInterventionsLibraryStore.fetchAll({ mode: 'patient', lang: language });
+  // Pass patientId so the backend uses the patient's profile preferred_language
+  // instead of the therapist's UI language.
+  patientInterventionsLibraryStore.fetchAll({ mode: 'patient', patientId, lang: language });
   healthPageStore.fetchCombinedHistoryForPatient(patientId, wFrom, wTo);
   healthPageStore.fetchCombinedHistoryForPatient(patientId, mFrom, mTo);
 }


### PR DESCRIPTION
# Description

## Summary

- **Patient interventions served in wrong language** (`list_all_interventions`): endpoint now reads `Patient.preferred_language` from the patient document when a `patient_id` is in the URL, overriding the therapist's `?lang` UI param. Previously patients always received the therapist's UI language.
- **Rehab plan served in wrong language** (`get_patient_plan`): explicit `?lang` param still wins (for therapist overrides), but when absent the patient's `preferred_language` is used as the default instead of falling back to English.
- **`preferred_language` editable via profile**: `user_profile_view` PUT now accepts `preferred_language` (validated against the 10 supported codes). Invalid codes return HTTP 400.
- **Intervention language selector in PatientPopup**: therapists can set the patient's content language directly from the patient detail popup.
- **Celery prod containers crashing** (`No module named celery`): prod Dockerfile installs packages into the `teleRehabApp` conda env, but the service commands used bare `python` (base env). Fixed by prefixing with `conda run --no-capture-output -n teleRehabApp`. Also removed `--statedb` (stale dbm files baked into the image caused a crash on every restart) and added celery runtime files to `.dockerignore`.

## Test plan

- [x] `pytest tests/recomendation_views/ tests/user_views/ -v` in the `django` container
- [x] Set a patient's `preferred_language` to `de` via the PatientPopup, confirm intervention library returns German variants
- [x] Confirm celery-prod and celery-beat-prod stay up after deploy (`docker ps`)
- [x] Confirm `preferred_language` PUT rejects an invalid code with 400

## Related Issue
[IssueName](IssueLink)

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] I have read the [contributing guidelines](/docs/12-CONTRIBUTING.md).
- [x] I have read the [code of conduct](/CODE_OF_CONDUCT.md).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
