### PR TITLE
305 fix: baseline window scans before discharge, not after

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 ## [Unreleased]
 
 ### Fixed
+- **COPAIN wearables sync always skipped**: the baseline monitoring window was `[reha_end, reha_end+4w]` for all projects. COPAIN collects Fitbit data during the in-hospital stay (before discharge), so every COPAIN patient got `no_fitbit_data_in_period` and REDCap remained empty. Fixed by introducing a per-project `baseline_anchor` config key: COPAIN now scans `[reha_end−4w, reha_end)`, COMPASS keeps `[reha_end, reha_end+4w)`.
 - **Fitbit Active Zone Minutes always wrong**: both the on-demand sync (`fitbit_sync.py`) and the nightly batch command (`fetch_fitbit_data.py`) looked for `activities-activeZoneMinutes` / `value.totalMinutes` in the Fitbit API response. The correct keys are `activities-active-zone-minutes` / `value.activeZoneMinutes`. As a result, AZM was silently dropped on every sync and `active_minutes` was always computed from the fallback (`minutesVeryActive + minutesFairlyActive`), producing values that did not match the Fitbit app.
 - **Sleep displayed as time-in-bed instead of actual sleep**: `_sleep_minutes()` in `fitbit_view.py` — and the inactivity calculation helpers in both sync files — used `sleep_duration` (total time in bed, ms) instead of `minutes_asleep` (actual sleep, matches Fitbit app). All three helpers now prefer `minutes_asleep`; fall back to `sleep_duration` for legacy records that lack `minutes_asleep`.
 

--- a/backend/core/services/wearables_redcap_service.py
+++ b/backend/core/services/wearables_redcap_service.py
@@ -42,11 +42,17 @@ _PROJECT_CONFIG: Dict[str, Dict[str, str]] = {
         "baseline": "visit_baseline_arm_1",
         "followup": "visit_6m_arm_1",
         "sleep_duration_format": "hours_int",
+        # Baseline data collected after discharge (outpatient rehab).
+        "baseline_anchor": "after_reha_end",
     },
     "COPAIN": {
         "baseline": "t0_at_disch_arm_1",
         "followup": "t2_six_months_afte_arm_1",
         "sleep_duration_format": "hhmm",
+        # Baseline data collected during the last weeks of the hospital stay,
+        # i.e. BEFORE discharge (reha_end_date). The window is
+        # [reha_end - BASELINE_WEEKS, reha_end).
+        "baseline_anchor": "before_reha_end",
     },
 }
 
@@ -183,14 +189,24 @@ def compute_wearables_summary(patient: Patient) -> Dict[str, Any]:
         )
 
     project_name = (patient.project or "").strip().upper()
-    sleep_fmt = _PROJECT_CONFIG.get(project_name, {}).get("sleep_duration_format", "hours_int")
+    proj_cfg = _PROJECT_CONFIG.get(project_name, {})
+    sleep_fmt = proj_cfg.get("sleep_duration_format", "hours_int")
 
     reha_end = _as_utc(patient.reha_end_date)
     study_end_raw = patient.study_end_date
     study_end = _as_utc(study_end_raw) if study_end_raw else reha_end + timedelta(weeks=26)
 
-    baseline_start = reha_end
-    baseline_end = reha_end + timedelta(weeks=BASELINE_WEEKS)
+    # baseline_anchor controls which side of reha_end_date to scan.
+    # "before_reha_end" — data collected before discharge (e.g. COPAIN in-hospital).
+    # "after_reha_end"  — data collected after discharge (default, e.g. COMPASS outpatient).
+    baseline_anchor = proj_cfg.get("baseline_anchor", "after_reha_end")
+    if baseline_anchor == "before_reha_end":
+        baseline_start = reha_end - timedelta(weeks=BASELINE_WEEKS)
+        baseline_end = reha_end
+    else:
+        baseline_start = reha_end
+        baseline_end = reha_end + timedelta(weeks=BASELINE_WEEKS)
+
     followup_start = study_end - timedelta(weeks=FOLLOWUP_WEEKS)
     followup_end = study_end
 

--- a/backend/tests/wearables_redcap/test_wearables_redcap_service.py
+++ b/backend/tests/wearables_redcap/test_wearables_redcap_service.py
@@ -382,6 +382,29 @@ class TestComputeWearablesSummary:
         summary = compute_wearables_summary(patient)
         assert summary["baseline"]["sleep_duration"] == "07:30"
 
