### PR TITLE
294 bug filter selection in library patient view

### DIFF
--- a/frontend/src/__tests__/pages/PatientInterventionsLibrary.test.tsx
+++ b/frontend/src/__tests__/pages/PatientInterventionsLibrary.test.tsx
@@ -117,9 +117,15 @@ const getLatestFilterSheetProps = () => {
   return calls[calls.length - 1][0];
 };
 
+const getLatestDesktopFiltersProps = () => {
+  const calls = mockDesktopFilters.mock.calls;
+  return calls[calls.length - 1][0];
+};
+
 describe('PatientInterventionsLibrary', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    sessionStorage.clear();
 
     mockStore.visibleItemsForPatient = [
       {
@@ -167,6 +173,92 @@ describe('PatientInterventionsLibrary', () => {
 
     await waitFor(() => {
       expect(getLatestFilterSheetProps().open).toBe(true);
+    });
+  });
+
+  describe('filter session persistence', () => {
+    const FILTER_KEY = 'patientLibraryFilters';
+
+    it('restores saved filters from sessionStorage on mount', async () => {
+      sessionStorage.setItem(
+        FILTER_KEY,
+        JSON.stringify({
+          searchTerm: 'yoga',
+          contentTypeFilter: ['video'],
+          aimsFilter: ['exercise'],
+          languageFilter: ['en'],
+          durationFilterIndices: [1, 3],
+          ratingFilterIndices: [2, 4],
+        })
+      );
+
+      render(<PatientInterventionsLibrary />);
+
+      await waitFor(() => {
+        expect(mockStore.fetchAll).toHaveBeenCalled();
+      });
+
+      const props = getLatestDesktopFiltersProps();
+      expect(props.searchTerm).toBe('yoga');
+      expect(props.contentTypeFilter).toEqual(['video']);
+      expect(props.aimsFilter).toEqual(['exercise']);
+      expect(props.languageFilter).toEqual(['en']);
+      expect(props.durationFilterIndices).toEqual([1, 3]);
+      expect(props.ratingFilterIndices).toEqual([2, 4]);
+    });
+
+    it('saves updated filters to sessionStorage when a filter changes', async () => {
+      render(<PatientInterventionsLibrary />);
+
+      await waitFor(() => {
+        expect(mockStore.fetchAll).toHaveBeenCalled();
+      });
+
+      await act(async () => {
+        getLatestDesktopFiltersProps().setAimsFilter(['exercise']);
+      });
+
+      await waitFor(() => {
+        const saved = JSON.parse(sessionStorage.getItem(FILTER_KEY) ?? '{}');
+        expect(saved.aimsFilter).toEqual(['exercise']);
+      });
+    });
+
+    it('resets filters to defaults in sessionStorage after resetAllFilters', async () => {
+      sessionStorage.setItem(
+        FILTER_KEY,
+        JSON.stringify({
+          searchTerm: 'yoga',
+          contentTypeFilter: ['video'],
+          aimsFilter: ['exercise'],
+          languageFilter: ['en'],
+          durationFilterIndices: [1, 3],
+          ratingFilterIndices: [2, 4],
+        })
+      );
+
+      render(<PatientInterventionsLibrary />);
+
+      await waitFor(() => {
+        expect(mockStore.fetchAll).toHaveBeenCalled();
+      });
+
+      // Verify saved values were loaded
+      expect(getLatestDesktopFiltersProps().searchTerm).toBe('yoga');
+
+      await act(async () => {
+        getLatestFilterSheetProps().onResetFilters();
+      });
+
+      await waitFor(() => {
+        expect(getLatestDesktopFiltersProps().searchTerm).toBe('');
+        expect(getLatestDesktopFiltersProps().aimsFilter).toEqual([]);
+        expect(getLatestDesktopFiltersProps().contentTypeFilter).toEqual([]);
+      });
+
+      const saved = JSON.parse(sessionStorage.getItem(FILTER_KEY) ?? '{}');
+      expect(saved.searchTerm).toBe('');
+      expect(saved.aimsFilter).toEqual([]);
     });
   });
 });

--- a/frontend/src/pages/PatientInterventionsLibrary.tsx
+++ b/frontend/src/pages/PatientInterventionsLibrary.tsx
@@ -1,5 +1,5 @@
 // src/pages/PatientInterventionsLibrary.tsx
-import React, { useEffect, useMemo, useState, useCallback } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import { observer } from 'mobx-react-lite';
@@ -212,7 +212,6 @@ const saveFilters = (filters: FilterState) => {
   }
 };
 
