### PR TITLE
293-bug-languages-cannot-be-switched-in-rehabilitation-table-when-viewing-an-intervention

### DIFF
--- a/frontend/src/__tests__/components/PatientPage/PatientInterventionPopUp.test.tsx
+++ b/frontend/src/__tests__/components/PatientPage/PatientInterventionPopUp.test.tsx
@@ -22,7 +22,7 @@ jest.mock('@/assets/icons/arrow-right-fill.svg?react', () => ({
   },
 }));
 
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import PatientInterventionPopUp from '@/components/PatientPage/PatientInterventionPopUp';
 import '@testing-library/jest-dom';
 
@@ -60,6 +60,7 @@ jest.mock('@/utils/interventions', () => ({
 jest.mock('react-i18next', () => jest.requireActual('@/__mocks__/react-i18next'));
 
 import { getMediaTypeLabelFromUrl } from '@/utils/interventions';
+import apiClient from '@/api/client';
 
 const defaultItem = {
   title: 'Test Intervention',
@@ -294,6 +295,84 @@ describe('PatientInterventionPopUp Component', () => {
       expect(screen.queryByTestId('media-dot-0')).not.toBeInTheDocument();
       // Counter still visible
       expect(screen.getByText('1 / 8')).toBeInTheDocument();
+    });
+  });
+
+  // ── Language options ──────────────────────────────────────────────────────
+
+  describe('language options', () => {
+    const langItem = {
+      ...defaultItem,
+      language: 'de',
+      external_id: 'ext-123',
+      available_languages: ['de', 'en', 'fr'],
+    };
+
+    beforeEach(() => {
+      (apiClient.get as jest.Mock).mockReset();
+    });
+
+    it('renders a language button for each entry in available_languages', () => {
+      render(<PatientInterventionPopUp show={true} item={langItem} handleClose={jest.fn()} />);
+      expect(screen.getByRole('button', { name: 'DE' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'EN' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'FR' })).toBeInTheDocument();
+    });
+
+    it('does not duplicate the current language when it also appears in available_languages', () => {
+      render(<PatientInterventionPopUp show={true} item={langItem} handleClose={jest.fn()} />);
+      expect(screen.getAllByRole('button', { name: 'DE' })).toHaveLength(1);
+    });
+
+    it('marks the current language button as active via aria-pressed', () => {
+      render(<PatientInterventionPopUp show={true} item={langItem} handleClose={jest.fn()} />);
+      expect(screen.getByRole('button', { name: 'DE' })).toHaveAttribute('aria-pressed', 'true');
+      expect(screen.getByRole('button', { name: 'EN' })).toHaveAttribute('aria-pressed', 'false');
+    });
+
+    it('sorts preferred language (en in test env) first, then de, then remaining alphabetically', () => {
+      render(<PatientInterventionPopUp show={true} item={langItem} handleClose={jest.fn()} />);
+      const allButtons = screen.getAllByRole('button');
+      const langBtns = allButtons.filter((b) => /^[A-Z]{2}$/.test((b.textContent ?? '').trim()));
+      expect(langBtns[0]).toHaveTextContent('EN');
+      expect(langBtns[1]).toHaveTextContent('DE');
+      expect(langBtns[2]).toHaveTextContent('FR');
+    });
+
+    it('does not render language buttons when the item has only one language', () => {
+      const singleLangItem = { ...defaultItem, language: 'de' };
+      render(
+        <PatientInterventionPopUp show={true} item={singleLangItem} handleClose={jest.fn()} />
+      );
+      expect(screen.queryByRole('button', { name: 'DE' })).not.toBeInTheDocument();
+    });
+
+    it('calls apiClient.get with the correct path and params when switching language', async () => {
+      (apiClient.get as jest.Mock).mockResolvedValue({
+        data: [{ ...langItem, language: 'en', title: 'Test EN' }],
+      });
+      render(<PatientInterventionPopUp show={true} item={langItem} handleClose={jest.fn()} />);
+
+      fireEvent.click(screen.getByRole('button', { name: 'EN' }));
+
+      await waitFor(() => {
+        expect(apiClient.get).toHaveBeenCalledWith('interventions/all/', {
+          params: { external_id: 'ext-123', lang: 'en' },
+        });
+      });
+    });
+
+    it('updates the displayed title after a successful language switch', async () => {
+      (apiClient.get as jest.Mock).mockResolvedValue({
+        data: [{ ...langItem, language: 'en', title: 'English Title' }],
+      });
+      render(<PatientInterventionPopUp show={true} item={langItem} handleClose={jest.fn()} />);
+
+      fireEvent.click(screen.getByRole('button', { name: 'EN' }));
+
+      await waitFor(() => {
+        expect(screen.getByText('English Title')).toBeInTheDocument();
+      });
     });
   });
 });

