### PR TITLE
Fix/prod celery conda env

### DIFF
--- a/docker-compose.prod.reha-advisor.yml
+++ b/docker-compose.prod.reha-advisor.yml
@@ -85,7 +85,7 @@ services:
       libretranslate:
         condition: service_started
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8000/api/"]
+      test: ["CMD", "wget", "-qO/dev/null", "http://localhost:8000/api/"]
       interval: 30s
       timeout: 10s
       retries: 3
@@ -97,7 +97,7 @@ services:
     image: ${GHCR_IMAGE}-backend:${IMAGE_TAG:-latest}
     container_name: celery-prod
     restart: always
-    command: python -m celery -A api.celery:app worker --loglevel=info --statedb=/app/celery_worker.state -c 4
+    command: conda run --no-capture-output -n teleRehabApp python -m celery -A api.celery:app worker --loglevel=info -c 4
     volumes:
       - ./mongo/tls/ca.crt:/etc/ssl/mongo/ca.crt:ro
       - /var/run/docker.sock:/var/run/docker.sock
@@ -111,7 +111,6 @@ services:
       - CELERY_BROKER_URL=redis://:${REDIS_PASSWORD:-changeme}@redis-prod:6379/0
       - CELERY_RESULT_BACKEND=redis://:${REDIS_PASSWORD:-changeme}@redis-prod:6379/0
       - CELERY_WORKER_PREFETCH_MULTIPLIER=4
-      - CELERY_WORKER_STATE_DB=/app/celery_worker.state
       # Certificate renewal — set CERTBOT_ENABLED=true in .env.prod to activate
       - CERTBOT_CONF_PATH=${CERTBOT_CONF_PATH:-/home/ubuntu/repos/telerehabapp-prod/nginx/certbot/conf}
       - CERTBOT_WWW_PATH=${CERTBOT_WWW_PATH:-/home/ubuntu/repos/telerehabapp-prod/nginx/certbot/www}
@@ -132,7 +131,7 @@ services:
     restart: always
     working_dir: /app
     command: >
-      python -m celery -A api.celery:app beat -l info
+      conda run --no-capture-output -n teleRehabApp python -m celery -A api.celery:app beat -l info
       --scheduler django_celery_beat.schedulers:DatabaseScheduler
     env_file:
       - ./.env.prod


### PR DESCRIPTION
## Description

Fixes two infrastructure bugs in `docker-compose.prod.reha-advisor.yml` that caused the production Celery containers to crash-loop and the Django health check to always fail.

**Problem 1 — Celery workers crash with `No module named celery`**
The `command` for `celery-prod` and `celery-beat-prod` used plain `python -m celery`, which invokes the base conda Python at `/opt/conda/bin/python`. Project dependencies (including Celery) are installed in the `teleRehabApp` conda environment, not the base env. The worker started, found no Celery, and exited immediately — indefinitely.

**Problem 2 — `django-prod` permanently unhealthy**
The health check ran `curl -f http://localhost:8000/api/`, but `curl` is not present in the backend image (only `wget` is). Docker marked the container unhealthy after every check despite the app responding correctly.

**Problem 3 — `--statedb` crash on first start**
After fixing the conda env, the worker crashed again because the `--statedb` shelve file could not be opened (`dbm.error: db type could not be determined`). This is a Python 3.12 dbm format incompatibility. The state DB only tracks task revocations across restarts and is not required for correct operation — removed.

## Related Issue

Prod incident — Celery workers down, scheduled Fitbit sync and REDCap export tasks not running.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Tests

Verified directly on the production server after applying the fix:

- `celery-prod` — Up, workers processing tasks (REDCap sync, Fitbit jobs visible in logs)
- `celery-beat-prod` — Up, scheduling periodic tasks
- `django-prod` — Up **(healthy)**, health check passing with `wget`

**Test Configuration**: Production server (`docker-compose.prod.reha-advisor.yml`), image tag `0.7.3`

## Checklist

- [x] I have read the contributing guidelines.
- [x] I have read the code of conduct.
- [x] My changes generate no new warnings.
