### PR TITLE
Fix/backup script tls and media

### DIFF
--- a/scripts/tests/test_backup.bats
+++ b/scripts/tests/test_backup.bats
@@ -88,24 +88,24 @@ teardown() { teardown_repo; }
 # Media backup
 # ---------------------------------------------------------------------------
 
-@test "django-prod not running skips media and exits 0" {
-    export MOCK_DOCKER_CONTAINERS="db-prod"  # no django-prod
+@test "media backup is skipped with a message (volume too large for CI)" {
+    export MOCK_DOCKER_CONTAINERS="db-prod django-prod"
     run bash "$REPO_DIR/scripts/backup.sh"
     [ "$status" -eq 0 ]
-    [[ "$output" == *"skipping media backup"* ]]
+    [[ "$output" == *"Media backup skipped"* ]]
     local count
     count=$(ls "$REPO_DIR/backups/media_"*.tar.gz 2>/dev/null | wc -l)
     [ "$count" -eq 0 ]
 }
 
-@test "full backup with all containers creates all three files" {
+@test "full backup creates mongodb and sqlite files but no media archive" {
     export MOCK_DOCKER_CONTAINERS="db-prod django-prod"
     touch "$REPO_DIR/data/db.sqlite3"
     run bash "$REPO_DIR/scripts/backup.sh"
     [ "$status" -eq 0 ]
     [ "$(ls "$REPO_DIR/backups/mongodb_"*.archive 2>/dev/null | wc -l)" -eq 1 ]
     [ "$(ls "$REPO_DIR/backups/sqlite_"*.db 2>/dev/null | wc -l)" -eq 1 ]
-    [ "$(ls "$REPO_DIR/backups/media_"*.tar.gz 2>/dev/null | wc -l)" -eq 1 ]
+    [ "$(ls "$REPO_DIR/backups/media_"*.tar.gz 2>/dev/null | wc -l)" -eq 0 ]
 }
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Description

Fixes two bugs in `scripts/backup.sh` that caused every pre-deploy MongoDB backup to silently fail and the media backup step to time out the GitHub Actions deploy runner. Updates the bats test suite to match the new behaviour.

**Bug 1 — MongoDB backup has been silently failing on every deploy**

`mongodump` inside `db-prod` is version 100.x, which requires `--ssl` / `--tlsInsecure`. The script was passing `--tls` / `--tlsAllowInvalidCertificates`, which that version does not recognise. Because `db-prod` runs with `tlsMode=requireTLS`, the connection is rejected before any data is read. `mongodump` exited immediately with `unknown option "tls"`, no archive was written, and the failure was swallowed by the `|| echo "Backup failed (non-fatal)"` guard in the deploy workflow — so every deploy since TLS was enabled has run without a database backup.

Fix: replace `--tls --tlsAllowInvalidCertificates` with `--ssl --tlsInsecure`.

**Bug 2 — Media backup was timing out the GitHub Actions deploy step**

The media volume has grown to ~16 GB of intervention videos. `docker exec django-prod tar -czf - /srv/app/media` ran for the full 10-minute GitHub Actions runner limit and killed the entire deploy step mid-flight. Media backup is removed from the script; it must be triggered manually when needed. MongoDB and SQLite (the critical data) are unaffected.

**Tests (Bug 3 — found during fix)**

Tests 8 and 9 in `scripts/tests/test_backup.bats` were asserting the old media backup behaviour. After the script was fixed the CI caught the mismatch. Updated to assert:
- Media backup is always skipped with an explanatory message
- No `media_*.tar.gz` archive is ever created

All 26 bats tests pass.

## Related Issue

Observed during production deploy on 2026-06-03 — runner timed out at 10 min, MongoDB backup log showed `unknown option "tls"`.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Tests

Verified locally against the live `db-prod` container:

✓ MongoDB backup: backups/mongodb_20260603_054642.archive (288K)
✓ SQLite backup:  backups/sqlite_20260603_054642.db (268K)
Media backup skipped — volume is too large for CI deploy steps.
✓ Backup complete


Full run completes in under 60 seconds. `bats scripts/tests/test_backup.bats` → 26/26 passed.

**Test Configuration**: production server, `db-prod` container running `mongo:8.0.3` with `tlsMode=requireTLS`.

## Checklist

- [x] I have read the contributing guidelines.
- [x] I have read the code of conduct.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
