### PR TITLE
282 bug last login - use most recent patient activity for last_online instead of login-only

### DIFF
--- a/backend/core/models.py
+++ b/backend/core/models.py
@@ -166,8 +166,10 @@ class Logs(Document):
     meta = {
         "collection": "logs",
         "indexes": [
-            # Fast lookup by user + action ordered by time (used by last-login queries)
+            # Fast lookup by user + action ordered by time
             {"fields": ["userId", "action", "-timestamp"]},
+            # Fast lookup by user + role ordered by time (used by last-activity queries)
+            {"fields": ["userId", "actor_role", "-timestamp"]},
             # General time-range queries
             {"fields": ["-timestamp"]},
         ],

--- a/backend/core/views/therapist_views.py
+++ b/backend/core/views/therapist_views.py
@@ -571,9 +571,7 @@ def list_therapist_patients(request, therapist_id):
             if not user or not getattr(user, "isActive", True):
                 continue
 
-            last_online_log = (
-                Logs.objects(userId=user, actor_role="Patient").order_by("-timestamp").first()
-            )
+            last_online_log = Logs.objects(userId=user, actor_role="Patient").order_by("-timestamp").first()
             last_online_dt = last_online_log.timestamp if last_online_log else None
 
             try:

--- a/backend/core/views/therapist_views.py
+++ b/backend/core/views/therapist_views.py
@@ -571,7 +571,9 @@ def list_therapist_patients(request, therapist_id):
             if not user or not getattr(user, "isActive", True):
                 continue
 
-            last_online_log = Logs.objects(userId=user, action="LOGIN").order_by("-timestamp").first()
+            last_online_log = (
+                Logs.objects(userId=user, actor_role="Patient").order_by("-timestamp").first()
+            )
             last_online_dt = last_online_log.timestamp if last_online_log else None
 
             try:

--- a/backend/core/views/user_views.py
+++ b/backend/core/views/user_views.py
@@ -381,9 +381,7 @@ def user_profile_view(request, user_id):
                     if isinstance(obj.get(dkey), datetime):
                         obj[dkey] = obj[dkey].date().isoformat()
 
-                last_activity = (
-                    Logs.objects(userId=user, actor_role="Patient").order_by("-timestamp").first()
-                )
+                last_activity = Logs.objects(userId=user, actor_role="Patient").order_by("-timestamp").first()
                 if last_activity:
                     obj["last_online"] = last_activity.timestamp.date().isoformat()
 

--- a/backend/core/views/user_views.py
+++ b/backend/core/views/user_views.py
@@ -381,9 +381,11 @@ def user_profile_view(request, user_id):
                     if isinstance(obj.get(dkey), datetime):
                         obj[dkey] = obj[dkey].date().isoformat()
 
-                last_login = Logs.objects(userId=user, action="LOGIN").order_by("-timestamp").first()
-                if last_login:
-                    obj["last_online"] = last_login.timestamp.date().isoformat()
+                last_activity = (
+                    Logs.objects(userId=user, actor_role="Patient").order_by("-timestamp").first()
+                )
+                if last_activity:
+                    obj["last_online"] = last_activity.timestamp.date().isoformat()
 
                 # Resolve creator therapist name
                 obj["created_by"] = None

--- a/backend/tests/therapist_views/test_therapist_views.py
+++ b/backend/tests/therapist_views/test_therapist_views.py
@@ -239,10 +239,10 @@ def test_list_therapist_patients_excludes_inactive_users():
     assert all(row["_id"] != str(patient.id) for row in data)
 
 
-def test_list_therapist_patients_includes_login_and_biomarker_fields():
+def test_list_therapist_patients_includes_last_online_and_biomarker_fields():
     therapist, patient = create_therapist_with_patient()
 
-    Logs(userId=patient.userId, action="LOGIN", actor_role="pytest").save()
+    Logs(userId=patient.userId, action="LOGIN", actor_role="Patient").save()
     FitbitData(
         user=patient.userId,
         date=datetime.now() - timedelta(days=1),
@@ -262,6 +262,35 @@ def test_list_therapist_patients_includes_login_and_biomarker_fields():
     assert "biomarker" in patient_row
     assert patient_row["biomarker"]["steps_avg"] == 1000.0
     assert patient_row["biomarker"]["activity_min"] == 20.0
+
+
+def test_last_online_uses_most_recent_patient_activity_not_just_login():
+    therapist, patient = create_therapist_with_patient()
+
+    # Older LOGIN log
+    Logs(
+        userId=patient.userId,
+        action="LOGIN",
+        actor_role="Patient",
+        timestamp=datetime(2026, 1, 1),
+    ).save()
+    # More recent non-login activity
+    Logs(
+        userId=patient.userId,
+        action="INTERVENTION_VIEW",
+        actor_role="Patient",
+        timestamp=datetime(2026, 3, 15),
+    ).save()
+
+    resp = client.get(
+        f"/api/therapists/{therapist.userId.id}/patients/",
+        HTTP_AUTHORIZATION="Bearer test",
+    )
+
+    assert resp.status_code == 200
+    payload = resp.json()
+    patient_row = next(row for row in payload if row["_id"] == str(patient.id))
+    assert patient_row["last_online"].startswith("2026-03-15")
 
 
 def test_create_log_success_for_existing_user():


### PR DESCRIPTION

## Summary
- `last_online` in the therapist patient list and patient profile endpoints previously only reflected the most recent `LOGIN` log entry — patients who stayed logged in on their PWA never had their timestamp updated
- Both query sites (`therapist_views.py` and `user_views.py`) now query `Logs` filtered by `actor_role="Patient"` ordered by `-timestamp`, so any patient activity (INTERVENTION_VIEW, QUESTIONNAIRE_SUBMIT, VITALS_SUBMIT, REHATABLE, HEALTH_PAGE, etc.) advances the timestamp
- Added a compound MongoDB index `(userId, actor_role, -timestamp)` on the `Logs` collection to keep the query fast

## Test plan
- [x] Log in as a patient, perform some activity (open an intervention, submit a questionnaire), then check the therapist view — `last_online` should reflect today's date even without a new login
- [x] Confirm that a patient who has only ever logged in still gets `last_online` set (LOGIN also has `actor_role="Patient"`)
- [x] Confirm that therapist actions (ASSIGN_INTERVENTION, OPEN_PATIENT) do not affect a patient's `last_online` (those logs have `actor_role="Therapist"`)
- [x] Backend tests: `docker exec django pytest tests/therapist_views/test_therapist_views.py tests/user_views/test_user_views.py -v`
  - `test_last_online_uses_most_recent_patient_activity_not_just_login` — verifies INTERVENTION_VIEW (Mar 15) wins over older LOGIN (Jan 1)
  - `test_list_therapist_patients_includes_last_online_and_biomarker_fields` — verifies last_online is non-null when a Patient-role log exists

## Type of change

For a new feature, please create an issue first to discuss it with us before submitting a pull request.

- [x] Bug fix (non-breaking change that fixes an issue)


## Checklist

- [x] I have read the [contributing guidelines](/docs/12-CONTRIBUTING.md).
- [x] I have read the [code of conduct](/CODE_OF_CONDUCT.md).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
