### PR TITLE
295-bug-opening-an-intervention-in-the-patient-view-scrolls-to-the-middledescription-section-instead-of-the-top

### DIFF
--- a/frontend/src/routes/index.tsx
+++ b/frontend/src/routes/index.tsx
@@ -1,6 +1,12 @@
-import { createElement, lazy, Suspense } from 'react';
+import { createElement, Fragment, lazy, Suspense } from 'react';
 import type { ComponentType, LazyExoticComponent, ReactElement } from 'react';
-import { createBrowserRouter, RouterProvider, Navigate } from 'react-router-dom';
+import {
+  createBrowserRouter,
+  RouterProvider,
+  Navigate,
+  ScrollRestoration,
+  Outlet,
+} from 'react-router-dom';
 
 import RootLayout from '@/RootLayout';
 import HomeSkeleton from '@/components/skeletons/HomeSkeleton';
@@ -75,6 +81,7 @@ export const router = createBrowserRouter([
   {
     // Root catch-all: errorElement here covers every child route
     path: '/',
+    element: createElement(Fragment, null, createElement(ScrollRestoration), createElement(Outlet)),
     errorElement: withSuspense(createElement(ErrorPage)),
     children: [
       {

--- a/frontend/src/routes/index.tsx
+++ b/frontend/src/routes/index.tsx
@@ -79,7 +79,6 @@ const withSuspense = (el: ReactElement, fallback: ReactElement = createElement(F
 // -------------------- Router Definition --------------------
 export const router = createBrowserRouter([
   {
-    // Root catch-all: errorElement here covers every child route
     path: '/',
     element: createElement(Fragment, null, createElement(ScrollRestoration), createElement(Outlet)),
     errorElement: withSuspense(createElement(ErrorPage)),


### PR DESCRIPTION
# Description

Resets scrolling position on site change.

## Related Issue
https://github.com/ARTORG-GERONTECHNOLOGY/Bearny-RehaAdvisor/issues/295

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Tests

1. Open any site
2. Scroll down
3. Change page
4. Make sure the scrolling position resets & you see the top of the new page

## Checklist

- [x] I have read the [contributing guidelines](/docs/12-CONTRIBUTING.md).
- [x] I have read the [code of conduct](/CODE_OF_CONDUCT.md).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