+    def test_compass_baseline_window_is_after_reha_end(self):
+        """COMPASS baseline looks at the 4 weeks AFTER discharge, not before."""
+        reha_end = datetime(2024, 6, 1, tzinfo=dt_tz.utc)
+        user, patient = _make_patient(project="COMPASS", reha_end_date=reha_end)
+
+        # Data 10 days after discharge — inside the after-discharge window.
+        _make_fitbit_day(user, reha_end + timedelta(days=10), steps=7777, wear_min=500)
+
+        summary = compute_wearables_summary(patient)
+        assert summary["baseline"] is not None
+        assert summary["baseline"]["fitbit_steps"] == 7777
+
+    def test_compass_data_before_reha_end_not_in_baseline(self):
+        """Data collected before discharge must not appear in COMPASS baseline."""
+        reha_end = datetime(2024, 6, 1, tzinfo=dt_tz.utc)
+        user, patient = _make_patient(project="COMPASS", reha_end_date=reha_end)
+
+        # Data 2 days BEFORE discharge — outside the after-discharge window.
+        _make_fitbit_day(user, reha_end - timedelta(days=2), steps=9999, wear_min=600)
+
+        summary = compute_wearables_summary(patient)
+        assert summary["baseline"] is None
+
     def test_copain_baseline_window_is_before_reha_end(self):
         """COPAIN baseline looks at the 4 weeks BEFORE discharge, not after."""
         reha_end = datetime(2024, 6, 1, tzinfo=dt_tz.utc)

--- a/backend/tests/wearables_redcap/test_wearables_redcap_service.py
+++ b/backend/tests/wearables_redcap/test_wearables_redcap_service.py
@@ -372,14 +372,38 @@ class TestComputeWearablesSummary:
     def test_copain_sleep_in_hhmm(self):
         reha_end = datetime(2024, 1, 1, tzinfo=dt_tz.utc)
         user, patient = _make_patient(project="COPAIN", reha_end_date=reha_end)
+        # COPAIN baseline is BEFORE discharge: put data 2 days before reha_end.
         _make_fitbit_day(
             user,
-            reha_end + timedelta(days=2),
+            reha_end - timedelta(days=2),
             sleep_ms=int(7.5 * 3_600_000),
             wear_min=500,  # 7h30m
         )
         summary = compute_wearables_summary(patient)
         assert summary["baseline"]["sleep_duration"] == "07:30"
+
+    def test_copain_baseline_window_is_before_reha_end(self):
+        """COPAIN baseline looks at the 4 weeks BEFORE discharge, not after."""
+        reha_end = datetime(2024, 6, 1, tzinfo=dt_tz.utc)
+        user, patient = _make_patient(project="COPAIN", reha_end_date=reha_end)
+
+        # Data 10 days before discharge — inside the before-discharge window.
+        _make_fitbit_day(user, reha_end - timedelta(days=10), steps=5555, wear_min=500)
+
+        summary = compute_wearables_summary(patient)
+        assert summary["baseline"] is not None
+        assert summary["baseline"]["fitbit_steps"] == 5555
+
+    def test_copain_data_after_reha_end_not_in_baseline(self):
+        """Data collected after discharge must not appear in COPAIN baseline."""
+        reha_end = datetime(2024, 6, 1, tzinfo=dt_tz.utc)
+        user, patient = _make_patient(project="COPAIN", reha_end_date=reha_end)
+
+        # Data 2 days AFTER discharge — outside the before-discharge window.
+        _make_fitbit_day(user, reha_end + timedelta(days=2), steps=9999, wear_min=600)
+
+        summary = compute_wearables_summary(patient)
+        assert summary["baseline"] is None
 
     def test_dates_formatted_as_dmy(self):
         reha_end = datetime(2024, 3, 1, tzinfo=dt_tz.utc)
@@ -511,7 +535,7 @@ class TestExportWearablesToRedcap:
     def test_copain_sleep_format_in_payload(self, monkeypatch):
         reha_end = datetime(2024, 1, 1, tzinfo=dt_tz.utc)
         user, patient = _make_patient(project="COPAIN", reha_end_date=reha_end)
-        _make_fitbit_day(user, reha_end + timedelta(days=2), wear_min=600, sleep_ms=int(7.5 * 3_600_000))
+        _make_fitbit_day(user, reha_end - timedelta(days=2), wear_min=600, sleep_ms=int(7.5 * 3_600_000))
 
         monkeypatch.setenv("REDCAP_TOKEN_COPAIN", "tok")
         captured = []

--- a/docs/wearables_redcap_sync.md
+++ b/docs/wearables_redcap_sync.md
@@ -17,9 +17,15 @@ For each patient the pipeline:
 
 ## Period definitions
 
+The baseline window direction depends on the project's `baseline_anchor` setting:
+
+| Project | Baseline start | Baseline end | Rationale |
+|---|---|---|---|
+| **COMPASS** | `reha_end_date` | `reha_end_date + 4 weeks` | Outpatient rehab — data collected after discharge |
+| **COPAIN** | `reha_end_date − 4 weeks` | `reha_end_date` | In-hospital stay — data collected before discharge |
+
 | Period | Start | End |
 |---|---|---|