-
 const PatientInterventionsLibrary: React.FC = observer(() => {
   const { t, i18n } = useTranslation();
   const navigate = useNavigate();
@@ -246,15 +245,16 @@ const PatientInterventionsLibrary: React.FC = observer(() => {
   }, []);
 
   // ─────────────────────────── filters ───────────────────────────
-  const [searchTerm, setSearchTerm] = useState(() => loadFilters().searchTerm);
-  const [contentTypeFilter, setContentTypeFilter] = useState(() => loadFilters().contentTypeFilter);
-  const [aimsFilter, setAimsFilter] = useState(() => loadFilters().aimsFilter);
-  const [languageFilter, setLanguageFilter] = useState(() => loadFilters().languageFilter);
+  const initialFilters = useMemo(() => loadFilters(), []);
+  const [searchTerm, setSearchTerm] = useState(initialFilters.searchTerm);
+  const [contentTypeFilter, setContentTypeFilter] = useState(initialFilters.contentTypeFilter);
+  const [aimsFilter, setAimsFilter] = useState(initialFilters.aimsFilter);
+  const [languageFilter, setLanguageFilter] = useState(initialFilters.languageFilter);
   const [durationFilterIndices, setDurationFilterIndices] = useState(
-    () => loadFilters().durationFilterIndices
+    initialFilters.durationFilterIndices
   );
   const [ratingFilterIndices, setRatingFilterIndices] = useState(
-    () => loadFilters().ratingFilterIndices
+    initialFilters.ratingFilterIndices
   );
 
   useEffect(() => {

--- a/frontend/src/pages/PatientInterventionsLibrary.tsx
+++ b/frontend/src/pages/PatientInterventionsLibrary.tsx
@@ -212,13 +212,6 @@ const saveFilters = (filters: FilterState) => {
   }
 };
 
-const clearFilters = () => {
-  try {
-    sessionStorage.removeItem(FILTER_SESSION_KEY);
-  } catch {
-    // ignore
-  }
-};
 
 const PatientInterventionsLibrary: React.FC = observer(() => {
   const { t, i18n } = useTranslation();
@@ -283,13 +276,13 @@ const PatientInterventionsLibrary: React.FC = observer(() => {
   ]);
 
   const resetAllFilters = useCallback(() => {
-    setSearchTerm('');
-    setContentTypeFilter([]);
-    setAimsFilter([]);
-    setLanguageFilter([]);
-    setDurationFilterIndices([0, 4]);
-    setRatingFilterIndices([0, 4]);
-    clearFilters();
+    setSearchTerm(DEFAULT_FILTERS.searchTerm);
+    setContentTypeFilter(DEFAULT_FILTERS.contentTypeFilter);
+    setAimsFilter(DEFAULT_FILTERS.aimsFilter);
+    setLanguageFilter(DEFAULT_FILTERS.languageFilter);
+    setDurationFilterIndices(DEFAULT_FILTERS.durationFilterIndices);
+    setRatingFilterIndices(DEFAULT_FILTERS.ratingFilterIndices);
+    saveFilters(DEFAULT_FILTERS);
   }, []);
 
   useEffect(() => {

--- a/frontend/src/pages/PatientInterventionsLibrary.tsx
+++ b/frontend/src/pages/PatientInterventionsLibrary.tsx
@@ -173,6 +173,53 @@ const getTranslatedTitle = (item: InterventionCardItem, translatedTitles: TitleM
   return getRawTitle(item) || '-';
 };
 
+// ─────────────────────────── filter session persistence ───────────────────────────
+const FILTER_SESSION_KEY = 'patientLibraryFilters';
+
+type FilterState = {
+  searchTerm: string;
+  contentTypeFilter: string[];
+  aimsFilter: string[];
+  languageFilter: string[];
+  durationFilterIndices: [number, number];
+  ratingFilterIndices: [number, number];
+};
+
+const DEFAULT_FILTERS: FilterState = {
+  searchTerm: '',
+  contentTypeFilter: [],
+  aimsFilter: [],
+  languageFilter: [],
+  durationFilterIndices: [0, 4],
+  ratingFilterIndices: [0, 4],
+};
+
+const loadFilters = (): FilterState => {
+  try {
+    const raw = sessionStorage.getItem(FILTER_SESSION_KEY);
+    if (raw) return { ...DEFAULT_FILTERS, ...JSON.parse(raw) };
+  } catch {
+    // ignore
+  }
+  return DEFAULT_FILTERS;
+};
+
+const saveFilters = (filters: FilterState) => {
+  try {
+    sessionStorage.setItem(FILTER_SESSION_KEY, JSON.stringify(filters));
+  } catch {
+    // ignore
+  }
+};
+
+const clearFilters = () => {
+  try {
+    sessionStorage.removeItem(FILTER_SESSION_KEY);
+  } catch {
+    // ignore
+  }
+};
+
 const PatientInterventionsLibrary: React.FC = observer(() => {
   const { t, i18n } = useTranslation();
   const navigate = useNavigate();
@@ -206,12 +253,34 @@ const PatientInterventionsLibrary: React.FC = observer(() => {
   }, []);
 
   // ─────────────────────────── filters ───────────────────────────
-  const [searchTerm, setSearchTerm] = useState('');
-  const [contentTypeFilter, setContentTypeFilter] = useState<string[]>([]);
-  const [aimsFilter, setAimsFilter] = useState<string[]>([]);
-  const [languageFilter, setLanguageFilter] = useState<string[]>([]);
-  const [durationFilterIndices, setDurationFilterIndices] = useState<[number, number]>([0, 4]);
-  const [ratingFilterIndices, setRatingFilterIndices] = useState<[number, number]>([0, 4]);
+  const [searchTerm, setSearchTerm] = useState(() => loadFilters().searchTerm);
+  const [contentTypeFilter, setContentTypeFilter] = useState(() => loadFilters().contentTypeFilter);
+  const [aimsFilter, setAimsFilter] = useState(() => loadFilters().aimsFilter);
+  const [languageFilter, setLanguageFilter] = useState(() => loadFilters().languageFilter);
+  const [durationFilterIndices, setDurationFilterIndices] = useState(
+    () => loadFilters().durationFilterIndices
+  );
+  const [ratingFilterIndices, setRatingFilterIndices] = useState(
+    () => loadFilters().ratingFilterIndices
+  );
+
+  useEffect(() => {
+    saveFilters({
+      searchTerm,
+      contentTypeFilter,
+      aimsFilter,
+      languageFilter,
+      durationFilterIndices,
+      ratingFilterIndices,
+    });
+  }, [
+    searchTerm,
+    contentTypeFilter,
+    aimsFilter,
+    languageFilter,
+    durationFilterIndices,
+    ratingFilterIndices,
+  ]);
 
   const resetAllFilters = useCallback(() => {
     setSearchTerm('');
@@ -220,6 +289,7 @@ const PatientInterventionsLibrary: React.FC = observer(() => {
     setLanguageFilter([]);
     setDurationFilterIndices([0, 4]);
     setRatingFilterIndices([0, 4]);
+    clearFilters();
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION
# Description

Stores patient library filters in session

## Related Issue
https://github.com/ARTORG-GERONTECHNOLOGY/Bearny-RehaAdvisor/issues/294

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Tests

1. Open patient interventions library
2. Set any filter
3. Change page
4. Go back to library and make sure filters are still set
5. Clear filters
6. Make sure filters are cleared

## Checklist

- [x] I have read the [contributing guidelines](/docs/12-CONTRIBUTING.md).
- [x] I have read the [code of conduct](/CODE_OF_CONDUCT.md).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
