### PR TITLE
311 fix fitbit patient view

### DIFF
--- a/backend/core/views/fitbit_sync.py
+++ b/backend/core/views/fitbit_sync.py
@@ -71,6 +71,189 @@ def get_valid_access_token(user):
 FETCH_COOLDOWN_MINUTES = 15
 
 
+def fetch_fitbit_date_range_for_user(user, start_date: datetime.date, end_date: datetime.date) -> int:
+    """Fetch Fitbit data for [start_date, end_date] inclusive and upsert into DB.
+
+    Used to backfill historical days that the background tasks missed (e.g. when
+    the patient's Fitbit data was synced to Fitbit's servers after the nightly
+    01:00 UTC run).  Does NOT skip already-present records — the caller is
+    responsible for only passing dates that have gaps.
+
+    Returns the number of days written.
+    """
+    token = FitbitUserToken.objects(user=user).first()
+    if not token:
+        logger.info("[fitbit_range] no token for user=%s, skip", user)
+        return 0
+
+    try:
+        access_token = get_valid_access_token(user)
+    except Exception:
+        logger.exception("[fitbit_range] token error for user=%s", user)
+        return 0
+
+    headers = {"Authorization": f"Bearer {access_token}"}
+    start_str = start_date.strftime("%Y-%m-%d")
+    end_str = end_date.strftime("%Y-%m-%d")
+    date_range = f"{start_str}/{end_str}"
+
+    series: dict[str, dict[datetime.date, object]] = {
+        "steps": {}, "floors": {}, "distance": {}, "calories": {},
+        "minutesVeryActive": {}, "minutesFairlyActive": {},
+        "activeZoneMinutes": {}, "resting_heart_rate": {}, "heart_rate_zones": {},
+    }
+    breathing_data: dict[datetime.date, object] = {}
+    hrv_data: dict[datetime.date, object] = {}
+    sleep_data: dict[datetime.date, dict] = {}
+    exercise_data: dict[datetime.date, list] = {}
+    azm_breakdown: dict[datetime.date, dict] = {}
+
+    def _fetch(key: str, url_suffix: str) -> None:
+        url = f"{FITBIT_API_URL}/{url_suffix}/date/{date_range}.json"
+        r = requests.get(url, headers=headers, timeout=15)
+        if r.status_code != 200:
+            logger.warning("[fitbit_range] %s HTTP %s for user=%s", key, r.status_code, user)
+            return
+        for item in r.json().get(f"activities-{key}", []):
+            dt = datetime.datetime.strptime(item["dateTime"], "%Y-%m-%d").date()
+            val = item.get("value")
+            try:
+                val = int(float(val)) if isinstance(val, str) else val
+            except Exception:
+                val = 0
+            series[key][dt] = val
+
+    _fetch("steps", "activities/steps")
+    _fetch("floors", "activities/floors")
+    _fetch("distance", "activities/distance")
+    _fetch("calories", "activities/calories")
+    _fetch("minutesVeryActive", "activities/minutesVeryActive")
+    _fetch("minutesFairlyActive", "activities/minutesFairlyActive")
+
+    # Heart rate (resting + zones)
+    r = requests.get(f"{FITBIT_API_URL}/activities/heart/date/{date_range}.json", headers=headers, timeout=15)
+    if r.status_code == 200:
+        for item in r.json().get("activities-heart", []):
+            dt = datetime.datetime.strptime(item["dateTime"], "%Y-%m-%d").date()
+            val = item.get("value", {})
+            series["resting_heart_rate"][dt] = val.get("restingHeartRate")
+            series["heart_rate_zones"][dt] = val.get("heartRateZones")
+
+    # Active Zone Minutes
+    r = requests.get(f"{FITBIT_API_URL}/activities/active-zone-minutes/date/{date_range}.json", headers=headers, timeout=15)
+    if r.status_code == 200:
+        for item in r.json().get("activities-active-zone-minutes", []):
+            dt = datetime.datetime.strptime(item["dateTime"], "%Y-%m-%d").date()
+            val = item.get("value") or {}
+            total = val.get("activeZoneMinutes")
+            if val:
+                azm_breakdown[dt] = {
+                    "fat_burn": val.get("fatBurnActiveZoneMinutes"),
+                    "cardio": val.get("cardioActiveZoneMinutes"),
+                    "peak": val.get("peakActiveZoneMinutes"),
+                    "total": total,
+                }
+            if total is not None:
+                series["activeZoneMinutes"][dt] = int(total)
+
+    # Breathing rate
+    r = requests.get(f"{FITBIT_API_URL}/br/date/{date_range}.json", headers=headers, timeout=15)
+    if r.status_code == 200:
+        for item in r.json().get("br", []):
+            dt = datetime.datetime.strptime(item["dateTime"], "%Y-%m-%d").date()
+            breathing_data[dt] = item.get("value")
+
+    # HRV
+    r = requests.get(f"{FITBIT_API_URL}/hrv/date/{date_range}.json", headers=headers, timeout=15)
+    if r.status_code == 200:
+        for item in r.json().get("hrv", []):
+            dt = datetime.datetime.strptime(item["dateTime"], "%Y-%m-%d").date()
+            hrv_data[dt] = item.get("value")
+
+    # Sleep
+    r = requests.get(f"{FITBIT_API_URL}/sleep/date/{date_range}.json", headers=headers, timeout=20)
+    if r.status_code == 200:
+        for entry in r.json().get("sleep", []):
+            dt = datetime.datetime.strptime(entry["dateOfSleep"], "%Y-%m-%d").date()
+            sleep_data[dt] = {
+                "sleep_duration": entry.get("duration"),
+                "minutes_asleep": entry.get("minutesAsleep"),
+                "sleep_start": entry.get("startTime"),
+                "sleep_end": entry.get("endTime"),
+                "awakenings": entry.get("awakeningsCount"),
+            }
+
+    # Exercise sessions
+    r = requests.get(
+        f"{FITBIT_API_URL}/activities/list.json?afterDate={start_str}&sort=asc&limit=200&offset=0",
+        headers=headers,
+        timeout=20,
+    )
+    if r.status_code == 200:
+        for act in r.json().get("activities", []):
+            dt = datetime.datetime.strptime(act["startTime"].split("T")[0], "%Y-%m-%d").date()
+            if start_date <= dt <= end_date:
+                exercise_data.setdefault(dt, []).append({
+                    "name": act.get("activityName"),
+                    "duration": act.get("duration"),
+                    "calories": act.get("calories"),
+                })
+
+    # Collect all dates with any data
+    all_dates: set[datetime.date] = set()
+    for m in series.values():
+        if isinstance(m, dict):
+            all_dates |= set(m.keys())
+    all_dates |= set(sleep_data.keys()) | set(exercise_data.keys())
+
+    upserted = 0
+    for dt in sorted(d for d in all_dates if start_date <= d <= end_date):
+        azm = series["activeZoneMinutes"].get(dt)
+        if azm is not None:
+            active_minutes = int(azm)
+        else:
+            va = int(series["minutesVeryActive"].get(dt, 0) or 0)
+            fa = int(series["minutesFairlyActive"].get(dt, 0) or 0)
+            active_minutes = va + fa
+
+        sm = sleep_data.get(dt) or {}
+        val = sm.get("minutes_asleep")
+        if val is not None:
+            try:
+                sleep_min = max(0, int(val))
+            except Exception:
+                sleep_min = 0
+        else:
+            dur_ms = sm.get("sleep_duration") or 0
+            try:
+                sleep_min = max(0, int(round(dur_ms / 60000)))
+            except Exception:
+                sleep_min = 0
+
+        inactivity = max(0, 1440 - (active_minutes + sleep_min))
+
+        FitbitData.objects(user=user, date=dt).update_one(
+            set__steps=series["steps"].get(dt),
+            set__floors=series["floors"].get(dt),
+            set__distance=series["distance"].get(dt),
+            set__calories=series["calories"].get(dt),
+            set__resting_heart_rate=series["resting_heart_rate"].get(dt),
+            set__active_minutes=active_minutes,
+            set__active_zone_minutes=azm_breakdown.get(dt),
+            set__inactivity_minutes=inactivity,
+            set__heart_rate_zones=series["heart_rate_zones"].get(dt),
+            set__sleep=sleep_data.get(dt),
+            set__breathing_rate=breathing_data.get(dt),
+            set__hrv=hrv_data.get(dt),
+            set__exercise=exercise_data.get(dt, []),
+            upsert=True,
+        )
+        upserted += 1
+
+    logger.info("[fitbit_range] backfilled %d days for user=%s (%s → %s)", upserted, user, start_str, end_str)
+    return upserted
+
+
 def fetch_fitbit_today_for_user(user, bypass_cooldown: bool = False) -> int:
     """Fetch **today only** for a single user; returns upserted day-count (0|1)."""
     today = datetime.date.today()

