### PR TITLE
fix(PatientLibrary): fetch with current language

### DIFF
--- a/frontend/src/pages/PatientInterventionsLibrary.tsx
+++ b/frontend/src/pages/PatientInterventionsLibrary.tsx
@@ -246,16 +246,9 @@ const PatientInterventionsLibrary: React.FC = observer(() => {
       return;
     }
 
-    const lang = (authStore.preferredLanguage || i18n.language || 'en').slice(0, 2);
+    const lang = i18n.language.slice(0, 2);
     patientInterventionsLibraryStore.fetchAll({ mode: 'patient', lang });
-  }, [
-    authChecked,
-    authStore.isAuthenticated,
-    authStore.userType,
-    authStore.preferredLanguage,
-    navigate,
-    i18n.language,
-  ]);
+  }, [authChecked, authStore.isAuthenticated, authStore.userType, navigate, i18n.language]);
 
   const sourceItems = patientInterventionsLibraryStore.visibleItemsForPatient;
   const storeError = patientInterventionsLibraryStore.error;


### PR DESCRIPTION
# Description

Patient Libarary now fetches all interventions in active language, not prefered one.
This makes the fetch logic consistent with therapist interventions libarary.
> Note: probably not the fix to the whole issue yet, will have another look at the sessionstorage.

## Related Issue
https://github.com/ARTORG-GERONTECHNOLOGY/Bearny-RehaAdvisor/issues/271

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Tests

1. Log in as patient
2. Navigate to interventions library
3. Make sure interventions get fetches in active language

## Checklist

- [x] I have read the [contributing guidelines](/docs/12-CONTRIBUTING.md).
- [x] I have read the [code of conduct](/CODE_OF_CONDUCT.md).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.