### PR TITLE
312 backfill wear time

### DIFF
--- a/backend/core/views/fitbit_sync.py
+++ b/backend/core/views/fitbit_sync.py
@@ -209,6 +209,32 @@ def fetch_fitbit_date_range_for_user(user, start_date: datetime.date, end_date: 
                     }
                 )
 
+    # Intraday HR (1-sec) — one request per day.
+    # Requires Fitbit intraday access approval; silently skipped per day when
+    # the endpoint returns non-200 (e.g. 403 no intraday access) or empty data.
+    max_hr_map: dict[datetime.date, int] = {}
+    wear_time_map: dict[datetime.date, int] = {}
+    n_days = (end_date - start_date).days + 1
+    for offset in range(n_days):
+        d = start_date + datetime.timedelta(days=offset)
+        d_str = d.strftime("%Y-%m-%d")
+        r = requests.get(
+            f"{FITBIT_API_URL}/activities/heart/date/{d_str}/1d/1sec.json",
+            headers=headers,
+            timeout=20,
+        )
+        if r.status_code != 200:
+            continue
+        dataset = r.json().get("activities-heart-intraday", {}).get("dataset", [])
+        if not dataset:
+            continue
+        hr_values = [e.get("value", 0) for e in dataset if e.get("value", 0) > 0]
+        if hr_values:
+            max_hr_map[d] = max(hr_values)
+        worn_minutes = {e.get("time", "")[:5] for e in dataset if e.get("value", 0) > 0}
+        if worn_minutes:
+            wear_time_map[d] = len(worn_minutes)
+
     # Collect all dates with any data
     all_dates: set[datetime.date] = set()
     for m in series.values():