-| **Baseline** | `reha_end_date` | `reha_end_date + 4 weeks` |
 | **Follow-up** | `study_end_date − 4 weeks` | `study_end_date` |
 
 If `study_end_date` is not set, the system defaults to `reha_end_date + 26 weeks` (≈ 6 months).
@@ -239,9 +245,13 @@ sync_wearables_to_redcap_patient.delay("<patient_mongo_id>")
        "baseline": "baseline_event_arm_1",
        "followup":  "followup_event_arm_1",
        "sleep_duration_format": "hours_int",  # or "hhmm"
+       "baseline_anchor": "after_reha_end",   # or "before_reha_end"
    },
    ```
-2. Verify the `sleep_duration` field type in the REDCap data dictionary:
+2. Choose `baseline_anchor`:
+   - `"after_reha_end"` — monitoring starts at discharge (outpatient / home rehab)
+   - `"before_reha_end"` — monitoring is during the hospital stay (in-patient)
+3. Verify the `sleep_duration` field type in the REDCap data dictionary:
    - `text (integer, Max: 24)` → use `"hours_int"`
    - `text (time, Max: 23:59)` → use `"hhmm"`
-3. Add `REDCAP_TOKEN_NEWPROJECT=<token>` to the environment
+4. Add `REDCAP_TOKEN_NEWPROJECT=<token>` to the environment

--- a/frontend/e2e/therapist-wearables-sync.spec.ts
+++ b/frontend/e2e/therapist-wearables-sync.spec.ts
@@ -150,6 +150,68 @@ test.describe('Therapist patient popup wearables sync', () => {
     await expect(successAlert.getByText('wearables_complete')).toBeVisible();
   });
 
+  test('shows COPAIN baseline period result when sync succeeds', async ({ page }) => {
+    skipUnlessSeeded(test);
+
+    await page.route('**/users/*/profile', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          _id: '680000000000000000000002',
+          first_name: 'E2E',
+          name: 'Copain',
+          patient_code: 'P-E2E-002',
+          redcap_project: 'COPAIN',
+          redcap_identifier: 'P-E2E-002',
+        }),
+      });
+    });
+
+    await page.route('**/wearables/sync-to-redcap/*/', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          ok: true,
+          results: {
+            baseline: 'ok',
+            followup: 'skipped',
+          },
+          sent_payloads: {
+            baseline: {
+              status: 'sent',
+              record: {
+                record_id: '42',
+                monitoring_start: '15-05-2024',
+                monitoring_end: '21-05-2024',
+                monitoring_days: '7',
+                fitbit_steps: '4200',
+                sleep_duration: '07:30',
+                redcap_event_name: 't0_at_disch_arm_1',
+                wearables_complete: '1',
+              },
+            },
+            followup: {
+              status: 'skipped',
+              reason: 'no_fitbit_data_in_period',
+            },
+          },
+        }),
+      });
+    });
+
+    await openPatientPopup(page);
+    await page.getByRole('button', { name: /sync wearables/i }).click();
+
+    const successAlert = page
+      .locator('.alert-success')
+      .filter({ hasText: /wearables synced to redcap/i });
+    await expect(successAlert).toBeVisible({ timeout: 10000 });
+    await expect(successAlert.getByText('t0_at_disch_arm_1')).toBeVisible();
+    await expect(successAlert.getByText('07:30')).toBeVisible();
+  });
+
   test('shows backend error reason when sync fails', async ({ page }) => {
     skipUnlessSeeded(test);
 


### PR DESCRIPTION
## Summary

- COPAIN patients always got `no_fitbit_data_in_period` for both Baseline and Follow-up, leaving REDCap empty after every sync
- Root cause: the baseline window was `[reha_end, reha_end+4w]`, but COPAIN collects activity data *during* the hospital stay (before discharge), so all in-hospital Fitbit records fell outside the window
- Fix: adds a `baseline_anchor` key to the per-project config in `_PROJECT_CONFIG`:
  - `"before_reha_end"` → window is `[reha_end − 4w, reha_end)` (COPAIN, in-hospital)
  - `"after_reha_end"` → window is `[reha_end, reha_end + 4w)` (COMPASS, outpatient — unchanged default)
- COMPASS follow-up logic is unaffected

## Test plan

- [x] `docker exec django pytest tests/wearables_redcap/ -v` — 42/42 pass
- [x] Updated `test_copain_sleep_in_hhmm` to place test data before `reha_end`
- [x] Added `test_copain_baseline_window_is_before_reha_end` — data 10 days before discharge is found in baseline
- [x] Added `test_copain_data_after_reha_end_not_in_baseline` — data after discharge is NOT included
