### PR TITLE
312 feature hide floors distance travelled hr variability from health page

### DIFF
--- a/frontend/src/__tests__/HealthChartsAccordion.test.tsx
+++ b/frontend/src/__tests__/HealthChartsAccordion.test.tsx
@@ -26,10 +26,10 @@ jest.mock('@/components/Health/charts/BloodPressureChart', () =>
 jest.mock('@/components/Health/charts/ExerciseSessionsChart', () =>
   React.forwardRef(() => <div data-testid="chart-exercise" />)
 );
-jest.mock('@/components/Health//charts/ExerciseSessionsTable', () => () => (
+jest.mock('@/components/Health/charts/ExerciseSessionsTable', () => () => (
   <div data-testid="table-exercise" />
 ));
-jest.mock('@/components/Health//QuestionnaireResultsTable', () => () => (
+jest.mock('@/components/Health/QuestionnaireResultsTable', () => () => (
   <div data-testid="table-questionnaire" />
 ));
 

--- a/frontend/src/__tests__/HealthChartsAccordion.test.tsx
+++ b/frontend/src/__tests__/HealthChartsAccordion.test.tsx
@@ -106,16 +106,7 @@ describe('HealthChartsAccordion – accordion headers', () => {
 describe('HealthChartsAccordion – device-hint messages', () => {
   const fitbitBase: FitbitEntry = {
     date: '2024-01-10',
-    resting_heart_rate: null,
-    wear_time_minutes: null,
     steps: 5000,
-    breathing_rate: null,
-    hr_zones: null,
-    sleep: null,
-    weight: null,
-    systolic_bp: null,
-    diastolic_bp: null,
-    exercise_sessions: [],
   };
 
   it('shows resting-HR hint when all Fitbit entries lack resting_heart_rate', () => {

--- a/frontend/src/__tests__/HealthChartsAccordion.test.tsx
+++ b/frontend/src/__tests__/HealthChartsAccordion.test.tsx
@@ -1,0 +1,146 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+// ── Chart sub-components use d3/SVG – replace with testid stubs ───────────────
+jest.mock('@/components/Health/charts/AdherenceLine', () =>
+  React.forwardRef(() => <div data-testid="chart-adherence" />)
+);
+jest.mock('@/components/Health/charts/MetricBarOrBox', () =>
+  React.forwardRef(({ titleKey }: { titleKey: string }) => (
+    <div data-testid={`chart-metric-${titleKey}`} />
+  ))
+);
+jest.mock('@/components/Health/charts/SleepChart', () =>
+  React.forwardRef(() => <div data-testid="chart-sleep" />)
+);
+jest.mock('@/components/Health/charts/HRZonesStacked', () =>
+  React.forwardRef(() => <div data-testid="chart-hrzones" />)
+);
+jest.mock('@/components/Health/charts/WeightChart', () =>
+  React.forwardRef(() => <div data-testid="chart-weight" />)
+);
+jest.mock('@/components/Health/charts/BloodPressureChart', () =>
+  React.forwardRef(() => <div data-testid="chart-bloodpressure" />)
+);
+jest.mock('@/components/Health/charts/ExerciseSessionsChart', () =>
+  React.forwardRef(() => <div data-testid="chart-exercise" />)
+);
+jest.mock('@/components/Health//charts/ExerciseSessionsTable', () => () => (
+  <div data-testid="table-exercise" />
+));
+jest.mock('@/components/Health//QuestionnaireResultsTable', () => () => (
+  <div data-testid="table-questionnaire" />
+));
+
+import HealthChartsAccordion from '@/components/Health/HealthChartsAccordion';
+import type { HealthPageStore } from '@/stores/healthPageStore';
+import type { FitbitEntry } from '@/types/health';
+
+// ── minimal store stub ────────────────────────────────────────────────────────
+const makeStore = (overrides: Partial<HealthPageStore> = {}): HealthPageStore =>
+  ({
+    fitbitData: [] as FitbitEntry[],
+    questionnaireData: [],
+    adherenceData: [],
+    chartRes: 'daily',
+    startDate: new Date('2024-01-08'),
+    endDate: new Date('2024-01-15'),
+    ...overrides,
+  }) as unknown as HealthPageStore;
+
+const t = (key: string) => key;
+
+// SVG ref stubs
+const svgRefs = {
+  adherence: React.createRef<SVGSVGElement>(),
+  restingHR: React.createRef<SVGSVGElement>(),
+  sleep: React.createRef<SVGSVGElement>(),
+  wearTime: React.createRef<SVGSVGElement>(),
+  hrZones: React.createRef<SVGSVGElement>(),
+  steps: React.createRef<SVGSVGElement>(),
+  breathing: React.createRef<SVGSVGElement>(),
+  weight: React.createRef<SVGSVGElement>(),
+  bloodPressure: React.createRef<SVGSVGElement>(),
+  exercise: React.createRef<SVGSVGElement>(),
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('HealthChartsAccordion – accordion headers', () => {
+  const expectedHeaders = [
+    'Adherence',
+    'Questionnaire Results By Date',
+    'Resting HR',
+    'Sleep',
+    'Wear Time',
+    'HR Zones',
+    'Steps',
+    'Breathing',
+    'WeightLabel',
+    'Blood pressure',
+    'Exercises',
+  ];
+
+  it('renders all 11 accordion section headers', () => {
+    render(<HealthChartsAccordion store={makeStore()} t={t} lang="en" svgRefs={svgRefs} />);
+
+    expectedHeaders.forEach((header) => {
+      expect(screen.getByText(header)).toBeInTheDocument();
+    });
+  });
+
+  it.each(expectedHeaders)('displays the "%s" accordion header', (header) => {
+    render(<HealthChartsAccordion store={makeStore()} t={t} lang="en" svgRefs={svgRefs} />);
+    expect(screen.getByText(header)).toBeInTheDocument();
+  });
+
+  it('renders exactly 11 accordion items', () => {
+    render(<HealthChartsAccordion store={makeStore()} t={t} lang="en" svgRefs={svgRefs} />);
+    // Each Accordion.Item renders a button for its header
+    const buttons = screen.getAllByRole('button');
+    expect(buttons).toHaveLength(11);
+  });
+});
+
+describe('HealthChartsAccordion – device-hint messages', () => {
+  const fitbitBase: FitbitEntry = {
+    date: '2024-01-10',
+    resting_heart_rate: null,
+    wear_time_minutes: null,
+    steps: 5000,
+    breathing_rate: null,
+    hr_zones: null,
+    sleep: null,
+    weight: null,
+    systolic_bp: null,
+    diastolic_bp: null,
+    exercise_sessions: [],
+  };
+
+  it('shows resting-HR hint when all Fitbit entries lack resting_heart_rate', () => {
+    const store = makeStore({ fitbitData: [fitbitBase] as FitbitEntry[] });
+    render(<HealthChartsAccordion store={store} t={t} lang="en" svgRefs={svgRefs} />);
+    expect(screen.getByText('hint_resting_hr_empty')).toBeInTheDocument();
+  });
+
+  it('shows wear-time hint when all Fitbit entries lack wear_time_minutes', () => {
+    const store = makeStore({ fitbitData: [fitbitBase] as FitbitEntry[] });
+    render(<HealthChartsAccordion store={store} t={t} lang="en" svgRefs={svgRefs} />);
+    expect(screen.getByText('hint_wear_time_empty')).toBeInTheDocument();
+  });
+
+  it('shows breathing-rate hint when all Fitbit entries lack breathing_rate', () => {
+    const store = makeStore({ fitbitData: [fitbitBase] as FitbitEntry[] });
+    render(<HealthChartsAccordion store={store} t={t} lang="en" svgRefs={svgRefs} />);
+    expect(screen.getByText('hint_breathing_rate_empty')).toBeInTheDocument();
+  });
+
+  it('does not show hints when Fitbit data is absent (no entries at all)', () => {
+    const store = makeStore({ fitbitData: [] });
+    render(<HealthChartsAccordion store={store} t={t} lang="en" svgRefs={svgRefs} />);
+    expect(screen.queryByText('hint_resting_hr_empty')).not.toBeInTheDocument();
+    expect(screen.queryByText('hint_wear_time_empty')).not.toBeInTheDocument();
+    expect(screen.queryByText('hint_breathing_rate_empty')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/Health/ExportModal.tsx
+++ b/frontend/src/components/Health/ExportModal.tsx
@@ -51,6 +51,7 @@ const ExportModal: React.FC<Props> = ({
     'hrZones',
     'steps',
     'breathing',
+    'wearTime',
     'weight',
     'bloodPressure',
     'exercise',

--- a/frontend/src/components/Health/ExportModal.tsx
+++ b/frontend/src/components/Health/ExportModal.tsx
@@ -43,6 +43,7 @@ const ExportModal: React.FC<Props> = ({
   }, [show, initialFrom, initialTo, selections]);
 
   const ids = [
+    'adherence',
     'totalScore',
     'questionnaire',
     'restingHR',
@@ -50,6 +51,9 @@ const ExportModal: React.FC<Props> = ({
     'hrZones',
     'steps',
     'breathing',
+    'weight',
+    'bloodPressure',
+    'exercise',
   ];
 
   const allSelected = Object.values(chosen).every(Boolean);

--- a/frontend/src/components/Health/ExportModal.tsx
+++ b/frontend/src/components/Health/ExportModal.tsx
@@ -48,11 +48,8 @@ const ExportModal: React.FC<Props> = ({
     'restingHR',
     'sleep',
     'hrZones',
-    'floors',
     'steps',
-    'distance',
     'breathing',
-    'hrv',
   ];
 
   const allSelected = Object.values(chosen).every(Boolean);

--- a/frontend/src/components/Health/HealthChartsAccordion.tsx
+++ b/frontend/src/components/Health/HealthChartsAccordion.tsx
@@ -1,17 +1,17 @@
 import React from 'react';
 import { observer } from 'mobx-react-lite';
 import { Accordion, Col, Row } from 'react-bootstrap';
-import type { HealthPageStore } from '../../stores/healthPageStore';
+import type { HealthPageStore } from '@/stores/healthPageStore';
 
-import MetricBarOrBox from './charts/MetricBarOrBox';
-import SleepChart from './charts/SleepChart';
-import HRZonesStacked from './charts/HRZonesStacked';
-import AdherenceLine from './charts/AdherenceLine';
-import WeightChart from './charts/WeightChart';
-import BloodPressureChart from './charts/BloodPressureChart';
-import ExerciseSessionsChart from './charts/ExerciseSessionsChart';
-import ExerciseSessionsTable from './charts/ExerciseSessionsTable';
-import QuestionnaireResultsTable from './QuestionnaireResultsTable';
+import MetricBarOrBox from '@/components/Health/charts/MetricBarOrBox';
+import SleepChart from '@/components/Health//charts/SleepChart';
+import HRZonesStacked from '@/components/Health//charts/HRZonesStacked';
+import AdherenceLine from '@/components/Health//charts/AdherenceLine';
+import WeightChart from '@/components/Health//charts/WeightChart';
+import BloodPressureChart from '@/components/Health//charts/BloodPressureChart';
+import ExerciseSessionsChart from '@/components/Health//charts/ExerciseSessionsChart';
+import ExerciseSessionsTable from '@/components/Health//charts/ExerciseSessionsTable';
+import QuestionnaireResultsTable from '@/components/Health//QuestionnaireResultsTable';
 
 type SvgRefs = {
   adherence: React.RefObject<SVGSVGElement>;
@@ -19,11 +19,8 @@ type SvgRefs = {
   sleep: React.RefObject<SVGSVGElement>;
   wearTime: React.RefObject<SVGSVGElement>;
   hrZones: React.RefObject<SVGSVGElement>;
-  floors: React.RefObject<SVGSVGElement>;
   steps: React.RefObject<SVGSVGElement>;
-  distance: React.RefObject<SVGSVGElement>;
   breathing: React.RefObject<SVGSVGElement>;
-  hrv: React.RefObject<SVGSVGElement>;
   weight: React.RefObject<SVGSVGElement>;
   bloodPressure: React.RefObject<SVGSVGElement>;
   exercise: React.RefObject<SVGSVGElement>;
@@ -48,7 +45,6 @@ const HealthChartsAccordion: React.FC<Props> = observer(({ store, t, lang, svgRe
   const wearTimeEmpty = hasAnyFitbit && store.fitbitData.every((d) => d.wear_time_minutes == null);
   const breathingEmpty =
     hasAnyFitbit && store.fitbitData.every((d) => d.breathing_rate?.breathingRate == null);
-  const hrvEmpty = hasAnyFitbit && store.fitbitData.every((d) => d.hrv?.dailyRmssd == null);
 
   return (
     <Accordion defaultActiveKey={['0']} alwaysOpen className="shadow-sm">
@@ -80,7 +76,7 @@ const HealthChartsAccordion: React.FC<Props> = observer(({ store, t, lang, svgRe
         </Accordion.Body>
       </Accordion.Item>
 
-      <Accordion.Item eventKey="3">
+      <Accordion.Item eventKey="2">
         <Accordion.Header>{t('Resting HR')}</Accordion.Header>
         <Accordion.Body className="p-2 p-md-3">
           <div className="d-flex justify-content-center">
@@ -100,7 +96,7 @@ const HealthChartsAccordion: React.FC<Props> = observer(({ store, t, lang, svgRe
         </Accordion.Body>
       </Accordion.Item>
 
-      <Accordion.Item eventKey="4">
+      <Accordion.Item eventKey="3">
         <Accordion.Header>{t('Sleep')}</Accordion.Header>
         <Accordion.Body className="p-2 p-md-3">
           <div className="d-flex justify-content-center">
@@ -109,7 +105,7 @@ const HealthChartsAccordion: React.FC<Props> = observer(({ store, t, lang, svgRe
         </Accordion.Body>
       </Accordion.Item>
 
-      <Accordion.Item eventKey="4b">
+      <Accordion.Item eventKey="4">
         <Accordion.Header>{t('Wear Time')}</Accordion.Header>
         <Accordion.Body className="p-2 p-md-3">
           <div className="d-flex justify-content-center">
@@ -139,23 +135,6 @@ const HealthChartsAccordion: React.FC<Props> = observer(({ store, t, lang, svgRe
       </Accordion.Item>
 
       <Accordion.Item eventKey="6">
-        <Accordion.Header>{t('Floors')}</Accordion.Header>
-        <Accordion.Body className="p-2 p-md-3">
-          <div className="d-flex justify-content-center">
-            <MetricBarOrBox
-              ref={svgRefs.floors}
-              titleKey="Floors Climbed"
-              data={store.fitbitData}
-              accessor={(d) => d.floors}
-              res={store.chartRes}
-              start={start}
-              end={end}
-            />
-          </div>
-        </Accordion.Body>
-      </Accordion.Item>
-
-      <Accordion.Item eventKey="7">
         <Accordion.Header>{t('Steps')}</Accordion.Header>
         <Accordion.Body className="p-2 p-md-3">
           <div className="d-flex justify-content-center">
@@ -172,24 +151,7 @@ const HealthChartsAccordion: React.FC<Props> = observer(({ store, t, lang, svgRe
         </Accordion.Body>
       </Accordion.Item>
 
-      <Accordion.Item eventKey="8">
-        <Accordion.Header>{t('Distance')}</Accordion.Header>
-        <Accordion.Body className="p-2 p-md-3">
-          <div className="d-flex justify-content-center">
-            <MetricBarOrBox
-              ref={svgRefs.distance}
-              titleKey="Distance Traveled (km)"
-              data={store.fitbitData}
-              accessor={(d) => d.distance}
-              res={store.chartRes}
-              start={start}
-              end={end}
-            />
-          </div>
-        </Accordion.Body>
-      </Accordion.Item>
-
-      <Accordion.Item eventKey="9">
+      <Accordion.Item eventKey="7">
         <Accordion.Header>{t('Breathing')}</Accordion.Header>
         <Accordion.Body className="p-2 p-md-3">
           <div className="d-flex justify-content-center">
@@ -209,25 +171,7 @@ const HealthChartsAccordion: React.FC<Props> = observer(({ store, t, lang, svgRe
         </Accordion.Body>
       </Accordion.Item>
 
-      <Accordion.Item eventKey="10">
-        <Accordion.Header>{t('HRV')}</Accordion.Header>
-        <Accordion.Body className="p-2 p-md-3">
-          <div className="d-flex justify-content-center">
-            <MetricBarOrBox
-              ref={svgRefs.hrv}
-              titleKey="Heart Rate Variability (dailyRmssd in ms)"
-              data={store.fitbitData}
-              accessor={(d) => d.hrv?.dailyRmssd}
-              res={store.chartRes}
-              start={start}
-              end={end}
-            />
-          </div>
-          {hrvEmpty && <p className="text-muted small text-center mt-1">{t('hint_hrv_empty')}</p>}
-        </Accordion.Body>
-      </Accordion.Item>
-
-      <Accordion.Item eventKey="11">
+      <Accordion.Item eventKey="8">
         <Accordion.Header>{t('WeightLabel')}</Accordion.Header>
         <Accordion.Body className="p-2 p-md-3">
           <div className="d-flex justify-content-center">
@@ -236,7 +180,7 @@ const HealthChartsAccordion: React.FC<Props> = observer(({ store, t, lang, svgRe
         </Accordion.Body>
       </Accordion.Item>
 
-      <Accordion.Item eventKey="12">
+      <Accordion.Item eventKey="9">
         <Accordion.Header>{t('Blood pressure')}</Accordion.Header>
         <Accordion.Body className="p-2 p-md-3">
           <div className="d-flex justify-content-center">
@@ -250,7 +194,7 @@ const HealthChartsAccordion: React.FC<Props> = observer(({ store, t, lang, svgRe
         </Accordion.Body>
       </Accordion.Item>
 
-      <Accordion.Item eventKey="13">
+      <Accordion.Item eventKey="10">
         <Accordion.Header>{t('Exercises')}</Accordion.Header>
         <Accordion.Body className="p-2 p-md-3">
           <Row className="g-3">

--- a/frontend/src/components/Health/HealthChartsAccordion.tsx
+++ b/frontend/src/components/Health/HealthChartsAccordion.tsx
@@ -4,14 +4,14 @@ import { Accordion, Col, Row } from 'react-bootstrap';
 import type { HealthPageStore } from '@/stores/healthPageStore';
 
 import MetricBarOrBox from '@/components/Health/charts/MetricBarOrBox';
-import SleepChart from '@/components/Health//charts/SleepChart';
-import HRZonesStacked from '@/components/Health//charts/HRZonesStacked';
-import AdherenceLine from '@/components/Health//charts/AdherenceLine';
-import WeightChart from '@/components/Health//charts/WeightChart';
-import BloodPressureChart from '@/components/Health//charts/BloodPressureChart';
-import ExerciseSessionsChart from '@/components/Health//charts/ExerciseSessionsChart';
-import ExerciseSessionsTable from '@/components/Health//charts/ExerciseSessionsTable';
-import QuestionnaireResultsTable from '@/components/Health//QuestionnaireResultsTable';
+import SleepChart from '@/components/Health/charts/SleepChart';
+import HRZonesStacked from '@/components/Health/charts/HRZonesStacked';
+import AdherenceLine from '@/components/Health/charts/AdherenceLine';
+import WeightChart from '@/components/Health/charts/WeightChart';
+import BloodPressureChart from '@/components/Health/charts/BloodPressureChart';
+import ExerciseSessionsChart from '@/components/Health/charts/ExerciseSessionsChart';
+import ExerciseSessionsTable from '@/components/Health/charts/ExerciseSessionsTable';
+import QuestionnaireResultsTable from '@/components/Health/QuestionnaireResultsTable';
 
 type SvgRefs = {
   adherence: React.RefObject<SVGSVGElement>;

--- a/frontend/src/pages/HealthPage.tsx
+++ b/frontend/src/pages/HealthPage.tsx
@@ -49,11 +49,8 @@ const HealthPage: React.FC = observer(() => {
     sleep: useRef<SVGSVGElement>(null),
     wearTime: useRef<SVGSVGElement>(null),
     hrZones: useRef<SVGSVGElement>(null),
-    floors: useRef<SVGSVGElement>(null),
     steps: useRef<SVGSVGElement>(null),
-    distance: useRef<SVGSVGElement>(null),
     breathing: useRef<SVGSVGElement>(null),
-    hrv: useRef<SVGSVGElement>(null),
     weight: useRef<SVGSVGElement>(null),
     bloodPressure: useRef<SVGSVGElement>(null),
     exercise: useRef<SVGSVGElement>(null),
@@ -67,11 +64,8 @@ const HealthPage: React.FC = observer(() => {
     restingHR: true,
     sleep: true,
     hrZones: true,
-    floors: true,
     steps: true,
-    distance: true,
     breathing: true,
-    hrv: true,
     weight: true,
     bloodPressure: true,
     exercise: true,
@@ -278,25 +272,10 @@ const HealthPage: React.FC = observer(() => {
         'Steps',
         fitIn.map((d) => ({ date: d.date, val: (d as any).steps }))
       );
-    if (selections.distance)
-      csv += emitScalar(
-        'Distance',
-        fitIn.map((d) => ({ date: d.date, val: (d as any).distance }))
-      );
-    if (selections.floors)
-      csv += emitScalar(
-        'Floors',
-        fitIn.map((d) => ({ date: d.date, val: (d as any).floors }))
-      );
     if (selections.breathing)
       csv += emitScalar(
         'Breathing Rate',
         fitIn.map((d: any) => ({ date: d.date, val: d.breathing_rate?.breathingRate }))
-      );
-    if (selections.hrv)
-      csv += emitScalar(
-        'HRV (dailyRmssd)',
-        fitIn.map((d: any) => ({ date: d.date, val: d.hrv?.dailyRmssd }))
       );
 
     if (selections.sleep) {
@@ -397,11 +376,8 @@ const HealthPage: React.FC = observer(() => {
       { ref: svgRefs.restingHR, key: 'restingHR', title: t('Resting Heart Rate') },
       { ref: svgRefs.sleep, key: 'sleep', title: t('Sleep Schedule and Duration') },
       { ref: svgRefs.hrZones, key: 'hrZones', title: t('Heart Rate Zones per Day') },
-      { ref: svgRefs.floors, key: 'floors', title: t('Floors Climbed') },
       { ref: svgRefs.steps, key: 'steps', title: t('Daily Steps') },
-      { ref: svgRefs.distance, key: 'distance', title: t('Distance Traveled') },
       { ref: svgRefs.breathing, key: 'breathing', title: t('Breathing Rate (breaths/min)') },
-      { ref: svgRefs.hrv, key: 'hrv', title: t('Heart Rate Variability (dailyRmssd in ms)') },
       { ref: svgRefs.weight, key: 'weight', title: t('Weight (kg)') },
       { ref: svgRefs.bloodPressure, key: 'bloodPressure', title: t('Blood Pressure (SYS/DIA)') },
       { ref: svgRefs.exercise, key: 'exercise', title: t('Exercise Summary') },

--- a/frontend/src/pages/HealthPage.tsx
+++ b/frontend/src/pages/HealthPage.tsx
@@ -63,6 +63,7 @@ const HealthPage: React.FC = observer(() => {
     questionnaire: true,
     restingHR: true,
     sleep: true,
+    wearTime: true,
     hrZones: true,
     steps: true,
     breathing: true,
@@ -277,6 +278,11 @@ const HealthPage: React.FC = observer(() => {
         'Breathing Rate',
         fitIn.map((d: any) => ({ date: d.date, val: d.breathing_rate?.breathingRate }))
       );
+    if (selections.wearTime)
+      csv += emitScalar(
+        'Wear Time (min)',
+        fitIn.map((d: any) => ({ date: d.date, val: d.wear_time_minutes }))
+      );
 
     if (selections.sleep) {
       const rows = fitIn
@@ -378,6 +384,7 @@ const HealthPage: React.FC = observer(() => {
       { ref: svgRefs.hrZones, key: 'hrZones', title: t('Heart Rate Zones per Day') },
       { ref: svgRefs.steps, key: 'steps', title: t('Daily Steps') },
       { ref: svgRefs.breathing, key: 'breathing', title: t('Breathing Rate (breaths/min)') },
+      { ref: svgRefs.wearTime, key: 'wearTime', title: t('Wear Time (min)') },
       { ref: svgRefs.weight, key: 'weight', title: t('Weight (kg)') },
       { ref: svgRefs.bloodPressure, key: 'bloodPressure', title: t('Blood Pressure (SYS/DIA)') },
       { ref: svgRefs.exercise, key: 'exercise', title: t('Exercise Summary') },


### PR DESCRIPTION
# Description

Hides the Floors, Distance Travelled, and HR Variability charts from the Health page.

## Related Issue
https://github.com/ARTORG-GERONTECHNOLOGY/Bearny-RehaAdvisor/issues/312

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Tests

These charts are no longer displayed on the Health page.

## Checklist

- [x] I have read the [contributing guidelines](/docs/12-CONTRIBUTING.md).
- [x] I have read the [code of conduct](/CODE_OF_CONDUCT.md).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