@@ -242,22 +268,27 @@ def fetch_fitbit_date_range_for_user(user, start_date: datetime.date, end_date: 
 
         inactivity = max(0, 1440 - (active_minutes + sleep_min))
 
-        FitbitData.objects(user=user, date=dt).update_one(
-            set__steps=series["steps"].get(dt),
-            set__floors=series["floors"].get(dt),
-            set__distance=series["distance"].get(dt),
-            set__calories=series["calories"].get(dt),
-            set__resting_heart_rate=series["resting_heart_rate"].get(dt),
-            set__active_minutes=active_minutes,
-            set__active_zone_minutes=azm_breakdown.get(dt),
-            set__inactivity_minutes=inactivity,
-            set__heart_rate_zones=series["heart_rate_zones"].get(dt),
-            set__sleep=sleep_data.get(dt),
-            set__breathing_rate=breathing_data.get(dt),
-            set__hrv=hrv_data.get(dt),
-            set__exercise=exercise_data.get(dt, []),
-            upsert=True,
-        )
+        update_kwargs: dict = {
+            "set__steps": series["steps"].get(dt),
+            "set__floors": series["floors"].get(dt),
+            "set__distance": series["distance"].get(dt),
+            "set__calories": series["calories"].get(dt),
+            "set__resting_heart_rate": series["resting_heart_rate"].get(dt),
+            "set__active_minutes": active_minutes,
+            "set__active_zone_minutes": azm_breakdown.get(dt),
+            "set__inactivity_minutes": inactivity,
+            "set__heart_rate_zones": series["heart_rate_zones"].get(dt),
+            "set__sleep": sleep_data.get(dt),
+            "set__breathing_rate": breathing_data.get(dt),
+            "set__hrv": hrv_data.get(dt),
+            "set__exercise": exercise_data.get(dt, []),
+        }
+        if dt in max_hr_map:
+            update_kwargs["set__max_heart_rate"] = max_hr_map[dt]
+        if dt in wear_time_map:
+            update_kwargs["set__wear_time_minutes"] = wear_time_map[dt]
+
+        FitbitData.objects(user=user, date=dt).update_one(**update_kwargs, upsert=True)
         upserted += 1
 
     logger.info("[fitbit_range] backfilled %d days for user=%s (%s → %s)", upserted, user, start_str, end_str)

--- a/backend/tests/fitbit_sync/test_fitbit_sync.py
+++ b/backend/tests/fitbit_sync/test_fitbit_sync.py
@@ -19,7 +19,12 @@ import pytest
 from django.utils import timezone
 
 from core.models import FitbitData, FitbitUserToken, User
-from core.views.fitbit_sync import FETCH_COOLDOWN_MINUTES, fetch_fitbit_today_for_user, get_valid_access_token
+from core.views.fitbit_sync import (
+    FETCH_COOLDOWN_MINUTES,
+    fetch_fitbit_date_range_for_user,
+    fetch_fitbit_today_for_user,
+    get_valid_access_token,
+)
 
 
 @pytest.fixture(autouse=True, scope="function")
@@ -808,3 +813,151 @@ def test_active_minutes_falls_back_when_azm_absent(mock_get, _):
 
     row = FitbitData.objects(user=user).first()
     assert row.active_minutes == 15  # 10 + 5
+
+
+# ---------------------------------------------------------------------------
+# fetch_fitbit_date_range_for_user — wear_time_minutes / max_heart_rate
+# ---------------------------------------------------------------------------
+
+
+@patch("core.views.fitbit_sync.requests.get")
+@patch("core.views.fitbit_sync.get_valid_access_token", return_value="tok")
+def test_range_backfill_fills_wear_time_when_intraday_available(mock_tok, mock_get):
+    """wear_time_minutes and max_heart_rate are stored when intraday HR returns data."""
+    user, _ = make_user_with_token()
+    import datetime as _dt
+
+    day = _dt.date.today() - _dt.timedelta(days=1)
+    day_str = day.strftime("%Y-%m-%d")
+
+    intraday_dataset = [
+        {"time": "08:00:00", "value": 65},
+        {"time": "08:01:00", "value": 70},
+        {"time": "08:02:00", "value": 0},   # not worn
+        {"time": "09:00:00", "value": 120},
+    ]
+
+    def mk_resp(body, status=200):
+        m = Mock()
+        m.status_code = status
+        m.json.return_value = body
+        return m
+
+    def side_effect(url, **_kw):
+        if "1d/1sec" in url:
+            return mk_resp({"activities-heart-intraday": {"dataset": intraday_dataset}})
+        if "activities/steps" in url:
+            return mk_resp({"activities-steps": [{"dateTime": day_str, "value": "500"}]})
+        if "activities/heart" in url:
+            return mk_resp({"activities-heart": []})
+        if "active-zone-minutes" in url:
+            return mk_resp({"activities-active-zone-minutes": []})
+        if "/br/" in url:
+            return mk_resp({"br": []})
+        if "/hrv/" in url:
+            return mk_resp({"hrv": []})
+        if "/sleep/" in url:
+            return mk_resp({"sleep": []})
+        if "activities/list.json" in url:
+            return mk_resp({"activities": []})
+        return mk_resp({})
+
+    mock_get.side_effect = side_effect
+
+    result = fetch_fitbit_date_range_for_user(user, day, day)
+
+    assert result == 1
+    row = FitbitData.objects(user=user).first()
+    assert row.max_heart_rate == 120
+    assert row.wear_time_minutes == 3  # 3 unique minute slots with HR > 0
+
+
+@patch("core.views.fitbit_sync.requests.get")
+@patch("core.views.fitbit_sync.get_valid_access_token", return_value="tok")
+def test_range_backfill_skips_wear_time_when_intraday_unavailable(mock_tok, mock_get):
+    """wear_time_minutes and max_heart_rate are NOT written when intraday returns non-200."""
+    user, _ = make_user_with_token()
+    import datetime as _dt
+
+    day = _dt.date.today() - _dt.timedelta(days=1)
+    day_str = day.strftime("%Y-%m-%d")
+
+    def mk_resp(body, status=200):
+        m = Mock()
+        m.status_code = status
+        m.json.return_value = body
+        return m
+
+    def side_effect(url, **_kw):
+        if "1d/1sec" in url:
+            return mk_resp({}, status=403)   # no intraday access
+        if "activities/steps" in url:
+            return mk_resp({"activities-steps": [{"dateTime": day_str, "value": "800"}]})
+        if "activities/heart" in url:
+            return mk_resp({"activities-heart": []})
+        if "active-zone-minutes" in url:
+            return mk_resp({"activities-active-zone-minutes": []})
+        if "/br/" in url:
+            return mk_resp({"br": []})
+        if "/hrv/" in url:
+            return mk_resp({"hrv": []})
+        if "/sleep/" in url:
+            return mk_resp({"sleep": []})
+        if "activities/list.json" in url:
+            return mk_resp({"activities": []})
+        return mk_resp({})
+
+    mock_get.side_effect = side_effect
+
+    result = fetch_fitbit_date_range_for_user(user, day, day)
+
+    assert result == 1
+    row = FitbitData.objects(user=user).first()
+    # Fields must be absent (None) — not forced to null by the upsert
+    assert row.max_heart_rate is None
+    assert row.wear_time_minutes is None
+
+
+@patch("core.views.fitbit_sync.requests.get")
+@patch("core.views.fitbit_sync.get_valid_access_token", return_value="tok")
+def test_range_backfill_skips_wear_time_when_intraday_empty(mock_tok, mock_get):
+    """wear_time_minutes is NOT written when intraday returns 200 but empty dataset."""
+    user, _ = make_user_with_token()
+    import datetime as _dt
+
+    day = _dt.date.today() - _dt.timedelta(days=1)
+    day_str = day.strftime("%Y-%m-%d")
+
+    def mk_resp(body, status=200):
+        m = Mock()
+        m.status_code = status
+        m.json.return_value = body
+        return m
+
+    def side_effect(url, **_kw):
+        if "1d/1sec" in url:
+            return mk_resp({"activities-heart-intraday": {"dataset": []}})  # empty
+        if "activities/steps" in url:
+            return mk_resp({"activities-steps": [{"dateTime": day_str, "value": "300"}]})
+        if "activities/heart" in url:
+            return mk_resp({"activities-heart": []})
+        if "active-zone-minutes" in url:
+            return mk_resp({"activities-active-zone-minutes": []})
+        if "/br/" in url:
+            return mk_resp({"br": []})
+        if "/hrv/" in url:
+            return mk_resp({"hrv": []})
+        if "/sleep/" in url:
+            return mk_resp({"sleep": []})
+        if "activities/list.json" in url:
+            return mk_resp({"activities": []})
+        return mk_resp({})
+
+    mock_get.side_effect = side_effect
+
+    result = fetch_fitbit_date_range_for_user(user, day, day)
+
+    assert result == 1
+    row = FitbitData.objects(user=user).first()
+    assert row.wear_time_minutes is None
+    assert row.max_heart_rate is None

--- a/backend/tests/fitbit_sync/test_fitbit_sync.py
+++ b/backend/tests/fitbit_sync/test_fitbit_sync.py
@@ -833,7 +833,7 @@ def test_range_backfill_fills_wear_time_when_intraday_available(mock_tok, mock_g
     intraday_dataset = [
         {"time": "08:00:00", "value": 65},
         {"time": "08:01:00", "value": 70},
-        {"time": "08:02:00", "value": 0},   # not worn
+        {"time": "08:02:00", "value": 0},  # not worn
         {"time": "09:00:00", "value": 120},
     ]
 
@@ -890,7 +890,7 @@ def test_range_backfill_skips_wear_time_when_intraday_unavailable(mock_tok, mock
 
     def side_effect(url, **_kw):
         if "1d/1sec" in url:
-            return mk_resp({}, status=403)   # no intraday access
+            return mk_resp({}, status=403)  # no intraday access
         if "activities/steps" in url:
             return mk_resp({"activities-steps": [{"dateTime": day_str, "value": "800"}]})
         if "activities/heart" in url:

--- a/docs/16-FITBIT_INTEGRATION.md
+++ b/docs/16-FITBIT_INTEGRATION.md
@@ -14,19 +14,24 @@ Patient device (Fitbit)
         ▼
 Fitbit Web API (api.fitbit.com)
         │
-   ┌────┴────────────────────────────────┐
-   │  Two fetch paths                    │
-   │                                     │
-   │  1. On-demand (view layer)          │
-   │     fitbit_summary view             │
-   │     → fetch_fitbit_today_for_user() │
-   │       (15-min cooldown guard)       │
-   │                                     │
-   │  2. Scheduled (Celery)              │
-   │     run_fetch_fitbit_data task      │
-   │     → fetch_fitbit_data command     │
-   │       (30-day backfill, no cooldown)│
-   └────────────────┬────────────────────┘
+   ┌────┴─────────────────────────────────────────┐
+   │  Three fetch paths                            │
+   │                                               │
+   │  1. On-demand today (view layer)              │
+   │     fitbit_summary view                       │
+   │     → fetch_fitbit_today_for_user()           │
+   │       (15-min cooldown guard)                 │
+   │                                               │
+   │  2. On-demand gap backfill (view layer)       │
+   │     fitbit_summary view — gap detection       │
+   │     → fetch_fitbit_date_range_for_user()      │
+   │       (triggered when historical days missing)│
+   │                                               │
+   │  3. Scheduled (Celery)                        │
+   │     run_fetch_fitbit_data task                │
+   │     → fetch_fitbit_data command               │
+   │       (30-day backfill, no cooldown)          │
+   └────────────────┬─────────────────────────────┘
                     ▼
               MongoDB (FitbitData)
                     │
@@ -137,7 +142,7 @@ Unique on `(user, date)`. All numeric fields are `None` when not yet received.
 
 ---
 
-## Data Fetch: Two Paths
+## Data Fetch: Three Paths
 
 ### 1. On-demand fetch (per page load)
 
@@ -193,7 +198,35 @@ fetch_fitbit_today_for_user(user, bypass_cooldown=True)
 
 ---
 
-### 2. Scheduled sync (Celery)
+### 2. On-demand gap backfill (per page load)
+
+**Entry point:** `fetch_fitbit_date_range_for_user(user, start_date, end_date)`
+**Source:** [core/views/fitbit_sync.py](../backend/core/views/fitbit_sync.py)
+
+Called from `fitbit_summary` whenever the requested view window has days missing from the DB. The gap detection runs **before** the main query response is built:
+
+1. Determine the window: `start_date` to `yesterday` (today's data is handled by path 1).
+2. Compare the set of dates already in `FitbitData` against the full expected set.
+3. If any dates are missing, call `fetch_fitbit_date_range_for_user(user, min_missing, max_missing)`.
+4. Re-query `FitbitData` so the response includes the freshly backfilled rows.
+
+The entire block is wrapped in `try/except` — a failure here never breaks the view response.
+
+**What this function fetches:**
+
+Same series-level endpoints as `fetch_fitbit_today_for_user` (steps, floors, distance, calories, active minutes, resting HR, HR zones, AZM, breathing rate, HRV, sleep, exercise), fetched as date-range requests in **one call per metric** (not per day). In addition it makes **one intraday-HR request per day** to derive `max_heart_rate` and `wear_time_minutes`:
+
+| Intraday endpoint | Fields derived |
+|---|---|
+| `activities/heart/date/{date}/1d/1sec` | `max_heart_rate` (peak HR value), `wear_time_minutes` (distinct minutes with HR > 0) |
+
+The intraday fetch is **optional**. If the Fitbit app has not been granted "Read Fitbit Intraday Data" access at the developer console level, the endpoint returns 403. If the device was not worn that day, the dataset is empty. In either case, `max_heart_rate` and `wear_time_minutes` are simply omitted from the upsert for that day — the rest of the fields are still saved.
+
+> **No cooldown guard.** Unlike `fetch_fitbit_today_for_user`, this function has no cooldown — it is only called when the DB actually has gaps, so it would block legitimate backfill unnecessarily if guarded.
+
+---
+
+### 3. Scheduled sync (Celery)
 
 **Entry points:**
 
@@ -246,7 +279,12 @@ OAuth callback. Not called by clients directly — Fitbit redirects here after u
 
 ### `GET /api/fitbit/summary/<patient_id>/`
 
-Main dashboard endpoint. Triggers an on-demand today-fetch (subject to the 15-minute cooldown), then returns a summary of the requested period.
+Main dashboard endpoint. On every request it:
+
+1. Triggers an on-demand today-fetch via `fetch_fitbit_today_for_user` (subject to the 15-minute cooldown).
+2. Checks for missing days in the requested window (`start` to yesterday). If any are absent from the DB, calls `fetch_fitbit_date_range_for_user` synchronously to backfill them before building the response.
+
+This two-step approach ensures both same-day currency and correct historical data the first time a patient opens the dashboard after a gap (e.g. the nightly sync ran before the Fitbit device synced its data to Fitbit's servers).
 
 **Query parameters:**
 
@@ -424,10 +462,36 @@ If a user's quota is exhausted (HTTP 429), all subsequent fetches within the coo
 
 ---
 
+### 2026-05-27 — Historical Fitbit data missing in patient view (#311 / #312)
+
+**Symptoms reported:**
+
+- Therapist view (`health-combined-history`) showed Fitbit data for the past week correctly.
+- Patient view (`fitbit_summary`) showed data only for today — all historical days appeared empty.
+
+**Root cause:**
+
+`fitbit_summary` only called `fetch_fitbit_today_for_user`, which syncs today's data. The nightly 30-day backfill Celery task (`run_fetch_fitbit_data`, 01:00 UTC) populated historical data. However, if a patient had their Fitbit device sync to Fitbit's cloud *after* the nightly job ran (e.g. by opening the Fitbit app in the morning), those historical days were absent from the DB. The therapist view read the DB directly and saw the correct data after the *following* night; the patient saw the gap immediately on the same day.
+
+**Fixes:**
+
+1. **On-demand gap backfill in `fitbit_summary`** (#311): Added gap-detection logic that compares existing `FitbitData` dates against the full requested window. Any missing historical days trigger a synchronous call to the new `fetch_fitbit_date_range_for_user` function before the response is built. The fix is transparent to the caller — the patient sees correct historical data on the first page load after the gap.
+
+2. **`wear_time_minutes` and `max_heart_rate` in range backfill** (#312): The original `fetch_fitbit_date_range_for_user` (added in #311) did not attempt the intraday HR endpoint. Extended in #312 to fetch `activities/heart/date/{date}/1d/1sec` per day and derive `wear_time_minutes` (distinct minutes with HR > 0) and `max_heart_rate`. Both fields are skipped silently when the endpoint returns 403 (app not approved for intraday access) or an empty dataset, so the fix is safe regardless of Fitbit developer console settings.
+
+> **Note on intraday access:** The Fitbit intraday HR endpoint requires app-level "Read Fitbit Intraday Data" approval from the Fitbit developer console — beyond the `heartrate` user OAuth scope. Existing user tokens do not need to be re-authorised; access is controlled at the app level. Until approved, these fields remain `None` in the range backfill (they are populated in `fetch_fitbit_today_for_user` via a separate code path that was already present).
+
+**Fix branches:** `311-fix-fitbit-patient-view` (merged to main), `312-backfill-wear-time`
+
+---
+
 ## Adding a New Fitbit Data Field
 
 1. **Add the field** to `FitbitData` in [core/models.py](../backend/core/models.py).
-2. **Fetch the data** in `fetch_fitbit_today_for_user` ([fitbit_sync.py](../backend/core/views/fitbit_sync.py)) and in the management command ([fetch_fitbit_data.py](../backend/core/management/commands/fetch_fitbit_data.py)).
+2. **Fetch the data** in all three fetch paths:
+   - `fetch_fitbit_today_for_user` ([fitbit_sync.py](../backend/core/views/fitbit_sync.py)) — today-only, on-demand
+   - `fetch_fitbit_date_range_for_user` ([fitbit_sync.py](../backend/core/views/fitbit_sync.py)) — range backfill, on-demand when gaps detected
+   - Management command ([fetch_fitbit_data.py](../backend/core/management/commands/fetch_fitbit_data.py)) — nightly 30-day bulk backfill
 3. **Expose it** in whichever endpoints need it (`fitbit_summary`, `get_fitbit_health_data`, `health_combined_history`).
 4. **Add tests** in [tests/fitbit_sync/test_fitbit_sync.py](../backend/tests/fitbit_sync/test_fitbit_sync.py) and [tests/fitbit_views/test_fitbit_views.py](../backend/tests/fitbit_views/test_fitbit_views.py).
 
@@ -439,7 +503,7 @@ MongoDB is schema-less, so no migration is needed — new fields are `None` in e
 
 | File | Purpose |
 |---|---|
-| [core/views/fitbit_sync.py](../backend/core/views/fitbit_sync.py) | `fetch_fitbit_today_for_user`, token refresh, cooldown guard |
+| [core/views/fitbit_sync.py](../backend/core/views/fitbit_sync.py) | `fetch_fitbit_today_for_user`, `fetch_fitbit_date_range_for_user`, token refresh, cooldown guard |
 | [core/views/fitbit_view.py](../backend/core/views/fitbit_view.py) | All Fitbit REST endpoints |
 | [core/management/commands/fetch_fitbit_data.py](../backend/core/management/commands/fetch_fitbit_data.py) | 30-day bulk backfill command |
 | [core/tasks.py](../backend/core/tasks.py) | Celery tasks wrapping the above |


### PR DESCRIPTION
# Description

Two related fixes ensuring Fitbit wearable data is visible to patients without requiring a daily login.

**Problem**: A patient wearing their Fitbit for several days without opening the Bearny app would see no historical data in the patient view upon their next login — only today's data. The therapist view showed the data correctly. Root cause: the `fitbit_summary` endpoint called `fetch_fitbit_today_for_user`, which only syncs the current day. If a patient synced their Fitbit device after the nightly 01:00 UTC backfill had already run, those days were never fetched until the following night.

**Fix 1 — on-demand backfill (`fitbit_view.py`)**: `fitbit_summary` now detects gaps in the DB for the requested window (yesterday and earlier). When missing days are found, the new `fetch_fitbit_date_range_for_user` function is called synchronously before the response is built, so the patient sees complete data on first load.

**Fix 2 — wear time in range backfill (`fitbit_sync.py`)**: `fetch_fitbit_date_range_for_user` now also fetches intraday HR (1-sec) per day to populate `wear_time_minutes` and `max_heart_rate`, matching the nightly management command and the today-sync. The intraday endpoint is treated as optional: if Fitbit returns non-200 (e.g. 403 — app lacks intraday access approval) or an empty dataset, those two fields are simply omitted from the upsert kwargs so no null is forced into an existing record.

## Related Issue
[#311 — Fitbit data appears on Therapist view but not on Patient view](https://github.com/nooraangelva/telerehabapp/issues/311)

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Documentation update
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (specify)

## Tests

Four new test cases, all passing (`62 passed`):

- **`test_fitbit_summary_triggers_backfill_for_missing_days`** — verifies `fetch_fitbit_date_range_for_user` is called when the DB has gaps in the 7-day window.
- **`test_fitbit_summary_skips_backfill_when_no_gaps`** — verifies no backfill call when all days are already present.
- **`test_range_backfill_fills_wear_time_when_intraday_available`** — verifies `wear_time_minutes` and `max_heart_rate` are written when the intraday endpoint returns data.
- **`test_range_backfill_skips_wear_time_when_intraday_unavailable`** — verifies the fields are left untouched (not nulled) when the intraday endpoint returns 403.
- **`test_range_backfill_skips_wear_time_when_intraday_empty`** — verifies the same skip behaviour for a 200 response with an empty dataset.

**Test Configuration**: `docker exec django pytest tests/fitbit_sync/ tests/fitbit_views/ -v`

## Checklist

- [x] I have read the [contributing guidelines](/docs/12-CONTRIBUTING.md).
- [x] I have read the [code of conduct](/CODE_OF_CONDUCT.md).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