--- a/frontend/src/components/PatientPage/PatientInterventionPopUp.tsx
+++ b/frontend/src/components/PatientPage/PatientInterventionPopUp.tsx
@@ -17,7 +17,7 @@ import apiClient from '@/api/client';
 import ErrorAlert from '@/components/common/ErrorAlert';
 import { translateText } from '@/utils/translate';
 import { isHttpUrl, matchesHost } from '@/utils/urlUtils';
-import { PlayableMedia } from '../common/PlayableMedia';
+import { PlayableMedia } from '@/components/common/PlayableMedia';
 import { generateTagColors, getTaxonomyTags } from '@/utils/interventions';
 import {
   getBadgeVariantFromIntervention,
@@ -245,7 +245,6 @@ const PatientInterventionPopUp: React.FC<Props> = ({ show, item, handleClose }) 
   const [titleLang, setTitleLang] = useState('');
 
   const [langOptions, setLangOptions] = useState<LangOpt[]>([]);
-  const [variantsByLang, setVariantsByLang] = useState<Record<string, any>>({});
   const [loadingLangs, setLoadingLangs] = useState(false);
 
   const [activeMediaIndex, setActiveMediaIndex] = useState<number>(0);
@@ -257,15 +256,9 @@ const PatientInterventionPopUp: React.FC<Props> = ({ show, item, handleClose }) 
     if (!show) {
       setLocalOverride(null);
       setLangOptions([]);
-      setVariantsByLang({});
       setError('');
     }
   }, [show]);
