### PR TITLE
fix: expose frontend sentry dsn to prod build

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -12,7 +12,8 @@ name: Production Deployment
 #   PROD_HOST            — SSH host for production server
 #   PROD_USERNAME        — SSH user
 #   PROD_SSH_KEY         — private SSH key (PEM)
-#   VITE_SENTRY_DSN      — baked into the frontend image at build time
+#   VITE_SENTRY_DSN      — baked into the frontend image at build time;
+#                          server .env.prod is too late for the static bundle
 #   SLACK_WEBHOOK_URL    — optional Slack notifications
 #   E2E_PATIENT_PASSWORD — Playwright E2E credentials (same as tests.yml)
 #   E2E_ADMIN_PASSWORD   — Playwright E2E credentials
@@ -20,7 +21,7 @@ name: Production Deployment
 #
 # GitHub Environment: "production"
 #   Recommended: add required reviewers so every release needs approval
-#   before the deploy job actually runs.
+#   before production image build/deploy jobs run.
 
 on:
   release:
@@ -292,6 +293,8 @@ jobs:
     timeout-minutes: 60
     needs: [test, frontend-e2e]
     if: always()
+    environment:
+      name: production
     permissions:
       contents: read
       packages: write
@@ -338,6 +341,15 @@ jobs:
             type=semver,pattern={{major}}.{{minor}},value=${{ steps.resolve-tag.outputs.tag }}
             type=raw,value=${{ steps.resolve-tag.outputs.image_tag }}
             type=raw,value=latest
+
+      - name: Verify frontend Sentry DSN is configured
+        env:
+          VITE_SENTRY_DSN: ${{ secrets.VITE_SENTRY_DSN }}
+        run: |
+          if [ -z "$VITE_SENTRY_DSN" ]; then
+            echo "::error::VITE_SENTRY_DSN is empty for the production build. The frontend reads this at Docker build time, so prod Sentry is disabled when this secret is missing or not visible to the build job."
+            exit 1
+          fi
 
       - name: Build and push frontend image
         uses: docker/build-push-action@v4


### PR DESCRIPTION
## Prerequisites

- [x] Tested that the bug appears on the current production version. Production `react-prod` image `0.7.2` was missing the frontend Sentry DSN in the static bundle.
- [x] Checked the relevant workflow and production secret setup.
- [x] Reproduction steps are documented below.
- [ ] Project files before/after are not relevant for this deployment workflow bug.

## Quick Summary

Production frontend Sentry logging was disabled because the frontend Docker build could not access the `VITE_SENTRY_DSN` production environment secret. Backend Sentry still worked because it reads `SENTRY_DSN` from `.env.prod` at runtime, while the frontend needs `VITE_SENTRY_DSN` at build time.

## Details

### Steps to Reproduce

1. Run the production deployment workflow before this fix.
2. Confirm `VITE_SENTRY_DSN` exists as a GitHub `production` environment secret.
3. Inspect the deployed `react-prod` static bundle.
4. Observe that the bundle does not contain the frontend Sentry DSN, so `initSentry()` returns early.

### Expected Behavior

The production frontend build receives `VITE_SENTRY_DSN`, bakes it into the Vite bundle, and browser-side Sentry logging works in production.

### Actual Behavior

The build job did not declare the `production` GitHub environment, so `${{ secrets.VITE_SENTRY_DSN }}` resolved empty during the frontend image build. The deployed bundle initialized with no DSN and frontend Sentry stayed disabled.

## Optional

### Possible Fix

Attach the build job to the `production` environment so it can access `VITE_SENTRY_DSN`, and add a fail-fast workflow step that errors if the frontend Sentry DSN is empty before building the Docker image.

### Additional Context

The workflow comments now clarify that server `.env.prod` is too late for Vite frontend configuration because the frontend is a static bundle.