--- a/backend/core/views/fitbit_sync.py
+++ b/backend/core/views/fitbit_sync.py
@@ -98,9 +98,15 @@ def fetch_fitbit_date_range_for_user(user, start_date: datetime.date, end_date: 
     date_range = f"{start_str}/{end_str}"
 
     series: dict[str, dict[datetime.date, object]] = {
-        "steps": {}, "floors": {}, "distance": {}, "calories": {},
-        "minutesVeryActive": {}, "minutesFairlyActive": {},
-        "activeZoneMinutes": {}, "resting_heart_rate": {}, "heart_rate_zones": {},
+        "steps": {},
+        "floors": {},
+        "distance": {},
+        "calories": {},
+        "minutesVeryActive": {},
+        "minutesFairlyActive": {},
+        "activeZoneMinutes": {},
+        "resting_heart_rate": {},
+        "heart_rate_zones": {},
     }
     breathing_data: dict[datetime.date, object] = {}
     hrv_data: dict[datetime.date, object] = {}
@@ -140,7 +146,9 @@ def fetch_fitbit_date_range_for_user(user, start_date: datetime.date, end_date: 
             series["heart_rate_zones"][dt] = val.get("heartRateZones")
 
     # Active Zone Minutes
-    r = requests.get(f"{FITBIT_API_URL}/activities/active-zone-minutes/date/{date_range}.json", headers=headers, timeout=15)
+    r = requests.get(
+        f"{FITBIT_API_URL}/activities/active-zone-minutes/date/{date_range}.json", headers=headers, timeout=15
+    )
     if r.status_code == 200:
         for item in r.json().get("activities-active-zone-minutes", []):
             dt = datetime.datetime.strptime(item["dateTime"], "%Y-%m-%d").date()
@@ -193,11 +201,13 @@ def fetch_fitbit_date_range_for_user(user, start_date: datetime.date, end_date: 
         for act in r.json().get("activities", []):
             dt = datetime.datetime.strptime(act["startTime"].split("T")[0], "%Y-%m-%d").date()
             if start_date <= dt <= end_date:
-                exercise_data.setdefault(dt, []).append({
-                    "name": act.get("activityName"),
-                    "duration": act.get("duration"),
-                    "calories": act.get("calories"),
-                })
+                exercise_data.setdefault(dt, []).append(
+                    {
+                        "name": act.get("activityName"),
+                        "duration": act.get("duration"),
+                        "calories": act.get("calories"),
+                    }
+                )
 
     # Collect all dates with any data
     all_dates: set[datetime.date] = set()

--- a/backend/core/views/fitbit_view.py
+++ b/backend/core/views/fitbit_view.py
@@ -17,7 +17,9 @@ from core.models import FitbitData, FitbitUserToken, Patient, User
 logger = logging.getLogger(__name__)
 FITBIT_API_URL = "https://api.fitbit.com/1/user/-"
 
-from core.views.fitbit_sync import fetch_fitbit_today_for_user
+import datetime as _dt
+
+from core.views.fitbit_sync import fetch_fitbit_date_range_for_user, fetch_fitbit_today_for_user
 
 
 def _sleep_minutes(entry: FitbitData) -> int:
@@ -135,6 +137,38 @@ def fitbit_summary(request, patient_id=None):
         start = (end - timedelta(days=days - 1)).replace(hour=0, minute=0, second=0, microsecond=0)
 
         qs = FitbitData.objects(user=patient.userId, date__gte=start, date__lte=end).order_by("date")
+
+        # Backfill any historical days missing from the DB.
+        # The background 4-hour task only syncs *today*, and the nightly 30-day
+        # task runs at 01:00 UTC.  If the patient synced their Fitbit device after
+        # 01:00 UTC, those days won't be in the DB until the next nightly run.
+        # We detect gaps here and fill them synchronously so the patient sees
+        # their data immediately.
+        try:
+            today_date = timezone.now().date()
+            yesterday_date = today_date - _dt.timedelta(days=1)
+            window_start_date = start.date()
+
+            if window_start_date <= yesterday_date:
+                existing_dates = set()
+                for _d in qs:
+                    try:
+                        existing_dates.add(_d.date.date())
+                    except Exception:
+                        existing_dates.add(_d.date)
+
+                missing_dates = set()
+                cur = window_start_date
+                while cur <= yesterday_date:
+                    if cur not in existing_dates:
+                        missing_dates.add(cur)
+                    cur += _dt.timedelta(days=1)
+
+                if missing_dates:
+                    fetch_fitbit_date_range_for_user(user, min(missing_dates), max(missing_dates))
+                    qs = FitbitData.objects(user=patient.userId, date__gte=start, date__lte=end).order_by("date")
+        except Exception:
+            logger.exception("[fitbit_summary] backfill check failed for user=%s", user)
 
         # -----------------------------
         # Pull patient vitals (BP) for range

--- a/backend/tests/fitbit_views/test_fitbit_views.py
+++ b/backend/tests/fitbit_views/test_fitbit_views.py
@@ -727,3 +727,48 @@ def test_sleep_minutes_falls_back_to_duration_when_minutes_asleep_absent():
         sleep=SleepData(sleep_duration=90 * 60 * 1000),  # 90 min in bed, no minutes_asleep
     )
     assert _sleep_minutes(row) == 90
+
+
+# ---------------------------------------------------------------------------
+# Backfill missing historical days on fitbit_summary
+# ---------------------------------------------------------------------------
+
+
+@patch("core.views.fitbit_view.fetch_fitbit_today_for_user")
+@patch("core.views.fitbit_view.fetch_fitbit_date_range_for_user")
+def test_fitbit_summary_triggers_backfill_for_missing_days(mock_backfill, mock_today_fetch):
+    """When historical days are absent from the DB, fitbit_summary triggers a range backfill."""
+    _, _, patient_user, patient = create_patient_graph()
+
+    # Only today has data — yesterday and earlier are missing
+    today_dt = datetime.now().replace(hour=12, minute=0, second=0, microsecond=0)
+    FitbitData(user=patient_user, date=today_dt, steps=5000).save()
+
+    mock_backfill.return_value = 2
+
+    resp = client.get(f"/api/fitbit/summary/{patient.id}/?days=7", HTTP_AUTHORIZATION="Bearer test")
+    assert resp.status_code == 200
+    # Backfill must have been invoked for the gap (yesterday and earlier)
+    mock_backfill.assert_called_once()
+    call_args = mock_backfill.call_args[0]  # positional: (user, start_date, end_date)
+    assert len(call_args) == 3
+
+
+@patch("core.views.fitbit_view.fetch_fitbit_today_for_user")
+@patch("core.views.fitbit_view.fetch_fitbit_date_range_for_user")
+def test_fitbit_summary_skips_backfill_when_no_gaps(mock_backfill, mock_today_fetch):
+    """When all days in the window have data, the range backfill is not triggered."""
+    _, _, patient_user, patient = create_patient_graph()
+    now = datetime.now()
+
+    # Insert FitbitData for all 7 days
+    for offset in range(7):
+        day = now.replace(hour=0, minute=0, second=0, microsecond=0)
+        from datetime import timedelta as _td
+
+        day = day - _td(days=offset)
+        FitbitData(user=patient_user, date=day, steps=1000 + offset).save()
+
+    resp = client.get(f"/api/fitbit/summary/{patient.id}/?days=7", HTTP_AUTHORIZATION="Bearer test")
+    assert resp.status_code == 200
+    mock_backfill.assert_not_called()


### PR DESCRIPTION
# Description

Root cause: fitbit_summary (the patient view endpoint) calls fetch_fitbit_today_for_user which only syncs the current day. If a patient syncs their Fitbit device after the nightly 01:00 UTC backfill runs (e.g. opens the Fitbit app at 08:00 AM), those historical days are never stored in the DB until the following night. The therapist view uses health_combined_history which queries the DB directly — once the nightly cron eventually runs, the therapist sees the data but the patient had already given up.

Fix — three files changed:

[fitbit_sync.py](vscode-webview://01s0e8cn5tnjldvcuuc83jqd8doji1p4aqm55jv1cnaq876q8qmk/backend/core/views/fitbit_sync.py) — new fetch_fitbit_date_range_for_user(user, start_date, end_date) function that fetches all standard Fitbit series (steps, sleep, HR, AZM, breathing rate, HRV, exercise) for an arbitrary date range using batched API calls (one call per metric type, not one per day).

[fitbit_view.py](vscode-webview://01s0e8cn5tnjldvcuuc83jqd8doji1p4aqm55jv1cnaq876q8qmk/backend/core/views/fitbit_view.py) — fitbit_summary now detects gaps after the initial DB query. If any days in the requested window (yesterday and earlier) are missing, it calls fetch_fitbit_date_range_for_user synchronously before building the response. Wrapped in try/except so a backfill failure never breaks the response.





## Related Issue
[IssueName](IssueLink)

## Type of change

For a new feature, please create an issue first to discuss it with us before submitting a pull request.

- [x] Bug fix (non-breaking change that fixes an issue)

## Tests

[test_fitbit_views.py](vscode-webview://01s0e8cn5tnjldvcuuc83jqd8doji1p4aqm55jv1cnaq876q8qmk/backend/tests/fitbit_views/test_fitbit_views.py) — two new tests confirming backfill is triggered when gaps exist and skipped when all days have data (59 tests pass).Root cause: fitbit_summary (the patient view endpoint) calls fetch_fitbit_today_for_user which only syncs the current day. If a patient syncs their Fitbit device after the nightly 01:00 UTC backfill runs (e.g. opens the Fitbit app at 08:00 AM), those historical days are never stored in the DB until the following night. The therapist view uses health_combined_history which queries the DB directly — once the nightly cron eventually runs, the therapist sees the data but the patient had already given up.

## Checklist

- [x] I have read the [contributing guidelines](/docs/12-CONTRIBUTING.md).
- [x] I have read the [code of conduct](/CODE_OF_CONDUCT.md).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