-
-  const toLangList = (x: any): string[] => {
-    if (Array.isArray(x)) return x.map((v) => String(v).trim().toLowerCase()).filter(Boolean);
-    return [];
-  };
 
   const preferredLang = useMemo(() => {
     const l = (i18n?.language || '').slice(0, 2).toLowerCase();
@@ -280,70 +273,36 @@ const PatientInterventionPopUp: React.FC<Props> = ({ show, item, handleClose }) 
     [effectiveItem?.language]
   );
 
-  // ✅ fetch variants by external_id (if available)
-  const fetchVariants = useCallback(async () => {
-    if (!show) return;
-
-    const externalId = norm(effectiveItem?.external_id);
-    const seeded = toLangList(effectiveItem?.available_languages);
-
-    const seedOpts: LangOpt[] = seeded.map((l) => ({ language: l, title: null }));
-    if (currentLang && !seeded.includes(currentLang))
-      seedOpts.unshift({ language: currentLang, title: null });
-    if (seedOpts.length) setLangOptions(seedOpts);
-
-    try {
-      setLoadingLangs(true);
-
-      if (externalId) {
-        // if your apiClient already prefixes /api, remove "/api" here
-        const res = await apiClient.get('/api/interventions/all/', {
-          params: { external_id: externalId },
-        });
-        const arr = Array.isArray(res.data)
-          ? res.data
-          : Array.isArray(res.data?.data)
-            ? res.data.data
-            : [];
-
-        const map: Record<string, any> = {};
-        const opts: LangOpt[] = [];
-
-        for (const v of arr) {
-          const l = String(v?.language || '')
-            .trim()
-            .toLowerCase();
-          if (!l) continue;
-          map[l] = v;
-          opts.push({ language: l, title: v?.title ?? null });
-        }
-
-        if (currentLang && !map[currentLang]) {
-          map[currentLang] = effectiveItem;
-          opts.push({ language: currentLang, title: effectiveItem?.title ?? null });
-        }
-
-        const uniqOpts = opts.reduce((acc: LangOpt[], cur) => {
-          const key = (cur.language || '').toLowerCase();
-          if (!key) return acc;
-          if (!acc.find((x) => (x.language || '').toLowerCase() === key)) acc.push(cur);
-          return acc;
-        }, []);
-
-        setVariantsByLang(map);
-        setLangOptions(uniqOpts.length ? uniqOpts : seedOpts);
-      }
-    } catch {
-      // keep seeded options
-    } finally {
-      setLoadingLangs(false);
-    }
-  }, [show, effectiveItem, currentLang]);
-
+  // populate language options from item.available_languages
   useEffect(() => {
     if (!show) return;
-    fetchVariants();
-  }, [show, fetchVariants]);
+    if (!effectiveItem) {
+      setLangOptions([]);
+      return;
+    }
+
+    const current = String(effectiveItem?.language || '')
+      .trim()
+      .toLowerCase();
+    const raw: string[] = Array.isArray(effectiveItem?.available_languages)
+      ? (effectiveItem.available_languages as unknown[])
+          .map((v) => String(v).trim().toLowerCase())
+          .filter(Boolean)
+      : [];
+    const opts: LangOpt[] = raw.map((l) => ({ language: l, title: null }));
+
+    const merged = [
+      ...(current ? [{ language: current, title: effectiveItem?.title ?? null }] : []),
+      ...opts,
+    ].reduce((acc: LangOpt[], cur) => {
+      const key = (cur.language || '').toLowerCase();
+      if (!key) return acc;
+      if (!acc.find((a) => (a.language || '').toLowerCase() === key)) acc.push(cur);
+      return acc;
+    }, []);
+
+    setLangOptions(merged);
+  }, [show, effectiveItem]);
 
   const sortedLangOptions = useMemo(() => {
     const score = (l: string) => {
@@ -368,17 +327,12 @@ const PatientInterventionPopUp: React.FC<Props> = ({ show, item, handleClose }) 
         .trim();
       if (!nextLang || nextLang === currentLang) return;
 
-      if (variantsByLang[nextLang]) {
-        setLocalOverride(variantsByLang[nextLang]);
-        return;
-      }
-
       const externalId = norm(effectiveItem?.external_id);
       if (!externalId) return;
 
       try {
         setLoadingLangs(true);
-        const res = await apiClient.get('/api/interventions/all/', {
+        const res = await apiClient.get('interventions/all/', {
           params: { external_id: externalId, lang: nextLang },
         });
 
@@ -395,7 +349,7 @@ const PatientInterventionPopUp: React.FC<Props> = ({ show, item, handleClose }) 
         setLoadingLangs(false);
       }
     },
-    [currentLang, variantsByLang, effectiveItem?.external_id, effectiveItem]
+    [currentLang, effectiveItem?.external_id]
   );
 
   // keep translations in sync with effectiveItem
@@ -603,7 +557,6 @@ const PatientInterventionPopUp: React.FC<Props> = ({ show, item, handleClose }) 
   const confirmClose = useCallback(() => {
     setError('');
     setLangOptions([]);
-    setVariantsByLang({});
     setLocalOverride(null);
     handleClose();
   }, [handleClose]);
@@ -666,7 +619,6 @@ const PatientInterventionPopUp: React.FC<Props> = ({ show, item, handleClose }) 
                         aria-pressed={active}
                       >
                         {optLang.toUpperCase()}
-                        {!active && optLang === preferredLang ? ' ★' : ''}
                       </Button>
                     );
                   })}


### PR DESCRIPTION
# Description

Fixed a double `/api/api/` URL bug causing language switching to fail in the rehab table, refactored the patient intervention popup's language-option logic to mirror the therapist popup (building from `available_languages` instead of an extra API call), and improved filter persistence by eliminating redundant sessionStorage parses and a brief key-missing window on reset.

## Related Issue
https://github.com/ARTORG-GERONTECHNOLOGY/Bearny-RehaAdvisor/issues/293

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Tests

1. Open an intervention in the rehab table
2. Verify all available language buttons appear
3. Switch languages
4. Confirm the content updates correctly

## Checklist

- [x] I have read the [contributing guidelines](/docs/12-CONTRIBUTING.md).
- [x] I have read the [code of conduct](/CODE_OF_CONDUCT.md).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
