### PR TITLE
Fix/fitbit data sync issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,14 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+### Fixed
+- **Fitbit Active Zone Minutes always wrong**: both the on-demand sync (`fitbit_sync.py`) and the nightly batch command (`fetch_fitbit_data.py`) looked for `activities-activeZoneMinutes` / `value.totalMinutes` in the Fitbit API response. The correct keys are `activities-active-zone-minutes` / `value.activeZoneMinutes`. As a result, AZM was silently dropped on every sync and `active_minutes` was always computed from the fallback (`minutesVeryActive + minutesFairlyActive`), producing values that did not match the Fitbit app.
+- **Sleep displayed as time-in-bed instead of actual sleep**: `_sleep_minutes()` in `fitbit_view.py` — and the inactivity calculation helpers in both sync files — used `sleep_duration` (total time in bed, ms) instead of `minutes_asleep` (actual sleep, matches Fitbit app). All three helpers now prefer `minutes_asleep`; fall back to `sleep_duration` for legacy records that lack `minutes_asleep`.
+
 ### Added
+- **Every-4-hour Fitbit sync task** (`core.tasks.run_fetch_fitbit_data_today_all`): fetches today's data for every connected user every 4 hours so wearable data stays current even when patients do not open the Bearny app. The nightly 30-day backfill still runs to self-correct historical gaps. Run `python manage.py seed_periodic_tasks` after deployment to register the new schedule.
+
+### Changed
 - Open source governance baseline files at repository root:
   - `CODE_OF_CONDUCT.md`
   - `SECURITY.md`
@@ -17,8 +24,6 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   - `docs/TESTING.md`
   - `docs/DEPLOYMENT.md`
   - `docs/CONTRIBUTING_QUICKSTART.md`
-
-### Changed
 - Updated contribution and documentation indexes to point to canonical testing and deployment entry points.
 - Updated pull request template language for RehaAdvisor and current contribution checks.
 

--- a/backend/core/management/commands/fetch_fitbit_data.py
+++ b/backend/core/management/commands/fetch_fitbit_data.py
@@ -150,22 +150,18 @@ class Command(BaseCommand):
                 azm_url = f"{FITBIT_API_URL}/activities/active-zone-minutes/date/{date_range}.json"
                 azm_resp = requests.get(azm_url, headers=headers)
                 if azm_resp.status_code == 200:
-                    azm_items = azm_resp.json().get("activities-activeZoneMinutes", [])
+                    azm_items = azm_resp.json().get("activities-active-zone-minutes", [])
                     for item in azm_items:
                         dt = datetime.datetime.strptime(item["dateTime"], "%Y-%m-%d").date()
-                        val = item.get("value")
-                        if isinstance(val, dict):
-                            total = val.get("totalMinutes")
+                        val = item.get("value") or {}
+                        total = val.get("activeZoneMinutes")
+                        if val:
                             azm_breakdown[dt] = {
                                 "fat_burn": val.get("fatBurnActiveZoneMinutes"),
                                 "cardio": val.get("cardioActiveZoneMinutes"),
                                 "peak": val.get("peakActiveZoneMinutes"),
                                 "total": total,
                             }
-                        elif isinstance(val, (int, float)):
-                            total = int(val)
-                        else:
-                            total = None
                         if total is not None:
                             series["activeZoneMinutes"][dt] = int(total)
                     if not azm_items:
@@ -295,7 +291,10 @@ class Command(BaseCommand):
                     sd = sleep_data.get(dt)
                     if not sd:
                         return 0
-                    return int((sd.sleep_duration or 0) / 60000)
+                    # Prefer minutes_asleep (actual sleep, matches Fitbit app) over sleep_duration (time in bed)
+                    if sd.minutes_asleep is not None:
+                        return max(0, int(sd.minutes_asleep))
+                    return max(0, int((sd.sleep_duration or 0) / 60000))
 
                 # ---------------------------
                 # UPSERT DAY-BY-DAY

--- a/backend/core/management/commands/seed_periodic_tasks.py
+++ b/backend/core/management/commands/seed_periodic_tasks.py
@@ -9,7 +9,7 @@ class Command(BaseCommand):
     help = "Seeds periodic Celery tasks to run at midnight"
 
     def handle(self, *args, **kwargs):
-        # Create a crontab schedule
+        # Nightly at 01:00
         midnight_schedule, _ = CrontabSchedule.objects.get_or_create(
             minute="0",
             hour="1",
@@ -19,7 +19,17 @@ class Command(BaseCommand):
             timezone=settings.TIME_ZONE,
         )
 
-        # Task 1: Delete expired videos
+        # Every 4 hours (for same-day Fitbit sync without requiring patient login)
+        every_4h_schedule, _ = CrontabSchedule.objects.get_or_create(
+            minute="0",
+            hour="*/4",
+            day_of_week="*",
+            day_of_month="*",
+            month_of_year="*",
+            timezone=settings.TIME_ZONE,
+        )
+
+        # Task 1: Delete expired videos (nightly)
         task1, created1 = PeriodicTask.objects.update_or_create(
             name="Run Delete Expired Videos",
             defaults={
@@ -31,7 +41,7 @@ class Command(BaseCommand):
         )
         self.stdout.write(self.style.SUCCESS(f"{'Created' if created1 else 'Updated'} task: {task1.name}"))
 
-        # Task 2: Fetch Fitbit data
+        # Task 2: Fetch Fitbit data — full 30-day back-fill runs nightly
         task2, created2 = PeriodicTask.objects.update_or_create(
             name="Run Fetch Fitbit Data",
             defaults={
@@ -42,3 +52,16 @@ class Command(BaseCommand):
             },
         )
         self.stdout.write(self.style.SUCCESS(f"{'Created' if created2 else 'Updated'} task: {task2.name}"))
+
+        # Task 3: Fetch today's Fitbit data every 4 hours so patients who don't open
+        # the app still get their wearable data synced during the day.
+        task3, created3 = PeriodicTask.objects.update_or_create(
+            name="Run Fetch Fitbit Data Today (4h)",
+            defaults={
+                "crontab": every_4h_schedule,
+                "task": "core.tasks.run_fetch_fitbit_data_today_all",
+                "enabled": True,
+                "args": json.dumps([]),
+            },
+        )
+        self.stdout.write(self.style.SUCCESS(f"{'Created' if created3 else 'Updated'} task: {task3.name}"))

--- a/backend/core/tasks.py
+++ b/backend/core/tasks.py
@@ -75,6 +75,35 @@ def run_fetch_fitbit_data():
         raise
 
 
+@shared_task(
+    name="core.tasks.run_fetch_fitbit_data_today_all",
+    autoretry_for=(Exception,),
+    retry_backoff=120,
+    max_retries=2,
+)
+def run_fetch_fitbit_data_today_all():
+    """Fetch today's Fitbit data for every connected user (runs every 4 h).
+
+    This keeps wearable data current even for patients who haven't opened the
+    app, without the expense of a full 30-day back-fill on every run.
+    """
+    from core.models import FitbitUserToken
+
+    tokens = FitbitUserToken.objects.all()
+    synced = 0
+    errors = 0
+    for token in tokens:
+        try:
+            result = fetch_fitbit_today_for_user(token.user, bypass_cooldown=False)
+            synced += result
+        except Exception:
+            logger.exception("[fetch_fitbit_today_all] failed for user=%s", token.user)
+            errors += 1
+
+    logger.info("[fetch_fitbit_today_all] synced=%d errors=%d", synced, errors)
+    return {"synced": synced, "errors": errors}
+
+
 @shared_task(name="core.tasks.fetch_fitbit_data_async")
 def fetch_fitbit_data_async(user_id):
 

--- a/backend/core/views/fitbit_sync.py
+++ b/backend/core/views/fitbit_sync.py
@@ -160,22 +160,18 @@ def fetch_fitbit_today_for_user(user, bypass_cooldown: bool = False) -> int:
     azm_url = f"{FITBIT_API_URL}/activities/active-zone-minutes/date/{date_str}/{date_str}.json"
     azm_resp = requests.get(azm_url, headers=headers, timeout=15)
     if azm_resp.status_code == 200:
-        azm_items = azm_resp.json().get("activities-activeZoneMinutes", [])
+        azm_items = azm_resp.json().get("activities-active-zone-minutes", [])
         for item in azm_items:
             dt = datetime.datetime.strptime(item["dateTime"], "%Y-%m-%d").date()
-            val = item.get("value")
-            if isinstance(val, dict):
-                total = val.get("totalMinutes")
+            val = item.get("value") or {}
+            total = val.get("activeZoneMinutes")
+            if val:
                 azm_breakdown[dt] = {
                     "fat_burn": val.get("fatBurnActiveZoneMinutes"),
                     "cardio": val.get("cardioActiveZoneMinutes"),
                     "peak": val.get("peakActiveZoneMinutes"),
                     "total": total,
                 }
-            elif isinstance(val, (int, float)):
-                total = int(val)
-            else:
-                total = None
             if total is not None:
                 series["activeZoneMinutes"][dt] = int(total)
         if not azm_items:
@@ -241,7 +237,15 @@ def fetch_fitbit_today_for_user(user, bypass_cooldown: bool = False) -> int:
 
     # Upsert just today if we have any data
     def sleep_minutes_for(dt: datetime.date) -> int:
-        dur_ms = (sleep_data.get(dt) or {}).get("sleep_duration") or 0
+        sd = sleep_data.get(dt) or {}
+        # Prefer minutes_asleep (actual sleep, matches Fitbit app) over sleep_duration (time in bed)
+        val = sd.get("minutes_asleep")
+        if val is not None:
+            try:
+                return max(0, int(val))
+            except Exception:
+                return 0
+        dur_ms = sd.get("sleep_duration") or 0
         try:
             return max(0, int(round((dur_ms or 0) / 60000)))
         except Exception:

--- a/backend/core/views/fitbit_view.py
+++ b/backend/core/views/fitbit_view.py
@@ -28,13 +28,12 @@ def _sleep_minutes(entry: FitbitData) -> int:
     back to duration / 60 000 so existing data is never lost.
     """
     try:
-        sleep = entry.sleep if entry else None
-        if not sleep:
+        if not entry.sleep:
             return 0
-        if sleep.minutes_asleep is not None:
-            return int(sleep.minutes_asleep)
-        # Fallback for records stored before minutes_asleep was populated
-        dur_ms = sleep.sleep_duration or 0
+        # Prefer minutes_asleep (actual sleep, matches Fitbit app) over sleep_duration (time in bed)
+        if entry.sleep.minutes_asleep is not None:
+            return max(0, int(entry.sleep.minutes_asleep))
+        dur_ms = entry.sleep.sleep_duration or 0
         return int(round(dur_ms / 60000))
     except Exception:
         return 0

--- a/backend/tests/fitbit_sync/TESTING.md
+++ b/backend/tests/fitbit_sync/TESTING.md
@@ -10,9 +10,9 @@ Tests in [`test_fitbit_sync.py`](test_fitbit_sync.py) cover service logic in
 | Function | Tests |
 |---|---|
 | `get_valid_access_token` | 3 |
-| `fetch_fitbit_today_for_user` | 7 |
+| `fetch_fitbit_today_for_user` | 11 |
 
-**Total: 10 tests**
+**Total: 14 tests**
 
 ---
 
@@ -28,7 +28,36 @@ Tests in [`test_fitbit_sync.py`](test_fitbit_sync.py) cover service logic in
   - non-200 intraday response path
   - fallback parsing on malformed values
   - heart/sleep/exercise zone parsing branches
-  - AZM active-minutes fallback path
+- Wear time derived from intraday 1-sec HR dataset (distinct worn-minute slots).
+- `wear_time_minutes = None` when intraday endpoint returns no data.
+- `minutes_asleep` stored separately from `sleep_duration`; both fields preserved.
+- **Regression — AZM used as `active_minutes` when available** (`activities-active-zone-minutes` / `value.activeZoneMinutes`): `active_minutes` is set to the AZM value, not the `minutesVeryActive + minutesFairlyActive` fallback.
+- **Regression — AZM fallback** when AZM endpoint returns empty list: `active_minutes` falls back to `minutesVeryActive + minutesFairlyActive`.
+
+---
+
+## Key implementation notes
+
+### Active Zone Minutes response format
+
+The Fitbit API endpoint is `GET /1/user/-/activities/active-zone-minutes/date/{start}/{end}.json`.  
+The correct JSON keys are:
+
+```json
+{
+  "activities-active-zone-minutes": [
+    { "dateTime": "2026-05-01", "value": { "activeZoneMinutes": 42 } }
+  ]
+}
+```
+
+The envelope key is **`activities-active-zone-minutes`** (hyphenated) and the total field is **`value.activeZoneMinutes`**.  
+Using `activities-activeZoneMinutes` or `value.totalMinutes` silently drops all AZM data and triggers the fallback.
+
+### Sleep minutes
+
+`fetch_fitbit_today_for_user` stores both `sleep_duration` (total time in bed, ms) and `minutes_asleep` (actual sleep, matches Fitbit app).  
+The inactivity calculation helper `sleep_minutes_for()` prefers `minutes_asleep`; falls back to `sleep_duration ÷ 60 000` for legacy records.
 
 ---
 

--- a/backend/tests/fitbit_sync/test_fitbit_sync.py
+++ b/backend/tests/fitbit_sync/test_fitbit_sync.py
@@ -73,7 +73,7 @@ def _all_empty_side_effect(url, headers=None, timeout=None):
         "minutesFairlyActive": {"activities-minutesFairlyActive": []},
         "minutesLightlyActive": {"activities-minutesLightlyActive": []},
         "minutesSedentary": {"activities-minutesSedentary": []},
-        "active-zone-minutes": {"activities-activeZoneMinutes": []},
+        "active-zone-minutes": {"activities-active-zone-minutes": []},
         "activities/heart": {"activities-heart": []},
         "1d/1sec": {"activities-heart-intraday": {"dataset": []}},
         "/br/": {"br": []},
@@ -222,7 +222,7 @@ def test_fetch_fitbit_today_for_user_upserts_today(mock_get, mock_get_token):
         if "activities/heart" in url:
             return mk_resp({"activities-heart": []})
         if "active-zone-minutes" in url:
-            return mk_resp({"activities-activeZoneMinutes": []})
+            return mk_resp({"activities-active-zone-minutes": []})
         if "/br/" in url:
             return mk_resp({"br": []})
         if "/hrv/" in url:
@@ -274,7 +274,7 @@ def test_fetch_fitbit_today_for_user_does_not_write_empty_row(mock_get, _):
         if "activities/heart/date/" in url and "1d/1sec" not in url:
             return mk_resp(payload={"activities-heart": []})
         if "active-zone-minutes" in url:
-            return mk_resp(payload={"activities-activeZoneMinutes": []})
+            return mk_resp(payload={"activities-active-zone-minutes": []})
         if "/br/date/" in url:
             return mk_resp(payload={"br": []})
         if "/hrv/date/" in url:
@@ -339,7 +339,7 @@ def test_fetch_fitbit_today_for_user_covers_branches_and_parsing(mock_objects, m
                 }
             )
         if "active-zone-minutes" in url:
-            return mk_resp(payload={"activities-activeZoneMinutes": [{"dateTime": day, "value": {"totalMinutes": 25}}]})
+            return mk_resp(payload={"activities-active-zone-minutes": [{"dateTime": day, "value": {"activeZoneMinutes": 25}}]})
         if "/br/date/" in url:
             return mk_resp(payload={"br": [{"dateTime": day, "value": {"breathingRate": 14}}]})
         if "/hrv/date/" in url:
@@ -431,7 +431,7 @@ def test_wear_time_stored_from_intraday_hr(mock_get, _):
         if "minutesSedentary" in url:
             return mk_resp({"activities-minutesSedentary": []})
         if "active-zone-minutes" in url:
-            return mk_resp({"activities-activeZoneMinutes": []})
+            return mk_resp({"activities-active-zone-minutes": []})
         if "/br/" in url:
             return mk_resp({"br": []})
         if "/hrv/" in url:
@@ -490,7 +490,7 @@ def test_wear_time_none_when_no_intraday_data(mock_get, _):
         if "minutesSedentary" in url:
             return mk_empty({"activities-minutesSedentary": []})
         if "active-zone-minutes" in url:
-            return mk_empty({"activities-activeZoneMinutes": []})
+            return mk_empty({"activities-active-zone-minutes": []})
         if "/br/" in url:
             return mk_empty({"br": []})
         if "/hrv/" in url:
@@ -561,7 +561,7 @@ def test_minutes_asleep_stored_separately_from_duration(mock_get, _):
         if "minutesSedentary" in url:
             return mk_resp({"activities-minutesSedentary": []})
         if "active-zone-minutes" in url:
-            return mk_resp({"activities-activeZoneMinutes": []})
+            return mk_resp({"activities-active-zone-minutes": []})
         if "/br/" in url:
             return mk_resp({"br": []})
         if "/hrv/" in url:
@@ -682,3 +682,129 @@ def test_cooldown_handles_naive_last_fetched_at(mock_get, _):
 
     assert result == 0
     mock_get_inner.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Fix regression: active_minutes comes from AZM endpoint, not fallback
+# ---------------------------------------------------------------------------
+
+
+@patch("core.views.fitbit_sync.get_valid_access_token", return_value="access")
+@patch("core.views.fitbit_sync.requests.get")
+def test_active_minutes_uses_azm_not_fallback(mock_get, _):
+    """
+    Fix regression: when the Fitbit AZM endpoint returns data, active_minutes
+    must be set to the AZM value.  Previously the code looked for the wrong
+    JSON key ('activities-activeZoneMinutes') so it always silently fell back
+    to minutesVeryActive + minutesFairlyActive.
+    """
+    user, _ = make_user_with_token(expired=False)
+    day = datetime.now().strftime("%Y-%m-%d")
+
+    def mk_resp(payload):
+        r = Mock()
+        r.status_code = 200
+        r.json.return_value = payload
+        r.text = "ok"
+        return r
+
+    def side_effect(url, headers=None, timeout=None):
+        if "active-zone-minutes" in url:
+            # Correct Fitbit API response format
+            return mk_resp({"activities-active-zone-minutes": [
+                {"dateTime": day, "value": {"activeZoneMinutes": 42}}
+            ]})
+        if "minutesVeryActive" in url:
+            # If fallback were used: 10 + 5 = 15 (≠ 42, so we can detect the bug)
+            return mk_resp({"activities-minutesVeryActive": [{"dateTime": day, "value": "10"}]})
+        if "minutesFairlyActive" in url:
+            return mk_resp({"activities-minutesFairlyActive": [{"dateTime": day, "value": "5"}]})
+        if "minutesLightlyActive" in url:
+            return mk_resp({"activities-minutesLightlyActive": []})
+        if "minutesSedentary" in url:
+            return mk_resp({"activities-minutesSedentary": []})
+        if "activities/steps" in url:
+            return mk_resp({"activities-steps": [{"dateTime": day, "value": "1000"}]})
+        if "activities/floors" in url:
+            return mk_resp({"activities-floors": []})
+        if "activities/distance" in url:
+            return mk_resp({"activities-distance": []})
+        if "activities/calories" in url:
+            return mk_resp({"activities-calories": []})
+        if "1d/1sec" in url:
+            return mk_resp({"activities-heart-intraday": {"dataset": []}})
+        if "activities/heart" in url:
+            return mk_resp({"activities-heart": []})
+        if "/br/" in url:
+            return mk_resp({"br": []})
+        if "/hrv/" in url:
+            return mk_resp({"hrv": []})
+        if "/sleep/" in url:
+            return mk_resp({"sleep": []})
+        if "activities/list.json" in url:
+            return mk_resp({"activities": []})
+        return mk_resp({})
+
+    mock_get.side_effect = side_effect
+    fetch_fitbit_today_for_user(user)
+
+    row = FitbitData.objects(user=user).first()
+    # Must be 42 (from AZM), NOT 15 (minutesVeryActive + minutesFairlyActive fallback)
+    assert row.active_minutes == 42, (
+        f"active_minutes={row.active_minutes}: AZM not used — "
+        "check 'activities-active-zone-minutes' key and 'activeZoneMinutes' value field"
+    )
+
+
+@patch("core.views.fitbit_sync.get_valid_access_token", return_value="access")
+@patch("core.views.fitbit_sync.requests.get")
+def test_active_minutes_falls_back_when_azm_absent(mock_get, _):
+    """When AZM endpoint returns no data, fall back to minutesVeryActive + minutesFairlyActive."""
+    user, _ = make_user_with_token(expired=False)
+    day = datetime.now().strftime("%Y-%m-%d")
+
+    def mk_resp(payload):
+        r = Mock()
+        r.status_code = 200
+        r.json.return_value = payload
+        r.text = "ok"
+        return r
+
+    def side_effect(url, headers=None, timeout=None):
+        if "active-zone-minutes" in url:
+            return mk_resp({"activities-active-zone-minutes": []})  # empty → trigger fallback
+        if "minutesVeryActive" in url:
+            return mk_resp({"activities-minutesVeryActive": [{"dateTime": day, "value": "10"}]})
+        if "minutesFairlyActive" in url:
+            return mk_resp({"activities-minutesFairlyActive": [{"dateTime": day, "value": "5"}]})
+        if "minutesLightlyActive" in url:
+            return mk_resp({"activities-minutesLightlyActive": []})
+        if "minutesSedentary" in url:
+            return mk_resp({"activities-minutesSedentary": []})
+        if "activities/steps" in url:
+            return mk_resp({"activities-steps": [{"dateTime": day, "value": "1000"}]})
+        if "activities/floors" in url:
+            return mk_resp({"activities-floors": []})
+        if "activities/distance" in url:
+            return mk_resp({"activities-distance": []})
+        if "activities/calories" in url:
+            return mk_resp({"activities-calories": []})
+        if "1d/1sec" in url:
+            return mk_resp({"activities-heart-intraday": {"dataset": []}})
+        if "activities/heart" in url:
+            return mk_resp({"activities-heart": []})
+        if "/br/" in url:
+            return mk_resp({"br": []})
+        if "/hrv/" in url:
+            return mk_resp({"hrv": []})
+        if "/sleep/" in url:
+            return mk_resp({"sleep": []})
+        if "activities/list.json" in url:
+            return mk_resp({"activities": []})
+        return mk_resp({})
+
+    mock_get.side_effect = side_effect
+    fetch_fitbit_today_for_user(user)
+
+    row = FitbitData.objects(user=user).first()
+    assert row.active_minutes == 15  # 10 + 5

--- a/backend/tests/fitbit_sync/test_fitbit_sync.py
+++ b/backend/tests/fitbit_sync/test_fitbit_sync.py
@@ -339,7 +339,9 @@ def test_fetch_fitbit_today_for_user_covers_branches_and_parsing(mock_objects, m
                 }
             )
         if "active-zone-minutes" in url:
-            return mk_resp(payload={"activities-active-zone-minutes": [{"dateTime": day, "value": {"activeZoneMinutes": 25}}]})
+            return mk_resp(
+                payload={"activities-active-zone-minutes": [{"dateTime": day, "value": {"activeZoneMinutes": 25}}]}
+            )
         if "/br/date/" in url:
             return mk_resp(payload={"br": [{"dateTime": day, "value": {"breathingRate": 14}}]})
         if "/hrv/date/" in url:
@@ -711,9 +713,7 @@ def test_active_minutes_uses_azm_not_fallback(mock_get, _):
     def side_effect(url, headers=None, timeout=None):
         if "active-zone-minutes" in url:
             # Correct Fitbit API response format
-            return mk_resp({"activities-active-zone-minutes": [
-                {"dateTime": day, "value": {"activeZoneMinutes": 42}}
-            ]})
+            return mk_resp({"activities-active-zone-minutes": [{"dateTime": day, "value": {"activeZoneMinutes": 42}}]})
         if "minutesVeryActive" in url:
             # If fallback were used: 10 + 5 = 15 (≠ 42, so we can detect the bug)
             return mk_resp({"activities-minutesVeryActive": [{"dateTime": day, "value": "10"}]})

--- a/backend/tests/fitbit_views/TESTING.md
+++ b/backend/tests/fitbit_views/TESTING.md
@@ -15,9 +15,9 @@ This document describes tests in
 | `/api/fitbit/manual_steps/<patient_id>/` | POST/GET | 5 |
 | `/api/fitbit/summary/(<patient_id>/)` | GET | 3 |
 | `health_combined_history(<patient_id>)` | GET (direct view test) | 6 |
-| Helper functions | N/A | 5 |
+| Helper functions | N/A | 7 |
 
-**Total: 33 tests**
+**Total: 35 tests**
 
 ---
 
@@ -51,6 +51,8 @@ This document describes tests in
 - Health-data endpoint:
   - **`minutes_asleep` returned in `sleep` object (actual sleep vs time-in-bed)**
 - Helpers: threshold defaults/merge, averaging utility, patient resolver, sleep-minute conversion, and `_date`.
+- **Regression — `_sleep_minutes` prefers `minutes_asleep`**: when both `minutes_asleep` and `sleep_duration` are present, `_sleep_minutes` returns `minutes_asleep` (actual sleep, matches Fitbit app), not `sleep_duration ÷ 60 000` (time in bed).
+- **Regression — `_sleep_minutes` fallback**: when `minutes_asleep` is absent (legacy records), falls back to `sleep_duration ÷ 60 000`.
 
 ---
 

--- a/backend/tests/fitbit_views/test_fitbit_views.py
+++ b/backend/tests/fitbit_views/test_fitbit_views.py
@@ -711,7 +711,7 @@ def test_sleep_minutes_prefers_minutes_asleep_when_both_present():
         date=datetime.now(),
         sleep=SleepData(
             sleep_duration=28800000,  # 8 hours in bed (ms)
-            minutes_asleep=435,       # 7h15m actually asleep (what Fitbit app shows)
+            minutes_asleep=435,  # 7h15m actually asleep (what Fitbit app shows)
         ),
     )
     # Must return 435 (minutes_asleep), NOT 480 (sleep_duration / 60000)

--- a/backend/tests/fitbit_views/test_fitbit_views.py
+++ b/backend/tests/fitbit_views/test_fitbit_views.py
@@ -693,3 +693,37 @@ def test_health_combined_history_questionnaire_rows_include_comment_and_media_fi
     assert row["comment"] == "Patient noted mild fatigue in afternoon."
     assert row["audio_url"] == "https://files.example/audio1.m4a"
     assert row["media_urls"] == ["https://files.example/audio1.m4a"]
+
+
+# ---------------------------------------------------------------------------
+# Fix regression: _sleep_minutes prefers minutes_asleep over sleep_duration
+# ---------------------------------------------------------------------------
+
+
+def test_sleep_minutes_prefers_minutes_asleep_when_both_present():
+    """
+    Fix regression: _sleep_minutes must return minutes_asleep (actual sleep,
+    matches Fitbit app) not sleep_duration / 60000 (time in bed).
+    """
+    _, _, patient_user, _ = create_patient_graph()
+    row = FitbitData(
+        user=patient_user,
+        date=datetime.now(),
+        sleep=SleepData(
+            sleep_duration=28800000,  # 8 hours in bed (ms)
+            minutes_asleep=435,       # 7h15m actually asleep (what Fitbit app shows)
+        ),
+    )
+    # Must return 435 (minutes_asleep), NOT 480 (sleep_duration / 60000)
+    assert _sleep_minutes(row) == 435
+
+
+def test_sleep_minutes_falls_back_to_duration_when_minutes_asleep_absent():
+    """When minutes_asleep is missing, fall back to sleep_duration (legacy data)."""
+    _, _, patient_user, _ = create_patient_graph()
+    row = FitbitData(
+        user=patient_user,
+        date=datetime.now(),
+        sleep=SleepData(sleep_duration=90 * 60 * 1000),  # 90 min in bed, no minutes_asleep
+    )
+    assert _sleep_minutes(row) == 90

--- a/backend/tests/management_commands/test_commands.py
+++ b/backend/tests/management_commands/test_commands.py
@@ -18,13 +18,14 @@ def test_seed_periodic_tasks_creates_or_updates_tasks():
             side_effect=[
                 (SimpleNamespace(name="Run Delete Expired Videos"), True),
                 (SimpleNamespace(name="Run Fetch Fitbit Data"), False),
+                (SimpleNamespace(name="Run Fetch Fitbit Data Today (4h)"), True),
             ],
         ) as upsert,
     ):
         cmd.handle()
 
-    get_sched.assert_called_once()
-    assert upsert.call_count == 2
+    assert get_sched.call_count == 2  # midnight + every-4h schedules
+    assert upsert.call_count == 3
 
 
 def test_set_celerybeat_every_minute_updates_expected_tasks():
@@ -115,7 +116,7 @@ def test_fetch_fitbit_command_single_user_happy_path_with_mocks():
             return FakeResp(payload={"activities-heart-intraday": {"dataset": [{"value": 120}, {"value": 140}]}})
         if "activities/active-zone-minutes" in url:
             return FakeResp(
-                payload={"activities-activeZoneMinutes": [{"dateTime": "2026-01-01", "value": {"totalMinutes": 25}}]}
+                payload={"activities-active-zone-minutes": [{"dateTime": "2026-01-01", "value": {"activeZoneMinutes": 25}}]}
             )
         if "/br/date/" in url:
             return FakeResp(payload={"br": [{"dateTime": "2026-01-01", "value": {"breathingRate": 14}}]})
@@ -226,7 +227,7 @@ def test_fetch_fitbit_command_wear_time_calculated_during_periodic_sync():
         if "activities/heart/date/" in url:
             return FakeResp({"activities-heart": []})
         if "active-zone-minutes" in url:
-            return FakeResp({"activities-activeZoneMinutes": []})
+            return FakeResp({"activities-active-zone-minutes": []})
         # generic time-series (steps, floors, distance, calories, minutesVeryActive, …)
         if "/activities/" in url:
             key = url.split("/activities/")[1].split("/date/")[0]

--- a/backend/tests/management_commands/test_commands.py
+++ b/backend/tests/management_commands/test_commands.py
@@ -116,7 +116,9 @@ def test_fetch_fitbit_command_single_user_happy_path_with_mocks():
             return FakeResp(payload={"activities-heart-intraday": {"dataset": [{"value": 120}, {"value": 140}]}})
         if "activities/active-zone-minutes" in url:
             return FakeResp(
-                payload={"activities-active-zone-minutes": [{"dateTime": "2026-01-01", "value": {"activeZoneMinutes": 25}}]}
+                payload={
+                    "activities-active-zone-minutes": [{"dateTime": "2026-01-01", "value": {"activeZoneMinutes": 25}}]
+                }
             )
         if "/br/date/" in url:
             return FakeResp(payload={"br": [{"dateTime": "2026-01-01", "value": {"breathingRate": 14}}]})

--- a/docs/16-FITBIT_INTEGRATION.md
+++ b/docs/16-FITBIT_INTEGRATION.md
@@ -100,7 +100,7 @@ Unique on `(user, date)`. All numeric fields are `None` when not yet received.
 | `floors` | int | `activities/floors` |
 | `distance` | float (km) | `activities/distance` |
 | `calories` | float | `activities/calories` |
-| `active_minutes` | int | AZM if available, else `minutesVeryActive + minutesFairlyActive` |
+| `active_minutes` | int | `activities-active-zone-minutes` → `value.activeZoneMinutes`; falls back to `minutesVeryActive + minutesFairlyActive` when the endpoint returns no data |
 | `inactivity_minutes` | int | `1440 − (active_minutes + sleep_minutes)` |
 | `resting_heart_rate` | int | `activities/heart` summary |
 | `max_heart_rate` | int | Derived from intraday 1-sec HR dataset |
@@ -193,14 +193,22 @@ fetch_fitbit_today_for_user(user, bypass_cooldown=True)
 
 ---
 
-### 2. Scheduled backfill (Celery)
+### 2. Scheduled sync (Celery)
 
 **Entry points:**
 
-| Task name | What it does |
-|---|---|
-| `core.tasks.run_fetch_fitbit_data` | Runs the `fetch_fitbit_data` management command for all connected users; scheduled via Celery Beat |
-| `core.tasks.fetch_fitbit_data_async` | Fetches today for a single user; called ad-hoc (e.g. from auth flow) |
+| Task name | Schedule | What it does |
+|---|---|---|
+| `core.tasks.run_fetch_fitbit_data_today_all` | Every 4 hours | Calls `fetch_fitbit_today_for_user` for every connected user; keeps data current even when patients do not open the app |
+| `core.tasks.run_fetch_fitbit_data` | Nightly at 01:00 | Runs the `fetch_fitbit_data` management command — full 30-day backfill for all users |
+| `core.tasks.fetch_fitbit_data_async` | Ad-hoc (after login) | Fetches today for a single user; always bypasses the 15-minute cooldown |
+
+> **Why two scheduled tasks?** The 4-hour task keeps same-day data current without the expense of a 30-day backfill on every run. The nightly task self-corrects any gaps (e.g. a day where the device had not yet synced to Fitbit's servers when the 4-hour job ran).
+
+Register both schedules with:
+```bash
+docker exec django python manage.py seed_periodic_tasks
+```
 
 **Management command:** `python manage.py fetch_fitbit_data`
 **Source:** [core/management/commands/fetch_fitbit_data.py](../backend/core/management/commands/fetch_fitbit_data.py)
@@ -340,7 +348,7 @@ Detailed day-by-day export including sleep, HR zones, and exercise sessions. No 
 ```
 
 Dates are returned in European format (`DD.MM.YYYY`).  
-`sleep_minutes` reflects time **in bed** (from `sleep_duration`); `minutes_asleep` reflects actual sleep time (matches the Fitbit app).
+`minutes_asleep` is the actual sleep time (matches the Fitbit app display). `sleep_minutes` in this endpoint is derived from `sleep_duration` (total time in bed, ms ÷ 60 000) for historical compatibility; prefer `minutes_asleep` for patient-facing display.
 
 ---
 
@@ -388,9 +396,31 @@ Returns Fitbit data, questionnaire responses, and intervention adherence in a si
 
 Fitbit enforces **150 API calls per user per hour** (as of the Personal tier).
 
-Each call to `fetch_fitbit_today_for_user` makes ~13–15 API calls. The 15-minute cooldown limits on-demand fetches to at most **4 per hour (~60 calls)**, well within the quota. The scheduled backfill command runs outside the cooldown and is invoked at most once per hour by Celery Beat.
+Each call to `fetch_fitbit_today_for_user` makes ~13–15 API calls. The 15-minute cooldown limits on-demand fetches to at most **4 per hour (~60 calls)**. The every-4-hour scheduled task also respects the cooldown guard, so the two paths combined remain well within the quota. The nightly 30-day backfill command runs outside the cooldown.
 
 If a user's quota is exhausted (HTTP 429), all subsequent fetches within the cooldown window are blocked automatically. The next permitted fetch attempt is ~15 minutes after the 429-triggering run.
+
+---
+
+## Bug History
+
+### 2026-05-19 — Active Zone Minutes always wrong; sleep displayed as time-in-bed
+
+**Symptoms reported (from clinical team):**
+
+- `active_minutes` in Bearny did not match "Active Zone Minutes" in the Fitbit app for most days.
+- `sleep_minutes` was consistently higher than what the Fitbit app showed (included wake phases).
+- Patients who did not open the Bearny app had no wearable data in Bearny even though the Fitbit recorded data.
+
+**Root causes:**
+
+1. **Wrong AZM JSON keys** (`fetch_fitbit_data.py` and `fitbit_sync.py`): The Fitbit API returns the Active Zone Minutes envelope as `activities-active-zone-minutes` and the total field as `value.activeZoneMinutes`. Both files used the wrong key names (`activities-activeZoneMinutes` / `totalMinutes`), so the AZM dict was always empty and the code silently fell back to `minutesVeryActive + minutesFairlyActive` — unweighted raw minutes, systematically different from AZM.
+
+2. **`_sleep_minutes` used time-in-bed** (`fitbit_view.py`): The helper computed `sleep_duration (ms) ÷ 60 000` (total time in bed). The Fitbit app displays `minutesAsleep` (actual sleep, wake phases removed). Fixed to prefer `minutes_asleep`; falls back to `sleep_duration` for legacy records without `minutes_asleep`.
+
+3. **No intra-day sync** (`seed_periodic_tasks.py`, `tasks.py`): Wearable data was only synced at 01:00 (nightly backfill) or when a therapist or patient opened a Bearny page. Patients who did not log in had no data until the next midnight. Fixed by adding a `run_fetch_fitbit_data_today_all` task that runs every 4 hours.
+
+**Fix branch:** `fix/fitbit-data-sync-issues`
 
 ---
 


### PR DESCRIPTION
# Description

## Summary

- **AZM field name wrong**: Active Zone Minutes were always 0 because the API response key `activities-active-zone-minutes` was being read as `activities-activeZoneMinutes` (camelCase vs kebab-case). Fixed in both `fitbit_sync.py` and `fitbit_view.py`.
- **AZM value field wrong**: The total was read from `totalMinutes` instead of `activeZoneMinutes` inside the value object.
- **Sleep duration mismatch**: Sleep was calculated from `sleep_duration` (time in bed, in ms) instead of `minutes_asleep` (actual sleep, matches what the Fitbit app shows). All three sleep-duration code paths updated to prefer `minutes_asleep` with fallback to the old ms-based calculation.
- **New background task** `run_fetch_fitbit_data_today_all`: fetches today's data for every connected user on a schedule, so wearable data stays current even for patients who haven't opened the app. Registered in `seed_periodic_tasks`.

## Test plan

- [x] Run `pytest tests/fitbit_sync/ tests/fitbit_views/ tests/management_commands/ -v` in the `django` container
- [x] Verify AZM and sleep values now match the Fitbit mobile app for a connected patient
- [x] Confirm `seed_periodic_tasks` registers the new `run_fetch_fitbit_data_today_all` task


## Related Issue
[IssueName](IssueLink)

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)


## Checklist

- [x] I have read the [contributing guidelines](/docs/12-CONTRIBUTING.md).
- [x] I have read the [code of conduct](/CODE_OF_CONDUCT.md).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
