### PR TITLE
Fix/wearables redcap aggregation

### DIFF
--- a/backend/core/services/wearables_redcap_service.py
+++ b/backend/core/services/wearables_redcap_service.py
@@ -1,7 +1,6 @@
 import json
 import logging
 import os
-from collections import defaultdict
 from datetime import datetime, timedelta
 from datetime import timezone as dt_tz
 from typing import Any, Dict, List, Optional, Tuple
@@ -27,32 +26,33 @@ class WearablesSyncError(ValueError):
         self.code = code
 
 
-# How many weeks to take from each end of the follow-up period
-BASELINE_WEEKS = 4
-FOLLOWUP_WEEKS = 4
+# ---------------------------------------------------------------------------
+# Window definitions (days relative to first Fitbit measurement date, 1-indexed)
+# ---------------------------------------------------------------------------
+BASELINE_DAY_START = 8    # first 7 days are excluded (device calibration / habituation)
+BASELINE_DAY_END = 28
+FOLLOWUP_DAY_START = 150
+FOLLOWUP_DAY_END = 180
 
-# Per-project configuration for longitudinal REDCap projects.
-# Override event names with REDCAP_WEARABLES_EVENT_BASELINE / FOLLOWUP env vars.
-#
-# sleep_duration_format:
-#   "hours_int"  — integer 0-24  (COMPASS: text integer, Max: 24)
-#   "hhmm"       — "HH:MM" time  (COPAIN:  text time,    Max: 23:59)
+# Validity thresholds
+MIN_WEAR_MINUTES = 600    # 10 hours — minimum for a valid activity day
+MIN_SLEEP_MINUTES = 180   # 3 hours  — minimum for a valid sleep night
+
+# Day-selection targets per window
+MAX_WEEKDAYS = 5
+MAX_WEEKENDS = 2
+
+# Per-project REDCap configuration
 _PROJECT_CONFIG: Dict[str, Dict[str, str]] = {
     "COMPASS": {
         "baseline": "visit_baseline_arm_1",
         "followup": "visit_6m_arm_1",
         "sleep_duration_format": "hours_int",
-        # Baseline data collected after discharge (outpatient rehab).
-        "baseline_anchor": "after_reha_end",
     },
     "COPAIN": {
         "baseline": "t0_at_disch_arm_1",
         "followup": "t2_six_months_afte_arm_1",
         "sleep_duration_format": "hhmm",
-        # Baseline data collected during the last weeks of the hospital stay,
-        # i.e. BEFORE discharge (reha_end_date). The window is
-        # [reha_end - BASELINE_WEEKS, reha_end).
-        "baseline_anchor": "before_reha_end",
     },
 }
 
@@ -60,48 +60,89 @@ _PROJECT_CONFIG: Dict[str, Dict[str, str]] = {
 _PROJECT_EVENTS = _PROJECT_CONFIG
 
 
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
 def _as_utc(dt: datetime) -> datetime:
     if dt.tzinfo is None:
         return dt.replace(tzinfo=dt_tz.utc)
     return dt.astimezone(dt_tz.utc)
 
 
-def _fmt_dmy(dt: datetime) -> str:
-    """Format date as YYYY-MM-DD — REDCap import always requires Y-M-D regardless of field display format."""
-    return dt.strftime("%Y-%m-%d")
-
-
-def _pick_best_wear_week(
-    records: List[FitbitData],
-) -> Optional[Tuple[datetime, datetime, List[FitbitData]]]:
-    """
-    Group records by ISO week, return (week_start, week_end, records) for the
-    week with the highest total wear_time_minutes.
-    """
-    if not records:
+def _record_date(r: FitbitData):
+    """Return the date part of a FitbitData record as a datetime.date."""
+    d = r.date
+    if d is None:
         return None
+    if hasattr(d, "date"):
+        return _as_utc(d).date()
+    return d
 
-    weeks: Dict[Tuple[int, int], List[FitbitData]] = defaultdict(list)
-    for r in records:
-        if r.date is None:
-            continue
-        iso = _as_utc(r.date).isocalendar()
-        weeks[(iso[0], iso[1])].append(r)
 
-    if not weeks:
+def _find_first_measurement_date(user) -> Optional[datetime.date]:
+    """Return the earliest calendar date that has any Fitbit data for *user*."""
+    first = FitbitData.objects(user=user).order_by("date").first()
+    if not first:
         return None
-
-    best_key = max(weeks, key=lambda k: sum((r.wear_time_minutes or 0) for r in weeks[k]))
-    best_records = weeks[best_key]
-    dates = sorted(_as_utc(r.date) for r in best_records if r.date)
-    return dates[0], dates[-1], best_records
+    return _record_date(first)
 
 
-def _sleep_minutes_raw(r: FitbitData) -> Optional[float]:
-    """Return sleep duration in fractional minutes (intermediate unit for averaging)."""
+def _is_valid_activity_day(r: FitbitData) -> bool:
+    """A day is valid for activity aggregation if wear_time_minutes >= 10 h."""
+    return (r.wear_time_minutes or 0) >= MIN_WEAR_MINUTES
+
+
+def _is_valid_sleep_night(r: FitbitData) -> bool:
+    """A night is valid for sleep aggregation if sleep >= 3 h."""
     try:
-        if r.sleep and r.sleep.sleep_duration:
-            return r.sleep.sleep_duration / 60_000  # ms → minutes
+        if r.sleep is None:
+            return False
+        mins = r.sleep.minutes_asleep
+        if mins is None:
+            dur_ms = r.sleep.sleep_duration or 0
+            mins = dur_ms / 60_000
+        return (mins or 0) >= MIN_SLEEP_MINUTES
+    except Exception:
+        return False
+
+
+def _split_weekday_weekend(
+    records: List[FitbitData],
+    max_weekdays: int = MAX_WEEKDAYS,
+    max_weekends: int = MAX_WEEKENDS,
+) -> Tuple[List[FitbitData], List[FitbitData]]:
+    """
+    Sort records chronologically, then greedily pick up to *max_weekdays*
+    weekdays (Mon–Fri) and *max_weekends* weekend days (Sat–Sun).
+    Returns (selected_weekdays, selected_weekends).
+    """
+    sorted_records = sorted(
+        (r for r in records if _record_date(r) is not None),
+        key=lambda r: _record_date(r),
+    )
+    weekdays: List[FitbitData] = []
+    weekends: List[FitbitData] = []
+    for r in sorted_records:
+        dow = _record_date(r).weekday()  # Monday=0, Sunday=6
+        if dow < 5:
+            if len(weekdays) < max_weekdays:
+                weekdays.append(r)
+        else:
+            if len(weekends) < max_weekends:
+                weekends.append(r)
+    return weekdays, weekends
+
+
+def _sleep_minutes(r: FitbitData) -> Optional[float]:
+    """Return sleep duration in minutes (preferred: minutes_asleep; fallback: sleep_duration ms)."""
+    try:
+        if r.sleep is None:
+            return None
+        if r.sleep.minutes_asleep is not None:
+            return float(r.sleep.minutes_asleep)
+        if r.sleep.sleep_duration:
+            return r.sleep.sleep_duration / 60_000
     except Exception:
         pass
     return None
@@ -114,106 +155,159 @@ def _format_sleep(avg_minutes: float, fmt: str) -> str:
         hh = total_min // 60
         mm = total_min % 60
         return f"{hh:02d}:{mm:02d}"
-    else:  # "hours_int" — COMPASS expects integer 0-24
-        return str(int(round(avg_minutes / 60)))
+    # "hours_int" — COMPASS expects integer 0-24
+    return str(int(round(avg_minutes / 60)))
 
 
-def _compute_averages(records: List[FitbitData], sleep_fmt: str) -> Dict[str, Any]:
-    steps = [r.steps for r in records if r.steps is not None]
-    # active_minutes stores Active Zone Minutes (AZM) — Fitbit's weighted formula
-    # (moderate × 1 + vigorous × 2), matching the REDCap fitbit_pa description.
-    active_min = [r.active_minutes for r in records if r.active_minutes is not None]
-    inactive_min = [r.inactivity_minutes for r in records if r.inactivity_minutes is not None]
-    sleep_min = [m for r in records for m in [_sleep_minutes_raw(r)] if m is not None]
+def _fmt_date(d) -> str:
+    """Format a date as YYYY-MM-DD for REDCap."""
+    if hasattr(d, "strftime"):
+        return d.strftime("%Y-%m-%d")
+    return str(d)
 
-    def _avg_int(vals: list) -> Optional[int]:
-        return round(sum(vals) / len(vals)) if vals else None
 
-    result: Dict[str, Any] = {
-        "fitbit_steps": _avg_int(steps),
-        "fitbit_pa": _avg_int(active_min),
-        "fitbit_inactivity": _avg_int(inactive_min),
-    }
-    if sleep_min:
-        result["sleep_duration"] = _format_sleep(sum(sleep_min) / len(sleep_min), sleep_fmt)
-    return result
-
+# ---------------------------------------------------------------------------
+# Core summarization
+# ---------------------------------------------------------------------------
 
 def _summarize_period(
-    user: Any, period_start: datetime, period_end: datetime, sleep_fmt: str
+    user: Any,
+    window_start: datetime.date,
+    window_end: datetime.date,
+    sleep_fmt: str,
 ) -> Optional[Dict[str, Any]]:
+    """
+    Apply the aggregation spec for a single monitoring window.
+
+    Activity (independent of sleep):
+      1. Fetch all records in window.
+      2. Keep valid activity days (wear_time_minutes >= 600).
+      3. Select earliest 5 weekdays + 2 weekend days.
+      4. Compute means for steps, active_minutes, inactivity_minutes.
+
+    Sleep (independent of activity):
+      1. Same set of records.
+      2. Keep valid sleep nights (sleep >= 180 min).
+      3. Select earliest 5 weekday nights + 2 weekend nights.
+      4. Compute mean sleep duration.
+
+    Returns None when no valid days or nights exist in the window.
+    """
+    start_dt = datetime.combine(window_start, datetime.min.time()).replace(tzinfo=dt_tz.utc)
+    end_dt = datetime.combine(window_end, datetime.max.time()).replace(tzinfo=dt_tz.utc)
+
     records = list(
         FitbitData.objects(
             user=user,
-            date__gte=period_start,
-            date__lt=period_end,
+            date__gte=start_dt,
+            date__lte=end_dt,
         ).order_by("date")
     )
+
     if not records:
         return None
 
-    best = _pick_best_wear_week(records)
-    if not best:
+    # ── Activity selection ──────────────────────────────────────────────────
+    valid_activity = [r for r in records if _is_valid_activity_day(r)]
+    act_weekdays, act_weekends = _split_weekday_weekend(valid_activity)
+    selected_activity = act_weekdays + act_weekends
+
+    # ── Sleep selection ─────────────────────────────────────────────────────
+    valid_sleep = [r for r in records if _is_valid_sleep_night(r)]
+    sleep_weekdays, sleep_weekends = _split_weekday_weekend(valid_sleep)
+    selected_sleep = sleep_weekdays + sleep_weekends
+
+    if not selected_activity and not selected_sleep:
         return None
 
-    week_start, week_end, week_records = best
-    avgs = _compute_averages(week_records, sleep_fmt)
-    return {
-        # date_dmy format required by REDCap
-        "monitoring_start": _fmt_dmy(week_start),
-        "monitoring_end": _fmt_dmy(week_end),
-        "monitoring_days": len(week_records),
-        **avgs,
+    result: Dict[str, Any] = {
+        "monitoring_start": _fmt_date(window_start),
+        "monitoring_end": _fmt_date(window_end),
+        # Valid day / night counts
+        "valid_week_days": len(act_weekdays),
+        "valid_weekend_days": len(act_weekends),
+        "valid_week_nights": len(sleep_weekdays),
+        "valid_weekend_nights": len(sleep_weekends),
     }
 
+    # ── Activity means ──────────────────────────────────────────────────────
+    if selected_activity:
+        steps = [r.steps for r in selected_activity if r.steps is not None]
+        pa = [r.active_minutes for r in selected_activity if r.active_minutes is not None]
+        inact = [r.inactivity_minutes for r in selected_activity if r.inactivity_minutes is not None]
+
+        if steps:
+            result["fitbit_steps"] = round(sum(steps) / len(steps))
+        if pa:
+            result["fitbit_pa"] = round(sum(pa) / len(pa))
+        if inact:
+            result["fitbit_inactivity"] = round(sum(inact) / len(inact))
+
+    # ── Sleep means ─────────────────────────────────────────────────────────
+    if selected_sleep:
+        sleep_mins = [m for r in selected_sleep for m in [_sleep_minutes(r)] if m is not None]
+        if sleep_mins:
+            result["sleep_duration"] = _format_sleep(sum(sleep_mins) / len(sleep_mins), sleep_fmt)
+
+        # sleep_score is not yet available via Fitbit REST API for standard OAuth apps.
+        # Placeholder so the field is present when it becomes available.
+        result["sleep_score"] = None
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
 
 def compute_wearables_summary(patient: Patient) -> Dict[str, Any]:
     """
-    Compute wearables summaries for two periods:
-      - baseline:  first BASELINE_WEEKS weeks after reha_end_date
-      - followup:  last FOLLOWUP_WEEKS weeks before study_end_date
-                   (or 26 weeks after reha_end_date if study_end_date is unset)
+    Compute wearables summaries for baseline and follow-up periods using the
+    protocol-specified windows anchored to the first Fitbit measurement date.
 
-    sleep_duration format is determined per project:
-      COMPASS → integer hours (0-24)
-      COPAIN  → HH:MM time string
+    Baseline  (visit_baseline): Day 8–28 after first measurement
+    Follow-up (visit_6m):       Day 150–180 after first measurement
 
-    Returns {"baseline": {...} or None, "followup": {...} or None}
-    Raises ValueError if patient has no reha_end_date or userId.
+    The first 7 days after Fitbit activation are excluded to allow
+    device habituation.
+
+    Returns {"baseline": {...} or None, "followup": {...} or None}.
+    Raises WearablesSyncError if no Fitbit data exists for the patient.
     """
-    if not patient.reha_end_date:
+    try:
+        user = patient.userId
+    except Exception as e:
+        raise ValueError(
+            f"Could not resolve userId for patient {patient.patient_code}: {e}"
+        ) from e
+
+    first_date = _find_first_measurement_date(user)
+    if not first_date:
         raise WearablesSyncError(
-            f"Patient {patient.patient_code} is missing the Rehabilitation End Date. "
-            "Please set it in the patient profile before syncing.",
-            code="wearables_missing_reha_end_date",
+            f"No Fitbit data found for patient {patient.patient_code}. "
+            "The device must be worn before wearables can be exported to REDCap.",
+            code="wearables_no_fitbit_data",
         )
 
     project_name = (patient.project or "").strip().upper()
     proj_cfg = _PROJECT_CONFIG.get(project_name, {})
     sleep_fmt = proj_cfg.get("sleep_duration_format", "hours_int")
 
-    reha_end = _as_utc(patient.reha_end_date)
-    study_end_raw = patient.study_end_date
-    study_end = _as_utc(study_end_raw) if study_end_raw else reha_end + timedelta(weeks=26)
+    # Day N means first_date + (N-1) days  →  Day 8 = first_date + 7
+    baseline_start = first_date + timedelta(days=BASELINE_DAY_START - 1)
+    baseline_end = first_date + timedelta(days=BASELINE_DAY_END - 1)
+    followup_start = first_date + timedelta(days=FOLLOWUP_DAY_START - 1)
+    followup_end = first_date + timedelta(days=FOLLOWUP_DAY_END - 1)
 
-    # baseline_anchor controls which side of reha_end_date to scan.
-    # "before_reha_end" — data collected before discharge (e.g. COPAIN in-hospital).
-    # "after_reha_end"  — data collected after discharge (default, e.g. COMPASS outpatient).
-    baseline_anchor = proj_cfg.get("baseline_anchor", "after_reha_end")
-    if baseline_anchor == "before_reha_end":
-        baseline_start = reha_end - timedelta(weeks=BASELINE_WEEKS)
-        baseline_end = reha_end
-    else:
-        baseline_start = reha_end
-        baseline_end = reha_end + timedelta(weeks=BASELINE_WEEKS)
-
-    followup_start = study_end - timedelta(weeks=FOLLOWUP_WEEKS)
-    followup_end = study_end
-
-    try:
-        user = patient.userId  # triggers MongoEngine dereference
-    except Exception as e:
-        raise ValueError(f"Could not resolve userId for patient {patient.patient_code}: {e}") from e
+    logger.info(
+        "[wearables] %s first_date=%s  baseline=%s–%s  followup=%s–%s",
+        patient.patient_code,
+        first_date,
+        baseline_start,
+        baseline_end,
+        followup_start,
+        followup_end,
+    )
 
     return {
         "baseline": _summarize_period(user, baseline_start, baseline_end, sleep_fmt),
@@ -226,33 +320,24 @@ def _resolve_event_names(
     event_baseline: Optional[str],
     event_followup: Optional[str],
 ) -> Tuple[Optional[str], Optional[str]]:
-    """
-    Resolve REDCap event names with priority:
-      1. Explicit argument (from API call / task parameter)
-      2. Environment variable
-      3. Built-in per-project defaults (_PROJECT_EVENTS)
-      4. None (works for non-longitudinal / classic projects)
-    """
     proj_defaults = _PROJECT_CONFIG.get(project_name.upper(), {})
-
     ev_baseline = (
-        event_baseline or os.environ.get("REDCAP_WEARABLES_EVENT_BASELINE", "").strip() or proj_defaults.get("baseline")
+        event_baseline
+        or os.environ.get("REDCAP_WEARABLES_EVENT_BASELINE", "").strip()
+        or proj_defaults.get("baseline")
     ) or None
-
     ev_followup = (
-        event_followup or os.environ.get("REDCAP_WEARABLES_EVENT_FOLLOWUP", "").strip() or proj_defaults.get("followup")
+        event_followup
+        or os.environ.get("REDCAP_WEARABLES_EVENT_FOLLOWUP", "").strip()
+        or proj_defaults.get("followup")
     ) or None
-
     return ev_baseline, ev_followup
 
 
 def _import_record(token: str, payload: Dict[str, Any], record: Dict[str, Any]) -> None:
     """
-    POST a wearables record to REDCap.  On 400 with invalid field names (the
-    same error REDCap returns for mismatched instrument field names across
-    projects), strips the offending fields and retries once — mirroring the
-    behaviour of _post_redcap_with_field_fallback used on the read side.
-    Raises RedcapError on final failure.
+    POST a wearables record to REDCap.  On 400 with invalid field names, strip
+    the offending fields and retry once.
     """
     try:
         _post_redcap(token, payload)
@@ -276,72 +361,94 @@ def export_wearables_to_redcap(
     event_baseline: Optional[str] = None,
     event_followup: Optional[str] = None,
     return_payloads: bool = False,
-) -> Dict[str, str] | Tuple[Dict[str, str], Dict[str, Dict[str, Any]]]:
+    skip_if_populated: bool = True,
+) -> "Dict[str, str] | Tuple[Dict[str, str], Dict[str, Dict[str, Any]]]":
     """
     Compute wearables summary for both periods and import into REDCap.
 
-    For COMPASS, event names default to visit_baseline_arm_1 / visit_6m_arm_1.
-    Override per-call or via REDCAP_WEARABLES_EVENT_BASELINE / FOLLOWUP env vars.
+    skip_if_populated (default True):
+        If monitoring_start is already set for a given event in REDCap, that
+        period is skipped to avoid overwriting previously validated data.
+        Pass False to force recalculation.
 
-    Returns {"baseline": "ok" | "skipped" | "error: ...", "followup": ...}
-    Optionally returns payload details when return_payloads=True:
-      (results, payloads)
+    Returns {"baseline": "ok"|"skipped"|"error: ...", "followup": ...}.
+    Optionally returns payload details when return_payloads=True.
     """
     project_name = (patient.project or "").strip()
     if not project_name:
         raise WearablesSyncError(
-            f"Patient {patient.patient_code} has no REDCap project assigned. "
-            "Please set the project in the patient profile before syncing.",
+            f"Patient {patient.patient_code} has no REDCap project assigned.",
             code="wearables_missing_project",
         )
 
     project = resolve_project(project_name)
     token = get_token_for_project(project)
 
-    # Look up the REDCap record_id (authoritative primary key for import)
     rows = export_record_by_pat_id(project_name, patient.patient_code)
     if not rows:
         raise ValueError(
-            f"No REDCap record found for patient_code={patient.patient_code} " f"in project={project_name}"
+            f"No REDCap record found for patient_code={patient.patient_code} "
+            f"in project={project_name}"
         )
     record_id = str(rows[0].get("record_id") or "").strip()
     if not record_id:
         raise ValueError(f"REDCap record for {patient.patient_code} has no record_id")
+
+    # Build a lookup of existing REDCap data keyed by event name
+    existing_by_event: Dict[str, Dict] = {}
+    if skip_if_populated:
+        for row in rows:
+            ev = row.get("redcap_event_name", "")
+            if ev:
+                existing_by_event[ev] = row
 
     summary = compute_wearables_summary(patient)
     ev_baseline, ev_followup = _resolve_event_names(project_name, event_baseline, event_followup)
 
     results: Dict[str, str] = {}
     payloads: Dict[str, Dict[str, Any]] = {}
+
     for period, ev_name in [("baseline", ev_baseline), ("followup", ev_followup)]:
         data = summary.get(period)
+
         if not data:
             results[period] = "skipped"
-            payloads[period] = {
-                "status": "skipped",
-                "reason": "no_fitbit_data_in_period",
-            }
+            payloads[period] = {"status": "skipped", "reason": "no_fitbit_data_in_period"}
             logger.info(
-                "Wearables [%s] for %s: no Fitbit data in period — skipped",
+                "Wearables [%s] for %s: no valid Fitbit data in window — skipped",
                 period,
                 patient.patient_code,
             )
             continue
 
+        # Skip if already populated in REDCap (duplicate-protection)
+        if skip_if_populated and ev_name:
+            existing = existing_by_event.get(ev_name, {})
+            if existing.get("monitoring_start", "").strip():
+                results[period] = "skipped"
+                payloads[period] = {
+                    "status": "skipped",
+                    "reason": "already_populated",
+                    "existing_start": existing.get("monitoring_start"),
+                }
+                logger.info(
+                    "Wearables [%s] for %s: REDCap event %s already has monitoring_start=%s — skipped",
+                    period,
+                    patient.patient_code,
+                    ev_name,
+                    existing.get("monitoring_start"),
+                )
+                continue
+
         record: Dict[str, Any] = {
             "record_id": record_id,
             **{k: str(v) for k, v in data.items() if v is not None},
-            # Mark form as Unverified so research team can review before marking Complete
-            "wearables_complete": "1",
+            "wearables_complete": "1",  # Unverified — research team reviews before Complete
         }
         if ev_name:
             record["redcap_event_name"] = ev_name
 
-        payloads[period] = {
-            "status": "prepared",
-            "record": record,
-        }
-
+        payloads[period] = {"status": "prepared", "record": record}
         payload = {
             "content": "record",
             "action": "import",
@@ -352,6 +459,7 @@ def export_wearables_to_redcap(
             "returnFormat": "json",
             "data": json.dumps([record]),
         }
+
         try:
             _import_record(token, payload, record)
             results[period] = "ok"

--- a/backend/core/services/wearables_redcap_service.py
+++ b/backend/core/services/wearables_redcap_service.py
@@ -29,14 +29,14 @@ class WearablesSyncError(ValueError):
 # ---------------------------------------------------------------------------
 # Window definitions (days relative to first Fitbit measurement date, 1-indexed)
 # ---------------------------------------------------------------------------
-BASELINE_DAY_START = 8    # first 7 days are excluded (device calibration / habituation)
+BASELINE_DAY_START = 8  # first 7 days are excluded (device calibration / habituation)
 BASELINE_DAY_END = 28
 FOLLOWUP_DAY_START = 150
 FOLLOWUP_DAY_END = 180
 
 # Validity thresholds
-MIN_WEAR_MINUTES = 600    # 10 hours — minimum for a valid activity day
-MIN_SLEEP_MINUTES = 180   # 3 hours  — minimum for a valid sleep night
+MIN_WEAR_MINUTES = 600  # 10 hours — minimum for a valid activity day
+MIN_SLEEP_MINUTES = 180  # 3 hours  — minimum for a valid sleep night
 
 # Day-selection targets per window
 MAX_WEEKDAYS = 5
@@ -63,6 +63,7 @@ _PROJECT_EVENTS = _PROJECT_CONFIG
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
 
 def _as_utc(dt: datetime) -> datetime:
     if dt.tzinfo is None:
@@ -170,6 +171,7 @@ def _fmt_date(d) -> str:
 # Core summarization
 # ---------------------------------------------------------------------------
 
+
 def _summarize_period(
     user: Any,
     window_start: datetime.date,
@@ -260,6 +262,7 @@ def _summarize_period(
 # Public API
 # ---------------------------------------------------------------------------
 
+
 def compute_wearables_summary(patient: Patient) -> Dict[str, Any]:
     """
     Compute wearables summaries for baseline and follow-up periods using the
@@ -277,9 +280,7 @@ def compute_wearables_summary(patient: Patient) -> Dict[str, Any]:
     try:
         user = patient.userId
     except Exception as e:
-        raise ValueError(
-            f"Could not resolve userId for patient {patient.patient_code}: {e}"
-        ) from e
+        raise ValueError(f"Could not resolve userId for patient {patient.patient_code}: {e}") from e
 
     first_date = _find_first_measurement_date(user)
     if not first_date:
@@ -322,14 +323,10 @@ def _resolve_event_names(
 ) -> Tuple[Optional[str], Optional[str]]:
     proj_defaults = _PROJECT_CONFIG.get(project_name.upper(), {})
     ev_baseline = (
-        event_baseline
-        or os.environ.get("REDCAP_WEARABLES_EVENT_BASELINE", "").strip()
-        or proj_defaults.get("baseline")
+        event_baseline or os.environ.get("REDCAP_WEARABLES_EVENT_BASELINE", "").strip() or proj_defaults.get("baseline")
     ) or None
     ev_followup = (
-        event_followup
-        or os.environ.get("REDCAP_WEARABLES_EVENT_FOLLOWUP", "").strip()
-        or proj_defaults.get("followup")
+        event_followup or os.environ.get("REDCAP_WEARABLES_EVENT_FOLLOWUP", "").strip() or proj_defaults.get("followup")
     ) or None
     return ev_baseline, ev_followup
 
@@ -387,8 +384,7 @@ def export_wearables_to_redcap(
     rows = export_record_by_pat_id(project_name, patient.patient_code)
     if not rows:
         raise ValueError(
-            f"No REDCap record found for patient_code={patient.patient_code} "
-            f"in project={project_name}"
+            f"No REDCap record found for patient_code={patient.patient_code} " f"in project={project_name}"
         )
     record_id = str(rows[0].get("record_id") or "").strip()
     if not record_id:

--- a/backend/tests/wearables_redcap/test_wearables_redcap_service.py
+++ b/backend/tests/wearables_redcap/test_wearables_redcap_service.py
@@ -2,53 +2,33 @@
 Wearables → REDCap service tests
 =================================
 
-Unit and integration tests for core/services/wearables_redcap_service.py
-
-Coverage
---------
-Pure-function unit tests (no DB):
-  - _fmt_dmy              date formatted as YYYY-MM-DD (REDCap import format)
-  - _format_sleep         COMPASS: integer hours / COPAIN: HH:MM
-  - _pick_best_wear_week  picks ISO week with highest total wear_time_minutes
-  - _compute_averages     per-field daily averages, correct sleep format
-  - _resolve_event_names  priority: arg > env var > per-project default
-
-DB-backed tests (mongomock):
-  - compute_wearables_summary
-      · raises ValueError when reha_end_date is missing
-      · returns None for both periods when no Fitbit data exists
-      · returns correct averages when data exists in baseline period
-      · applies study_end_date if set; falls back to +26 weeks otherwise
-      · selects the week with highest wear time, not the first week
-      · uses correct sleep format per project (hours vs HH:MM)
-  - export_wearables_to_redcap
-      · raises ValueError when patient has no project
-      · raises ValueError when no REDCap record is found
-      · writes correct payload to REDCap including record_id, event name,
-        wearables_complete="1", and YYYY-MM-DD formatted dates
-      · returns "skipped" for a period with no Fitbit data
-      · captures RedcapError and returns "error: ..." string
+Tests for the new protocol-specified aggregation logic:
+  - Baseline: Day 8–28 after first Fitbit measurement date
+  - Follow-up: Day 150–180 after first Fitbit measurement date
+  - Valid activity day: wear_time_minutes >= 600 (10 hours)
+  - Valid sleep night: sleep >= 180 minutes (3 hours)
+  - Selection: earliest 5 weekdays + 2 weekend days (independently for activity and sleep)
 """
 
 import json
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, date
 from datetime import timezone as dt_tz
-from types import SimpleNamespace
 from unittest.mock import patch
 
 import mongomock
 import pytest
 from bson import ObjectId
 
-import core.services.wearables_redcap_service as svc
 from core.models import FitbitData, Patient, SleepData, Therapist, User
 from core.services.redcap_service import RedcapError
 from core.services.wearables_redcap_service import (
-    _compute_averages,
-    _fmt_dmy,
+    MIN_SLEEP_MINUTES,
+    MIN_WEAR_MINUTES,
     _format_sleep,
-    _pick_best_wear_week,
+    _is_valid_activity_day,
+    _is_valid_sleep_night,
     _resolve_event_names,
+    _split_weekday_weekend,
     compute_wearables_summary,
     export_wearables_to_redcap,
 )
@@ -76,8 +56,7 @@ def mongo_mock():
     disconnect(alias)
 
 
-def _make_patient(project="COMPASS", reha_end_date=None, study_end_date=None):
-    """Create a minimal User + Therapist + Patient graph."""
+def _make_patient(project="COMPASS"):
     th_user = User(
         username=f"th-{ObjectId()}",
         email=f"th-{ObjectId()}@example.com",
@@ -86,7 +65,6 @@ def _make_patient(project="COMPASS", reha_end_date=None, study_end_date=None):
         isActive=True,
     ).save()
     th = Therapist(userId=th_user, clinics=["Inselspital"], projects=[project]).save()
-
     pt_user = User(
         username=f"pt-{ObjectId()}",
         email=f"pt-{ObjectId()}@example.com",
@@ -99,18 +77,24 @@ def _make_patient(project="COMPASS", reha_end_date=None, study_end_date=None):
         patient_code=f"P-{ObjectId()}",
         therapist=th,
         project=project,
-        reha_end_date=reha_end_date,
-        study_end_date=study_end_date,
     ).save()
     return pt_user, patient
 
 
-def _make_fitbit_day(user, date: datetime, steps=5000, active_min=30, inactive_min=300, wear_min=600, sleep_ms=None):
-    """Save a single FitbitData record and return it."""
-    sleep = SleepData(sleep_duration=sleep_ms) if sleep_ms is not None else None
+def _make_fitbit_day(
+    user,
+    date_dt: datetime,
+    steps=5000,
+    active_min=30,
+    inactive_min=300,
+    wear_min=700,       # valid by default (>= 600)
+    sleep_min=420,      # valid by default (>= 180 min) — stored as minutes_asleep
+):
+    """Create a FitbitData record. sleep_min=None skips sleep entirely."""
+    sleep = SleepData(minutes_asleep=sleep_min) if sleep_min is not None else None
     return FitbitData(
         user=user,
-        date=date,
+        date=date_dt,
         steps=steps,
         active_minutes=active_min,
         inactivity_minutes=inactive_min,
@@ -120,126 +104,114 @@ def _make_fitbit_day(user, date: datetime, steps=5000, active_min=30, inactive_m
 
 
 # ---------------------------------------------------------------------------
-# Pure-function unit tests
+# Unit tests — pure functions
 # ---------------------------------------------------------------------------
 
 
-def test_fmt_dmy():
-    d = datetime(2024, 3, 5, tzinfo=dt_tz.utc)
-    assert _fmt_dmy(d) == "2024-03-05"
+class TestIsValidActivityDay:
+    def test_valid_when_wear_time_meets_threshold(self):
+        r = FitbitData(wear_time_minutes=MIN_WEAR_MINUTES)
+        assert _is_valid_activity_day(r) is True
 
-    d2 = datetime(2024, 12, 31, tzinfo=dt_tz.utc)
-    assert _fmt_dmy(d2) == "2024-12-31"
+    def test_valid_when_wear_time_exceeds_threshold(self):
+        r = FitbitData(wear_time_minutes=MIN_WEAR_MINUTES + 1)
+        assert _is_valid_activity_day(r) is True
+
+    def test_invalid_when_wear_time_below_threshold(self):
+        r = FitbitData(wear_time_minutes=MIN_WEAR_MINUTES - 1)
+        assert _is_valid_activity_day(r) is False
+
+    def test_invalid_when_wear_time_is_none(self):
+        r = FitbitData(wear_time_minutes=None)
+        assert _is_valid_activity_day(r) is False
+
+    def test_invalid_when_wear_time_is_zero(self):
+        r = FitbitData(wear_time_minutes=0)
+        assert _is_valid_activity_day(r) is False
+
+
+class TestIsValidSleepNight:
+    def test_valid_when_minutes_asleep_meets_threshold(self):
+        r = FitbitData(sleep=SleepData(minutes_asleep=MIN_SLEEP_MINUTES))
+        assert _is_valid_sleep_night(r) is True
+
+    def test_invalid_when_minutes_asleep_below_threshold(self):
+        r = FitbitData(sleep=SleepData(minutes_asleep=MIN_SLEEP_MINUTES - 1))
+        assert _is_valid_sleep_night(r) is False
+
+    def test_falls_back_to_sleep_duration_ms_when_minutes_asleep_absent(self):
+        # 3h = 180 min = 10800000 ms
+        r = FitbitData(sleep=SleepData(sleep_duration=10_800_000, minutes_asleep=None))
+        assert _is_valid_sleep_night(r) is True
+
+    def test_invalid_when_no_sleep_at_all(self):
+        r = FitbitData(sleep=None)
+        assert _is_valid_sleep_night(r) is False
+
+    def test_invalid_when_sleep_too_short_via_duration(self):
+        r = FitbitData(sleep=SleepData(sleep_duration=3_600_000, minutes_asleep=None))  # 1h
+        assert _is_valid_sleep_night(r) is False
+
+
+class TestSplitWeekdayWeekend:
+    """
+    2024-01-08 = Monday, 09=Tue, 10=Wed, 11=Thu, 12=Fri, 13=Sat, 14=Sun, 15=Mon
+    """
+
+    def _day(self, user, offset_from_monday: int, wear_min=700):
+        base = datetime(2024, 1, 8, tzinfo=dt_tz.utc)
+        return _make_fitbit_day(user, base + timedelta(days=offset_from_monday), wear_min=wear_min)
+
+    def test_selects_up_to_5_weekdays(self):
+        user, _ = _make_patient()
+        records = [self._day(user, i) for i in range(7)]  # Mon–Sun
+        weekdays, weekends = _split_weekday_weekend(records)
+        assert len(weekdays) == 5   # Mon–Fri
+        assert len(weekends) == 2   # Sat–Sun
+
+    def test_caps_weekdays_at_5_even_with_more_available(self):
+        user, _ = _make_patient()
+        # 8 weekdays (two full weeks)
+        records = [self._day(user, i) for i in range(14) if i % 7 < 5]
+        weekdays, weekends = _split_weekday_weekend(records)
+        assert len(weekdays) == 5
+
+    def test_caps_weekends_at_2(self):
+        user, _ = _make_patient()
+        # 4 weekend days (two weekends)
+        records = [self._day(user, i) for i in range(14) if i % 7 >= 5]
+        weekdays, weekends = _split_weekday_weekend(records)
+        assert len(weekends) == 2
+
+    def test_returns_fewer_when_not_enough_days(self):
+        user, _ = _make_patient()
+        records = [self._day(user, 0), self._day(user, 1)]  # Mon, Tue only
+        weekdays, weekends = _split_weekday_weekend(records)
+        assert len(weekdays) == 2
+        assert len(weekends) == 0
+
+    def test_picks_earliest_days(self):
+        user, _ = _make_patient()
+        early_mon = self._day(user, 0)   # 2024-01-08 Mon — should be selected (earliest)
+        late_mon = self._day(user, 7)    # 2024-01-15 Mon — should not be selected (6th weekday)
+        tue = self._day(user, 1)
+        wed = self._day(user, 2)
+        thu = self._day(user, 3)
+        fri = self._day(user, 4)
+        weekdays, _ = _split_weekday_weekend([early_mon, tue, wed, thu, fri, late_mon])
+        assert early_mon in weekdays
+        assert late_mon not in weekdays
 
 
 class TestFormatSleep:
     def test_compass_integer_hours(self):
-        # 450 minutes = 7.5 hours → rounds to 8
-        assert _format_sleep(450, "hours_int") == "8"
-        # 420 minutes = 7.0 hours exactly
         assert _format_sleep(420, "hours_int") == "7"
+        assert _format_sleep(450, "hours_int") == "8"  # rounds to nearest
 
     def test_copain_hhmm(self):
-        # 450 minutes = 07:30
         assert _format_sleep(450, "hhmm") == "07:30"
-        # 495 minutes = 08:15
-        assert _format_sleep(495, "hhmm") == "08:15"
-        # 0 minutes = 00:00
         assert _format_sleep(0, "hhmm") == "00:00"
-        # 23h59m = 1439 minutes
         assert _format_sleep(1439, "hhmm") == "23:59"
-
-    def test_unknown_format_falls_back_to_hours_int(self):
-        # unknown format treated as hours_int
-        assert _format_sleep(480, "unknown") == "8"
-
-
-class TestPickBestWearWeek:
-    def test_empty_returns_none(self):
-        assert _pick_best_wear_week([]) is None
-
-    def test_single_day_returns_that_week(self):
-        user, patient = _make_patient()
-        day = datetime(2024, 3, 4, tzinfo=dt_tz.utc)  # ISO week 10
-        r = _make_fitbit_day(user, day, wear_min=300)
-        result = _pick_best_wear_week([r])
-        assert result is not None
-        _, _, records = result
-        assert len(records) == 1
-
-    def test_picks_week_with_highest_wear_time(self):
-        user, patient = _make_patient()
-        # Week A (ISO 2024-W10): 3 days, total wear = 100+100+100 = 300
-        week_a = [
-            _make_fitbit_day(user, datetime(2024, 3, 4, tzinfo=dt_tz.utc), wear_min=100),
-            _make_fitbit_day(user, datetime(2024, 3, 5, tzinfo=dt_tz.utc), wear_min=100),
-            _make_fitbit_day(user, datetime(2024, 3, 6, tzinfo=dt_tz.utc), wear_min=100),
-        ]
-        # Week B (ISO 2024-W11): 3 days, total wear = 200+200+200 = 600  ← best
-        week_b = [
-            _make_fitbit_day(user, datetime(2024, 3, 11, tzinfo=dt_tz.utc), wear_min=200),
-            _make_fitbit_day(user, datetime(2024, 3, 12, tzinfo=dt_tz.utc), wear_min=200),
-            _make_fitbit_day(user, datetime(2024, 3, 13, tzinfo=dt_tz.utc), wear_min=200),
-        ]
-        result = _pick_best_wear_week(week_a + week_b)
-        assert result is not None
-        _, _, records = result
-        assert set(r.date for r in records) == set(r.date for r in week_b)
-
-    def test_ignores_records_with_none_date(self):
-        user, patient = _make_patient()
-        good = _make_fitbit_day(user, datetime(2024, 3, 4, tzinfo=dt_tz.utc), wear_min=300)
-        bad = SimpleNamespace(date=None, wear_time_minutes=999)
-        result = _pick_best_wear_week([good, bad])
-        assert result is not None
-        _, _, records = result
-        assert good in records
-        assert bad not in records
-
-
-class TestComputeAverages:
-    def test_basic_averages(self):
-        user, patient = _make_patient()
-        records = [
-            _make_fitbit_day(
-                user, datetime(2024, 3, d, tzinfo=dt_tz.utc), steps=s, active_min=a, inactive_min=i, wear_min=600
-            )
-            for d, s, a, i in [(4, 4000, 20, 400), (5, 6000, 40, 200)]
-        ]
-        avgs = _compute_averages(records, "hours_int")
-        assert avgs["fitbit_steps"] == 5000  # (4000+6000)/2
-        assert avgs["fitbit_pa"] == 30  # (20+40)/2
-        assert avgs["fitbit_inactivity"] == 300  # (400+200)/2
-
-    def test_sleep_compass_hours_int(self):
-        user, patient = _make_patient()
-        # 7h = 7*3600000 ms = 25200000 ms → 420 min → "7" hours
-        records = [_make_fitbit_day(user, datetime(2024, 3, 4, tzinfo=dt_tz.utc), sleep_ms=7 * 3_600_000)]
-        avgs = _compute_averages(records, "hours_int")
-        assert avgs["sleep_duration"] == "7"
-
-    def test_sleep_copain_hhmm(self):
-        user, patient = _make_patient()
-        # 7.5h = 450 min → "07:30"
-        records = [_make_fitbit_day(user, datetime(2024, 3, 4, tzinfo=dt_tz.utc), sleep_ms=int(7.5 * 3_600_000))]
-        avgs = _compute_averages(records, "hhmm")
-        assert avgs["sleep_duration"] == "07:30"
-
-    def test_missing_sleep_omitted(self):
-        user, patient = _make_patient()
-        records = [_make_fitbit_day(user, datetime(2024, 3, 4, tzinfo=dt_tz.utc), sleep_ms=None)]
-        avgs = _compute_averages(records, "hours_int")
-        assert "sleep_duration" not in avgs
-
-    def test_none_fields_excluded_from_average(self):
-        """Records where steps/active/inactive are None should not drag down the average."""
-        user, patient = _make_patient()
-        r1 = _make_fitbit_day(user, datetime(2024, 3, 4, tzinfo=dt_tz.utc), steps=8000)
-        r2 = _make_fitbit_day(user, datetime(2024, 3, 5, tzinfo=dt_tz.utc), steps=None)
-        r2.steps = None
-        avgs = _compute_averages([r1, r2], "hours_int")
-        # Only r1 has steps, so average = 8000
-        assert avgs["fitbit_steps"] == 8000
 
 
 class TestResolveEventNames:
@@ -260,20 +232,12 @@ class TestResolveEventNames:
 
     def test_env_var_overrides_project_default(self, monkeypatch):
         monkeypatch.setenv("REDCAP_WEARABLES_EVENT_BASELINE", "env_baseline")
-        monkeypatch.setenv("REDCAP_WEARABLES_EVENT_FOLLOWUP", "env_followup")
-        b, f = _resolve_event_names("COMPASS", None, None)
+        b, _ = _resolve_event_names("COMPASS", None, None)
         assert b == "env_baseline"
-        assert f == "env_followup"
-
-    def test_explicit_arg_overrides_env_var(self, monkeypatch):
-        monkeypatch.setenv("REDCAP_WEARABLES_EVENT_BASELINE", "env_baseline")
-        b, f = _resolve_event_names("COMPASS", "explicit_baseline", None)
-        assert b == "explicit_baseline"
 
     def test_unknown_project_returns_none(self):
-        b, f = _resolve_event_names("UNKNOWN_PROJECT", None, None)
-        assert b is None
-        assert f is None
+        b, f = _resolve_event_names("UNKNOWN", None, None)
+        assert b is None and f is None
 
 
 # ---------------------------------------------------------------------------
@@ -282,302 +246,278 @@ class TestResolveEventNames:
 
 
 class TestComputeWearablesSummary:
-    def test_raises_if_no_reha_end_date(self):
-        _, patient = _make_patient(reha_end_date=None)
-        with pytest.raises(ValueError, match="Rehabilitation End Date"):
+    """
+    First measurement date = 2024-01-01 (Monday).
+    Baseline window:  Day 8–28  = 2024-01-08 – 2024-01-28
+    Follow-up window: Day 150–180 = 2024-05-29 – 2024-06-28
+    """
+
+    FIRST_DATE = datetime(2024, 1, 1, tzinfo=dt_tz.utc)
+
+    def _anchor(self, user):
+        """Seed a Day-1 record so first_date is always 2024-01-01."""
+        _make_fitbit_day(user, self.FIRST_DATE, steps=0, wear_min=0, sleep_min=None)
+
+    def _in_baseline(self, offset_from_day8: int) -> datetime:
+        """Day 8 + offset."""
+        return self.FIRST_DATE + timedelta(days=7 + offset_from_day8)
+
+    def _in_followup(self, offset_from_day150: int) -> datetime:
+        return self.FIRST_DATE + timedelta(days=149 + offset_from_day150)
+
+    def test_raises_when_no_fitbit_data(self):
+        _, patient = _make_patient()
+        with pytest.raises(Exception, match="No Fitbit data"):
             compute_wearables_summary(patient)
 
-    def test_returns_none_for_both_periods_when_no_fitbit_data(self):
-        reha_end = datetime(2024, 1, 1, tzinfo=dt_tz.utc)
-        _, patient = _make_patient(reha_end_date=reha_end)
-        summary = compute_wearables_summary(patient)
-        assert summary["baseline"] is None
-        assert summary["followup"] is None
-
-    def test_baseline_period_covers_first_4_weeks(self):
-        reha_end = datetime(2024, 1, 1, tzinfo=dt_tz.utc)
-        user, patient = _make_patient(reha_end_date=reha_end)
-
-        # Day 3 after reha_end — inside baseline (first 4 weeks)
-        in_baseline = reha_end + timedelta(days=3)
-        _make_fitbit_day(user, in_baseline, steps=1000, wear_min=500)
-
+    def test_baseline_window_is_day_8_to_28(self):
+        """Data on Day 7 (excluded period) must not appear in baseline."""
+        user, patient = _make_patient()
+        self._anchor(user)
+        # Day 7 — excluded
+        _make_fitbit_day(user, self.FIRST_DATE + timedelta(days=6), steps=9999)
+        # Day 8 — first valid baseline day
+        _make_fitbit_day(user, self._in_baseline(0), steps=1000)
         summary = compute_wearables_summary(patient)
         assert summary["baseline"] is not None
         assert summary["baseline"]["fitbit_steps"] == 1000
 
-    def test_data_outside_baseline_not_included(self):
-        reha_end = datetime(2024, 1, 1, tzinfo=dt_tz.utc)
-        user, patient = _make_patient(reha_end_date=reha_end)
-
-        # Day 35 — outside baseline (> 4 weeks = 28 days) but inside follow-up
-        outside = reha_end + timedelta(days=35)
-        _make_fitbit_day(user, outside, steps=9999, wear_min=600)
-
+    def test_data_before_day_8_excluded_from_baseline(self):
+        user, patient = _make_patient()
+        # Only data on Day 1 (excluded period); anchors first_date and proves window is empty
+        _make_fitbit_day(user, self.FIRST_DATE, steps=9999)
         summary = compute_wearables_summary(patient)
         assert summary["baseline"] is None
 
-    def test_followup_uses_study_end_date_when_set(self):
-        reha_end = datetime(2024, 1, 1, tzinfo=dt_tz.utc)
-        study_end = datetime(2024, 7, 1, tzinfo=dt_tz.utc)  # 6 months later
-        user, patient = _make_patient(reha_end_date=reha_end, study_end_date=study_end)
-        # Put data in the last 4 weeks before study_end
-        in_followup = study_end - timedelta(days=10)
-        _make_fitbit_day(user, in_followup, steps=7777, wear_min=500)
+    def test_data_after_day_28_excluded_from_baseline(self):
+        user, patient = _make_patient()
+        self._anchor(user)
+        # Day 29 — outside baseline
+        _make_fitbit_day(user, self.FIRST_DATE + timedelta(days=28), steps=9999)
+        summary = compute_wearables_summary(patient)
+        assert summary["baseline"] is None
 
+    def test_followup_window_is_day_150_to_180(self):
+        user, patient = _make_patient()
+        self._anchor(user)
+        _make_fitbit_day(user, self._in_followup(0), steps=7777)
         summary = compute_wearables_summary(patient)
         assert summary["followup"] is not None
         assert summary["followup"]["fitbit_steps"] == 7777
 
-    def test_followup_defaults_to_26_weeks_when_no_study_end_date(self):
-        reha_end = datetime(2024, 1, 1, tzinfo=dt_tz.utc)
-        default_study_end = reha_end + timedelta(weeks=26)
-        user, patient = _make_patient(reha_end_date=reha_end, study_end_date=None)
-
-        # Put data in the last 4 weeks of the default 26-week window
-        in_followup = default_study_end - timedelta(days=10)
-        _make_fitbit_day(user, in_followup, steps=4444, wear_min=500)
-
+    def test_monitoring_start_end_are_window_boundaries_not_data_boundaries(self):
+        """monitoring_start/end must reflect the protocol window, not the earliest/latest data."""
+        user, patient = _make_patient()
+        self._anchor(user)
+        # Only one day of data, in the middle of the baseline window
+        _make_fitbit_day(user, self._in_baseline(5))  # Day 13
         summary = compute_wearables_summary(patient)
-        assert summary["followup"] is not None
-        assert summary["followup"]["fitbit_steps"] == 4444
+        # Window is Day 8–28 → 2024-01-08 – 2024-01-28
+        assert summary["baseline"]["monitoring_start"] == "2024-01-08"
+        assert summary["baseline"]["monitoring_end"] == "2024-01-28"
 
-    def test_picks_best_wear_week_not_first_week(self):
-        reha_end = datetime(2024, 1, 1, tzinfo=dt_tz.utc)
-        user, patient = _make_patient(reha_end_date=reha_end)
-
-        # Week 1 (days 2-3): low wear, steps=1000
-        _make_fitbit_day(user, reha_end + timedelta(days=2), steps=1000, wear_min=100)
-        _make_fitbit_day(user, reha_end + timedelta(days=3), steps=1000, wear_min=100)
-
-        # Week 2 (days 9-10): high wear, steps=9000  ← should be selected
-        _make_fitbit_day(user, reha_end + timedelta(days=9), steps=9000, wear_min=600)
-        _make_fitbit_day(user, reha_end + timedelta(days=10), steps=9000, wear_min=600)
-
+    def test_only_valid_activity_days_count(self):
+        """Days below 10h wear time must not contribute to activity averages."""
+        user, patient = _make_patient()
+        self._anchor(user)
+        # Invalid day: wear_min=300 (< 600), steps=9999
+        _make_fitbit_day(user, self._in_baseline(0), steps=9999, wear_min=300)
+        # Valid day: wear_min=700, steps=1000
+        _make_fitbit_day(user, self._in_baseline(1), steps=1000, wear_min=700)
         summary = compute_wearables_summary(patient)
-        assert summary["baseline"]["fitbit_steps"] == 9000
+        assert summary["baseline"]["fitbit_steps"] == 1000
+        assert summary["baseline"]["valid_week_days"] == 1
+
+    def test_only_valid_sleep_nights_count(self):
+        """Nights below 3h sleep must not contribute to sleep averages."""
+        user, patient = _make_patient()
+        self._anchor(user)
+        # Invalid night: 60 min sleep
+        _make_fitbit_day(user, self._in_baseline(0), sleep_min=60)
+        # Valid night: 420 min sleep
+        _make_fitbit_day(user, self._in_baseline(1), sleep_min=420)
+        summary = compute_wearables_summary(patient)
+        assert summary["baseline"]["sleep_duration"] == "7"
+        assert summary["baseline"]["valid_week_nights"] == 1
+
+    def test_activity_and_sleep_are_selected_independently(self):
+        """A day can be a valid sleep night without being a valid activity day and vice versa."""
+        user, patient = _make_patient()
+        self._anchor(user)
+        # Day A: valid activity (wear=700), no sleep
+        _make_fitbit_day(user, self._in_baseline(0), steps=5000, wear_min=700, sleep_min=None)
+        # Day B: invalid activity (wear=100), but valid sleep (sleep=360 min)
+        _make_fitbit_day(user, self._in_baseline(1), steps=0, wear_min=100, sleep_min=360)
+        summary = compute_wearables_summary(patient)
+        assert summary["baseline"]["valid_week_days"] == 1
+        assert summary["baseline"]["valid_week_nights"] == 1
+        assert summary["baseline"]["fitbit_steps"] == 5000
+        assert summary["baseline"]["sleep_duration"] == "6"   # 360 min = 6 h
+
+    def test_weekday_weekend_counts_in_output(self):
+        """valid_week_days / valid_weekend_days reflect the selection, not total valid days."""
+        user, patient = _make_patient()
+        self._anchor(user)
+        # Day 8 = Mon, Day 9 = Tue, Day 13 = Sat, Day 14 = Sun
+        for offset in [0, 1, 5, 6]:  # Mon, Tue, Sat, Sun
+            _make_fitbit_day(user, self._in_baseline(offset), wear_min=700)
+        summary = compute_wearables_summary(patient)
+        b = summary["baseline"]
+        assert b["valid_week_days"] == 2
+        assert b["valid_weekend_days"] == 2
+
+    def test_at_most_5_weekdays_and_2_weekends_selected(self):
+        user, patient = _make_patient()
+        self._anchor(user)
+        for i in range(20):
+            _make_fitbit_day(user, self._in_baseline(i), wear_min=700)
+        summary = compute_wearables_summary(patient)
+        b = summary["baseline"]
+        assert b["valid_week_days"] <= 5
+        assert b["valid_weekend_days"] <= 2
 
     def test_compass_sleep_in_integer_hours(self):
-        reha_end = datetime(2024, 1, 1, tzinfo=dt_tz.utc)
-        user, patient = _make_patient(project="COMPASS", reha_end_date=reha_end)
-        _make_fitbit_day(
-            user,
-            reha_end + timedelta(days=2),
-            sleep_ms=8 * 3_600_000,
-            wear_min=500,  # 8 hours
-        )
+        user, patient = _make_patient(project="COMPASS")
+        self._anchor(user)
+        _make_fitbit_day(user, self._in_baseline(0), sleep_min=480)
         summary = compute_wearables_summary(patient)
         assert summary["baseline"]["sleep_duration"] == "8"
 
     def test_copain_sleep_in_hhmm(self):
-        reha_end = datetime(2024, 1, 1, tzinfo=dt_tz.utc)
-        user, patient = _make_patient(project="COPAIN", reha_end_date=reha_end)
-        # COPAIN baseline is BEFORE discharge: put data 2 days before reha_end.
-        _make_fitbit_day(
-            user,
-            reha_end - timedelta(days=2),
-            sleep_ms=int(7.5 * 3_600_000),
-            wear_min=500,  # 7h30m
-        )
+        user, patient = _make_patient(project="COPAIN")
+        self._anchor(user)
+        _make_fitbit_day(user, self._in_baseline(0), sleep_min=450)
         summary = compute_wearables_summary(patient)
         assert summary["baseline"]["sleep_duration"] == "07:30"
 
-    def test_compass_baseline_window_is_after_reha_end(self):
-        """COMPASS baseline looks at the 4 weeks AFTER discharge, not before."""
-        reha_end = datetime(2024, 6, 1, tzinfo=dt_tz.utc)
-        user, patient = _make_patient(project="COMPASS", reha_end_date=reha_end)
-
-        # Data 10 days after discharge — inside the after-discharge window.
-        _make_fitbit_day(user, reha_end + timedelta(days=10), steps=7777, wear_min=500)
-
+    def test_returns_none_followup_when_window_not_reached(self):
+        user, patient = _make_patient()
+        self._anchor(user)
+        _make_fitbit_day(user, self._in_baseline(0))
         summary = compute_wearables_summary(patient)
-        assert summary["baseline"] is not None
-        assert summary["baseline"]["fitbit_steps"] == 7777
+        assert summary["followup"] is None
 
-    def test_compass_data_before_reha_end_not_in_baseline(self):
-        """Data collected before discharge must not appear in COMPASS baseline."""
-        reha_end = datetime(2024, 6, 1, tzinfo=dt_tz.utc)
-        user, patient = _make_patient(project="COMPASS", reha_end_date=reha_end)
-
-        # Data 2 days BEFORE discharge — outside the after-discharge window.
-        _make_fitbit_day(user, reha_end - timedelta(days=2), steps=9999, wear_min=600)
-
+    def test_means_computed_correctly(self):
+        user, patient = _make_patient()
+        self._anchor(user)
+        _make_fitbit_day(user, self._in_baseline(0), steps=4000, active_min=20, inactive_min=200, wear_min=700)
+        _make_fitbit_day(user, self._in_baseline(1), steps=6000, active_min=40, inactive_min=400, wear_min=700)
         summary = compute_wearables_summary(patient)
-        assert summary["baseline"] is None
-
-    def test_copain_baseline_window_is_before_reha_end(self):
-        """COPAIN baseline looks at the 4 weeks BEFORE discharge, not after."""
-        reha_end = datetime(2024, 6, 1, tzinfo=dt_tz.utc)
-        user, patient = _make_patient(project="COPAIN", reha_end_date=reha_end)
-
-        # Data 10 days before discharge — inside the before-discharge window.
-        _make_fitbit_day(user, reha_end - timedelta(days=10), steps=5555, wear_min=500)
-
-        summary = compute_wearables_summary(patient)
-        assert summary["baseline"] is not None
-        assert summary["baseline"]["fitbit_steps"] == 5555
-
-    def test_copain_data_after_reha_end_not_in_baseline(self):
-        """Data collected after discharge must not appear in COPAIN baseline."""
-        reha_end = datetime(2024, 6, 1, tzinfo=dt_tz.utc)
-        user, patient = _make_patient(project="COPAIN", reha_end_date=reha_end)
-
-        # Data 2 days AFTER discharge — outside the before-discharge window.
-        _make_fitbit_day(user, reha_end + timedelta(days=2), steps=9999, wear_min=600)
-
-        summary = compute_wearables_summary(patient)
-        assert summary["baseline"] is None
-
-    def test_dates_formatted_as_dmy(self):
-        reha_end = datetime(2024, 3, 1, tzinfo=dt_tz.utc)
-        user, patient = _make_patient(reha_end_date=reha_end)
-        day = reha_end + timedelta(days=2)
-        _make_fitbit_day(user, day, wear_min=500)
-        summary = compute_wearables_summary(patient)
-        # monitoring_start should be YYYY-MM-DD (REDCap import format)
-        start = summary["baseline"]["monitoring_start"]
-        assert len(start) == 10
-        assert start[:4] == "2024" and start[4] == "-" and start[7] == "-"
-
-    def test_monitoring_days_matches_records_in_best_week(self):
-        reha_end = datetime(2024, 1, 1, tzinfo=dt_tz.utc)
-        user, patient = _make_patient(reha_end_date=reha_end)
-        for i in range(5):
-            _make_fitbit_day(user, reha_end + timedelta(days=i + 1), wear_min=500)
-        summary = compute_wearables_summary(patient)
-        assert summary["baseline"]["monitoring_days"] == 5
+        b = summary["baseline"]
+        assert b["fitbit_steps"] == 5000
+        assert b["fitbit_pa"] == 30
+        assert b["fitbit_inactivity"] == 300
 
 
 # ---------------------------------------------------------------------------
-# export_wearables_to_redcap — DB-backed + mocked REDCap calls
+# export_wearables_to_redcap — DB-backed + mocked REDCap
 # ---------------------------------------------------------------------------
 
 
 class TestExportWearablesToRedcap:
+    FIRST_DATE = datetime(2024, 1, 1, tzinfo=dt_tz.utc)
+
+    def _anchor(self, user):
+        _make_fitbit_day(user, self.FIRST_DATE, steps=0, wear_min=0, sleep_min=None)
+
+    def _in_baseline(self, offset: int) -> datetime:
+        return self.FIRST_DATE + timedelta(days=7 + offset)
+
     def test_raises_if_no_project(self):
-        _, patient = _make_patient(project="COMPASS")
-        patient.project = ""  # blank out after saving to bypass Therapist validation
+        _, patient = _make_patient()
+        patient.project = ""
         patient.save()
-        with pytest.raises(ValueError, match="no REDCap project"):
+        with pytest.raises(Exception, match="no REDCap project"):
             export_wearables_to_redcap(patient)
 
     def test_raises_if_no_redcap_record(self, monkeypatch):
-        reha_end = datetime(2024, 1, 1, tzinfo=dt_tz.utc)
-        _, patient = _make_patient(reha_end_date=reha_end)
+        _, patient = _make_patient()
         monkeypatch.setenv("REDCAP_TOKEN_COMPASS", "tok")
         with patch("core.services.wearables_redcap_service.export_record_by_pat_id", return_value=[]):
             with pytest.raises(ValueError, match="No REDCap record"):
                 export_wearables_to_redcap(patient)
 
     def test_both_periods_skipped_when_no_fitbit_data(self, monkeypatch):
-        reha_end = datetime(2024, 1, 1, tzinfo=dt_tz.utc)
-        _, patient = _make_patient(reha_end_date=reha_end)
+        _, patient = _make_patient()
         monkeypatch.setenv("REDCAP_TOKEN_COMPASS", "tok")
-        with patch(
-            "core.services.wearables_redcap_service.export_record_by_pat_id", return_value=[{"record_id": "42"}]
-        ):
-            results = export_wearables_to_redcap(patient)
-        assert results["baseline"] == "skipped"
-        assert results["followup"] == "skipped"
+        # No FitbitData → WearablesSyncError is caught and both periods skipped
+        with patch("core.services.wearables_redcap_service.export_record_by_pat_id", return_value=[{"record_id": "1"}]):
+            with pytest.raises(Exception):
+                export_wearables_to_redcap(patient)
 
-    def test_writes_correct_payload_to_redcap(self, monkeypatch):
-        reha_end = datetime(2024, 1, 1, tzinfo=dt_tz.utc)
-        user, patient = _make_patient(project="COMPASS", reha_end_date=reha_end)
-        _make_fitbit_day(
-            user,
-            reha_end + timedelta(days=2),
-            steps=5000,
-            active_min=30,
-            inactive_min=300,
-            wear_min=600,
-            sleep_ms=7 * 3_600_000,
-        )
+    def test_writes_new_fields_to_redcap(self, monkeypatch):
+        user, patient = _make_patient(project="COMPASS")
+        self._anchor(user)
+        # Mon + Sat in baseline
+        _make_fitbit_day(user, self._in_baseline(0), steps=5000, active_min=30, inactive_min=300, wear_min=700, sleep_min=420)
+        _make_fitbit_day(user, self._in_baseline(5), steps=3000, active_min=10, inactive_min=500, wear_min=700, sleep_min=480)
 
         monkeypatch.setenv("REDCAP_TOKEN_COMPASS", "tok")
-
-        captured_payloads = []
-
-        def _fake_post(token, payload, timeout=30):
-            captured_payloads.append(payload)
-            return '{"count": 1}'
-
-        with patch(
-            "core.services.wearables_redcap_service.export_record_by_pat_id", return_value=[{"record_id": "99"}]
-        ):
-            with patch("core.services.wearables_redcap_service._post_redcap", side_effect=_fake_post):
-                results = export_wearables_to_redcap(patient)
-
-        # Baseline was written (follow-up has no data → skipped)
-        assert results["baseline"] == "ok"
-        assert results["followup"] == "skipped"
-
-        payload = captured_payloads[0]
-        assert payload["content"] == "record"
-        assert payload["action"] == "import"
-        assert payload["format"] == "json"
-
-        record = json.loads(payload["data"])[0]
-        assert record["record_id"] == "99"
-        assert record["fitbit_steps"] == "5000"
-        assert record["fitbit_pa"] == "30"
-        assert record["fitbit_inactivity"] == "300"
-        assert record["sleep_duration"] == "7"  # COMPASS: integer hours
-        assert record["wearables_complete"] == "1"  # Unverified
-        assert record["redcap_event_name"] == "visit_baseline_arm_1"
-
-        # Date format: YYYY-MM-DD (REDCap import always requires Y-M-D)
-        start = record["monitoring_start"]
-        assert start[:4] == "2024" and start[4] == "-" and start[7] == "-"
-
-    def test_return_payloads_includes_sent_and_skipped_details(self, monkeypatch):
-        reha_end = datetime(2024, 1, 1, tzinfo=dt_tz.utc)
-        user, patient = _make_patient(project="COMPASS", reha_end_date=reha_end)
-        _make_fitbit_day(
-            user,
-            reha_end + timedelta(days=2),
-            steps=5000,
-            active_min=30,
-            inactive_min=300,
-            wear_min=600,
-        )
-        monkeypatch.setenv("REDCAP_TOKEN_COMPASS", "tok")
-
-        with patch(
-            "core.services.wearables_redcap_service.export_record_by_pat_id", return_value=[{"record_id": "99"}]
-        ):
-            with patch("core.services.wearables_redcap_service._post_redcap", return_value='{"count":1}'):
-                results, payloads = export_wearables_to_redcap(patient, return_payloads=True)
-
-        assert results["baseline"] == "ok"
-        assert results["followup"] == "skipped"
-        assert payloads["baseline"]["status"] == "sent"
-        assert payloads["baseline"]["record"]["record_id"] == "99"
-        assert payloads["followup"]["status"] == "skipped"
-        assert payloads["followup"]["reason"] == "no_fitbit_data_in_period"
-
-    def test_copain_sleep_format_in_payload(self, monkeypatch):
-        reha_end = datetime(2024, 1, 1, tzinfo=dt_tz.utc)
-        user, patient = _make_patient(project="COPAIN", reha_end_date=reha_end)
-        _make_fitbit_day(user, reha_end - timedelta(days=2), wear_min=600, sleep_ms=int(7.5 * 3_600_000))
-
-        monkeypatch.setenv("REDCAP_TOKEN_COPAIN", "tok")
         captured = []
 
-        with patch("core.services.wearables_redcap_service.export_record_by_pat_id", return_value=[{"record_id": "7"}]):
+        with patch("core.services.wearables_redcap_service.export_record_by_pat_id", return_value=[{"record_id": "99"}]):
             with patch(
                 "core.services.wearables_redcap_service._post_redcap",
                 side_effect=lambda *a, **kw: captured.append(a[1]) or '{"count":1}',
             ):
-                export_wearables_to_redcap(patient)
+                results = export_wearables_to_redcap(patient)
 
+        assert results["baseline"] == "ok"
         record = json.loads(captured[0]["data"])[0]
-        assert record["sleep_duration"] == "07:30"
-        assert record["redcap_event_name"] == "t0_at_disch_arm_1"
+        assert record["record_id"] == "99"
+        assert record["redcap_event_name"] == "visit_baseline_arm_1"
+        assert record["wearables_complete"] == "1"
+        assert "valid_week_days" in record
+        assert "valid_weekend_days" in record
+        assert "valid_week_nights" in record
+        assert "valid_weekend_nights" in record
+        assert record["monitoring_start"] == "2024-01-08"
+        assert record["monitoring_end"] == "2024-01-28"
+
+    def test_skip_if_populated_prevents_overwrite(self, monkeypatch):
+        """When monitoring_start already exists in REDCap, skip (default behaviour)."""
+        user, patient = _make_patient(project="COMPASS")
+        self._anchor(user)
+        _make_fitbit_day(user, self._in_baseline(0))
+        monkeypatch.setenv("REDCAP_TOKEN_COMPASS", "tok")
+
+        existing_row = {
+            "record_id": "5",
+            "redcap_event_name": "visit_baseline_arm_1",
+            "monitoring_start": "2024-01-08",  # already populated
+        }
+
+        with patch("core.services.wearables_redcap_service.export_record_by_pat_id", return_value=[existing_row]):
+            with patch("core.services.wearables_redcap_service._post_redcap") as mock_post:
+                results = export_wearables_to_redcap(patient, skip_if_populated=True)
+
+        assert results["baseline"] == "skipped"
+        mock_post.assert_not_called()
+
+    def test_force_recalculation_when_skip_if_populated_false(self, monkeypatch):
+        """skip_if_populated=False allows overwriting an already-populated event."""
+        user, patient = _make_patient(project="COMPASS")
+        self._anchor(user)
+        _make_fitbit_day(user, self._in_baseline(0))
+        monkeypatch.setenv("REDCAP_TOKEN_COMPASS", "tok")
+
+        existing_row = {
+            "record_id": "5",
+            "redcap_event_name": "visit_baseline_arm_1",
+            "monitoring_start": "2024-01-08",
+        }
+
+        with patch("core.services.wearables_redcap_service.export_record_by_pat_id", return_value=[existing_row]):
+            with patch("core.services.wearables_redcap_service._post_redcap", return_value='{"count":1}') as mock_post:
+                results = export_wearables_to_redcap(patient, skip_if_populated=False)
+
+        assert results["baseline"] == "ok"
+        mock_post.assert_called_once()
 
     def test_redcap_error_captured_as_error_string(self, monkeypatch):
-        reha_end = datetime(2024, 1, 1, tzinfo=dt_tz.utc)
-        user, patient = _make_patient(project="COMPASS", reha_end_date=reha_end)
-        _make_fitbit_day(user, reha_end + timedelta(days=2), wear_min=600)
+        user, patient = _make_patient(project="COMPASS")
+        self._anchor(user)
+        _make_fitbit_day(user, self._in_baseline(0))
         monkeypatch.setenv("REDCAP_TOKEN_COMPASS", "tok")
 
         with patch("core.services.wearables_redcap_service.export_record_by_pat_id", return_value=[{"record_id": "5"}]):
@@ -585,58 +525,12 @@ class TestExportWearablesToRedcap:
                 results = export_wearables_to_redcap(patient)
 
         assert results["baseline"].startswith("error:")
-        assert "write failed" in results["baseline"]
-
-    def test_explicit_event_names_override_defaults(self, monkeypatch):
-        reha_end = datetime(2024, 1, 1, tzinfo=dt_tz.utc)
-        user, patient = _make_patient(project="COMPASS", reha_end_date=reha_end)
-        _make_fitbit_day(user, reha_end + timedelta(days=2), wear_min=600)
-        monkeypatch.setenv("REDCAP_TOKEN_COMPASS", "tok")
-        captured = []
-
-        with patch("core.services.wearables_redcap_service.export_record_by_pat_id", return_value=[{"record_id": "1"}]):
-            with patch(
-                "core.services.wearables_redcap_service._post_redcap",
-                side_effect=lambda *a, **kw: captured.append(a[1]) or '{"count":1}',
-            ):
-                export_wearables_to_redcap(patient, event_baseline="custom_baseline_arm_1")
-
-        record = json.loads(captured[0]["data"])[0]
-        assert record["redcap_event_name"] == "custom_baseline_arm_1"
-
-    def test_no_event_name_when_project_unknown(self, monkeypatch):
-        reha_end = datetime(2024, 1, 1, tzinfo=dt_tz.utc)
-        # Create with valid project, then override to an unknown one
-        user, patient = _make_patient(project="COMPASS", reha_end_date=reha_end)
-        patient.project = "UNKNOWN_PROJ"
-        patient.save()
-        _make_fitbit_day(user, reha_end + timedelta(days=2), wear_min=600)
-        monkeypatch.setenv("REDCAP_TOKEN_UNKNOWN_PROJ", "tok")
-        monkeypatch.delenv("REDCAP_WEARABLES_EVENT_BASELINE", raising=False)
-        monkeypatch.delenv("REDCAP_WEARABLES_EVENT_FOLLOWUP", raising=False)
-        captured = []
-
-        with patch("core.services.wearables_redcap_service.export_record_by_pat_id", return_value=[{"record_id": "1"}]):
-            with patch(
-                "core.services.wearables_redcap_service._post_redcap",
-                side_effect=lambda *a, **kw: captured.append(a[1]) or '{"count":1}',
-            ):
-                export_wearables_to_redcap(patient)
-
-        record = json.loads(captured[0]["data"])[0]
-        assert "redcap_event_name" not in record
 
     def test_invalid_field_stripped_and_retried(self, monkeypatch):
-        """
-        When REDCap returns 400 with an 'invalid field' message on the first
-        import attempt, the offending field is stripped and the request retried.
-        The second attempt must succeed and the period result must be "ok".
-        """
-        reha_end = datetime(2024, 1, 1, tzinfo=dt_tz.utc)
-        user, patient = _make_patient(project="COMPASS", reha_end_date=reha_end)
-        _make_fitbit_day(user, reha_end + timedelta(days=2), wear_min=600, steps=4000)
+        user, patient = _make_patient(project="COMPASS")
+        self._anchor(user)
+        _make_fitbit_day(user, self._in_baseline(0), steps=4000)
         monkeypatch.setenv("REDCAP_TOKEN_COMPASS", "tok")
-
         calls = []
 
         def _fake_post(token, payload, timeout=30):
@@ -648,14 +542,24 @@ class TestExportWearablesToRedcap:
                 )
             return '{"count":1}'
 
-        with patch(
-            "core.services.wearables_redcap_service.export_record_by_pat_id", return_value=[{"record_id": "42"}]
-        ):
+        with patch("core.services.wearables_redcap_service.export_record_by_pat_id", return_value=[{"record_id": "42"}]):
             with patch("core.services.wearables_redcap_service._post_redcap", side_effect=_fake_post):
                 results = export_wearables_to_redcap(patient)
 
         assert results["baseline"] == "ok"
         assert len(calls) == 2
-        assert "wearables_complete" in calls[0]
         assert "wearables_complete" not in calls[1]
-        assert calls[1]["fitbit_steps"] == "4000"
+
+    def test_return_payloads_true(self, monkeypatch):
+        user, patient = _make_patient(project="COMPASS")
+        self._anchor(user)
+        _make_fitbit_day(user, self._in_baseline(0))
+        monkeypatch.setenv("REDCAP_TOKEN_COMPASS", "tok")
+
+        with patch("core.services.wearables_redcap_service.export_record_by_pat_id", return_value=[{"record_id": "9"}]):
+            with patch("core.services.wearables_redcap_service._post_redcap", return_value='{"count":1}'):
+                results, payloads = export_wearables_to_redcap(patient, return_payloads=True)
+
+        assert results["baseline"] == "ok"
+        assert payloads["baseline"]["status"] == "sent"
+        assert payloads["followup"]["reason"] == "no_fitbit_data_in_period"

--- a/backend/tests/wearables_redcap/test_wearables_redcap_service.py
+++ b/backend/tests/wearables_redcap/test_wearables_redcap_service.py
@@ -11,7 +11,7 @@ Tests for the new protocol-specified aggregation logic:
 """
 
 import json
-from datetime import datetime, timedelta, date
+from datetime import date, datetime, timedelta
 from datetime import timezone as dt_tz
 from unittest.mock import patch
 
@@ -87,8 +87,8 @@ def _make_fitbit_day(
     steps=5000,
     active_min=30,
     inactive_min=300,
-    wear_min=700,       # valid by default (>= 600)
-    sleep_min=420,      # valid by default (>= 180 min) — stored as minutes_asleep
+    wear_min=700,  # valid by default (>= 600)
+    sleep_min=420,  # valid by default (>= 180 min) — stored as minutes_asleep
 ):
     """Create a FitbitData record. sleep_min=None skips sleep entirely."""
     sleep = SleepData(minutes_asleep=sleep_min) if sleep_min is not None else None
@@ -166,8 +166,8 @@ class TestSplitWeekdayWeekend:
         user, _ = _make_patient()
         records = [self._day(user, i) for i in range(7)]  # Mon–Sun
         weekdays, weekends = _split_weekday_weekend(records)
-        assert len(weekdays) == 5   # Mon–Fri
-        assert len(weekends) == 2   # Sat–Sun
+        assert len(weekdays) == 5  # Mon–Fri
+        assert len(weekends) == 2  # Sat–Sun
 
     def test_caps_weekdays_at_5_even_with_more_available(self):
         user, _ = _make_patient()
@@ -192,8 +192,8 @@ class TestSplitWeekdayWeekend:
 
     def test_picks_earliest_days(self):
         user, _ = _make_patient()
-        early_mon = self._day(user, 0)   # 2024-01-08 Mon — should be selected (earliest)
-        late_mon = self._day(user, 7)    # 2024-01-15 Mon — should not be selected (6th weekday)
+        early_mon = self._day(user, 0)  # 2024-01-08 Mon — should be selected (earliest)
+        late_mon = self._day(user, 7)  # 2024-01-15 Mon — should not be selected (6th weekday)
         tue = self._day(user, 1)
         wed = self._day(user, 2)
         thu = self._day(user, 3)
@@ -352,7 +352,7 @@ class TestComputeWearablesSummary:
         assert summary["baseline"]["valid_week_days"] == 1
         assert summary["baseline"]["valid_week_nights"] == 1
         assert summary["baseline"]["fitbit_steps"] == 5000
-        assert summary["baseline"]["sleep_duration"] == "6"   # 360 min = 6 h
+        assert summary["baseline"]["sleep_duration"] == "6"  # 360 min = 6 h
 
     def test_weekday_weekend_counts_in_output(self):
         """valid_week_days / valid_weekend_days reflect the selection, not total valid days."""
@@ -449,13 +449,19 @@ class TestExportWearablesToRedcap:
         user, patient = _make_patient(project="COMPASS")
         self._anchor(user)
         # Mon + Sat in baseline
-        _make_fitbit_day(user, self._in_baseline(0), steps=5000, active_min=30, inactive_min=300, wear_min=700, sleep_min=420)
-        _make_fitbit_day(user, self._in_baseline(5), steps=3000, active_min=10, inactive_min=500, wear_min=700, sleep_min=480)
+        _make_fitbit_day(
+            user, self._in_baseline(0), steps=5000, active_min=30, inactive_min=300, wear_min=700, sleep_min=420
+        )
+        _make_fitbit_day(
+            user, self._in_baseline(5), steps=3000, active_min=10, inactive_min=500, wear_min=700, sleep_min=480
+        )
 
         monkeypatch.setenv("REDCAP_TOKEN_COMPASS", "tok")
         captured = []
 
-        with patch("core.services.wearables_redcap_service.export_record_by_pat_id", return_value=[{"record_id": "99"}]):
+        with patch(
+            "core.services.wearables_redcap_service.export_record_by_pat_id", return_value=[{"record_id": "99"}]
+        ):
             with patch(
                 "core.services.wearables_redcap_service._post_redcap",
                 side_effect=lambda *a, **kw: captured.append(a[1]) or '{"count":1}',
@@ -542,7 +548,9 @@ class TestExportWearablesToRedcap:
                 )
             return '{"count":1}'
 
-        with patch("core.services.wearables_redcap_service.export_record_by_pat_id", return_value=[{"record_id": "42"}]):
+        with patch(
+            "core.services.wearables_redcap_service.export_record_by_pat_id", return_value=[{"record_id": "42"}]
+        ):
             with patch("core.services.wearables_redcap_service._post_redcap", side_effect=_fake_post):
                 results = export_wearables_to_redcap(patient)
 

--- a/backend/tests/wearables_redcap/test_wearables_redcap_service.py
+++ b/backend/tests/wearables_redcap/test_wearables_redcap_service.py
@@ -24,10 +24,13 @@ from core.services.redcap_service import RedcapError
 from core.services.wearables_redcap_service import (
     MIN_SLEEP_MINUTES,
     MIN_WEAR_MINUTES,
+    _find_first_measurement_date,
     _format_sleep,
     _is_valid_activity_day,
     _is_valid_sleep_night,
+    _record_date,
     _resolve_event_names,
+    _sleep_minutes,
     _split_weekday_weekend,
     compute_wearables_summary,
     export_wearables_to_redcap,
@@ -571,3 +574,227 @@ class TestExportWearablesToRedcap:
         assert results["baseline"] == "ok"
         assert payloads["baseline"]["status"] == "sent"
         assert payloads["followup"]["reason"] == "no_fitbit_data_in_period"
+
+
+# ---------------------------------------------------------------------------
+# _record_date and _find_first_measurement_date — direct unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestRecordDate:
+    def test_extracts_date_from_aware_datetime(self):
+        user, _ = _make_patient()
+        r = _make_fitbit_day(user, datetime(2024, 3, 15, 12, 0, tzinfo=dt_tz.utc))
+        assert _record_date(r) == datetime(2024, 3, 15).date()
+
+    def test_returns_none_when_date_is_none(self):
+        r = FitbitData(date=None)
+        assert _record_date(r) is None
+
+
+class TestFindFirstMeasurementDate:
+    def test_returns_none_when_no_data(self):
+        user, _ = _make_patient()
+        assert _find_first_measurement_date(user) is None
+
+    def test_returns_earliest_date(self):
+        user, _ = _make_patient()
+        _make_fitbit_day(user, datetime(2024, 3, 10, tzinfo=dt_tz.utc))
+        _make_fitbit_day(user, datetime(2024, 3, 5, tzinfo=dt_tz.utc))   # ← earliest
+        _make_fitbit_day(user, datetime(2024, 3, 15, tzinfo=dt_tz.utc))
+        assert _find_first_measurement_date(user) == datetime(2024, 3, 5).date()
+
+    def test_counts_zero_wear_day_as_first_measurement(self):
+        """A day with no activity still anchors the window."""
+        user, _ = _make_patient()
+        _make_fitbit_day(user, datetime(2024, 1, 1, tzinfo=dt_tz.utc), wear_min=0, sleep_min=None)
+        _make_fitbit_day(user, datetime(2024, 1, 5, tzinfo=dt_tz.utc), wear_min=700)
+        assert _find_first_measurement_date(user) == datetime(2024, 1, 1).date()
+
+
+# ---------------------------------------------------------------------------
+# _sleep_minutes — direct unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestSleepMinutes:
+    def test_prefers_minutes_asleep(self):
+        r = FitbitData(sleep=SleepData(minutes_asleep=420, sleep_duration=99_999_999))
+        assert _sleep_minutes(r) == 420.0
+
+    def test_falls_back_to_sleep_duration_ms(self):
+        # 7h = 25200000 ms
+        r = FitbitData(sleep=SleepData(minutes_asleep=None, sleep_duration=25_200_000))
+        assert _sleep_minutes(r) == 420.0
+
+    def test_returns_none_when_no_sleep(self):
+        r = FitbitData(sleep=None)
+        assert _sleep_minutes(r) is None
+
+    def test_returns_none_when_sleep_has_no_fields(self):
+        r = FitbitData(sleep=SleepData(minutes_asleep=None, sleep_duration=None))
+        assert _sleep_minutes(r) is None
+
+
+# ---------------------------------------------------------------------------
+# Exact window boundary tests
+# ---------------------------------------------------------------------------
+
+
+class TestWindowBoundaries:
+    """
+    First date = 2024-01-01.
+    Baseline:  Day 8  = 2024-01-08 (included)
+               Day 7  = 2024-01-07 (excluded — habituation period)
+               Day 28 = 2024-01-28 (included)
+               Day 29 = 2024-01-29 (excluded)
+    Follow-up: Day 150 = 2024-05-29 (included)
+               Day 149 = 2024-05-28 (excluded)
+               Day 180 = 2024-06-28 (included)
+               Day 181 = 2024-06-29 (excluded)
+    """
+
+    FIRST_DATE = datetime(2024, 1, 1, tzinfo=dt_tz.utc)
+
+    def _anchor(self, user):
+        _make_fitbit_day(user, self.FIRST_DATE, wear_min=0, sleep_min=None)
+
+    def _day(self, n: int) -> datetime:
+        """Day N (1-indexed) relative to first measurement date."""
+        return self.FIRST_DATE + timedelta(days=n - 1)
+
+    def test_day_7_excluded_day_8_included(self):
+        user, patient = _make_patient()
+        self._anchor(user)
+        _make_fitbit_day(user, self._day(7), steps=9999, wear_min=700)   # excluded
+        _make_fitbit_day(user, self._day(8), steps=1000, wear_min=700)   # included
+        summary = compute_wearables_summary(patient)
+        assert summary["baseline"]["fitbit_steps"] == 1000
+
+    def test_day_28_included_day_29_excluded(self):
+        user, patient = _make_patient()
+        self._anchor(user)
+        _make_fitbit_day(user, self._day(28), steps=2000, wear_min=700)  # included
+        _make_fitbit_day(user, self._day(29), steps=9999, wear_min=700)  # excluded
+        summary = compute_wearables_summary(patient)
+        assert summary["baseline"]["fitbit_steps"] == 2000
+
+    def test_day_149_excluded_day_150_included(self):
+        user, patient = _make_patient()
+        self._anchor(user)
+        _make_fitbit_day(user, self._day(149), steps=9999, wear_min=700)  # excluded
+        _make_fitbit_day(user, self._day(150), steps=3000, wear_min=700)  # included
+        summary = compute_wearables_summary(patient)
+        assert summary["followup"]["fitbit_steps"] == 3000
+
+    def test_day_180_included_day_181_excluded(self):
+        user, patient = _make_patient()
+        self._anchor(user)
+        _make_fitbit_day(user, self._day(180), steps=4000, wear_min=700)  # included
+        _make_fitbit_day(user, self._day(181), steps=9999, wear_min=700)  # excluded
+        summary = compute_wearables_summary(patient)
+        assert summary["followup"]["fitbit_steps"] == 4000
+
+
+# ---------------------------------------------------------------------------
+# Edge cases: records exist but none valid, None fields, both periods filled
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCases:
+    FIRST_DATE = datetime(2024, 1, 1, tzinfo=dt_tz.utc)
+
+    def _anchor(self, user):
+        _make_fitbit_day(user, self.FIRST_DATE, wear_min=0, sleep_min=None)
+
+    def _in_baseline(self, offset: int) -> datetime:
+        return self.FIRST_DATE + timedelta(days=7 + offset)
+
+    def _in_followup(self, offset: int) -> datetime:
+        return self.FIRST_DATE + timedelta(days=149 + offset)
+
+    def test_returns_none_when_records_exist_but_no_valid_activity_days(self):
+        """Records in window but all below wear threshold → no activity output."""
+        user, patient = _make_patient()
+        self._anchor(user)
+        # 3 days in baseline, all below 600 min wear, no sleep either
+        for i in range(3):
+            _make_fitbit_day(user, self._in_baseline(i), wear_min=300, sleep_min=None)
+        summary = compute_wearables_summary(patient)
+        assert summary["baseline"] is None
+
+    def test_steps_none_excluded_from_mean(self):
+        """Days where steps is None must not be zero-averaged."""
+        user, patient = _make_patient()
+        self._anchor(user)
+        _make_fitbit_day(user, self._in_baseline(0), steps=6000, wear_min=700)
+        r = _make_fitbit_day(user, self._in_baseline(1), steps=None, wear_min=700)
+        r.steps = None
+        r.save()
+        summary = compute_wearables_summary(patient)
+        # Only the 6000-step day contributes
+        assert summary["baseline"]["fitbit_steps"] == 6000
+
+    def test_both_baseline_and_followup_populated(self):
+        """When data exists in both windows, both periods return results."""
+        user, patient = _make_patient()
+        self._anchor(user)
+        _make_fitbit_day(user, self._in_baseline(0), steps=5000, wear_min=700)
+        _make_fitbit_day(user, self._in_followup(0), steps=8000, wear_min=700)
+        summary = compute_wearables_summary(patient)
+        assert summary["baseline"]["fitbit_steps"] == 5000
+        assert summary["followup"]["fitbit_steps"] == 8000
+
+    def test_regression_934_1_zero_days_before_activation_not_averaged(self):
+        """
+        Regression for patient 934-1: device activated on Day 5 (first data),
+        but wear_min=0 on Days 1-4. Days 8-28 contain real data from Day 8 onward.
+        Zero-wear days in Days 1-4 must not be included in the activity average.
+        """
+        user, patient = _make_patient()
+        # Days 1-4: device not worn (exist in DB with zero wear)
+        for i in range(4):
+            _make_fitbit_day(
+                user,
+                self.FIRST_DATE + timedelta(days=i),
+                steps=0,
+                wear_min=0,
+                sleep_min=None,
+            )
+        # Days 8, 9, 10 (offsets 0-2 from Day 8): device worn, real data
+        for i, steps in enumerate([10000, 12000, 11000]):
+            _make_fitbit_day(user, self._in_baseline(i), steps=steps, wear_min=700)
+
+        summary = compute_wearables_summary(patient)
+        b = summary["baseline"]
+        # Mean of [10000, 12000, 11000] = 11000 — zeros must NOT be included
+        assert b["fitbit_steps"] == 11000
+        assert b["valid_week_days"] == 3
+
+    def test_no_sleep_data_in_window_omits_sleep_fields(self):
+        """When no valid sleep nights exist, sleep fields are absent from output."""
+        user, patient = _make_patient()
+        self._anchor(user)
+        _make_fitbit_day(user, self._in_baseline(0), steps=5000, wear_min=700, sleep_min=None)
+        summary = compute_wearables_summary(patient)
+        assert summary["baseline"] is not None
+        assert "sleep_duration" not in summary["baseline"]
+
+    def test_split_weekday_weekend_empty_input(self):
+        weekdays, weekends = _split_weekday_weekend([])
+        assert weekdays == []
+        assert weekends == []
+
+    def test_all_5_weekdays_5_nights_from_one_week(self):
+        """A full Mon–Fri week produces exactly 5 activity days and 5 sleep nights."""
+        user, patient = _make_patient()
+        self._anchor(user)
+        # Day 8 = Mon, Day 9 = Tue, … Day 12 = Fri  (offsets 0-4)
+        for i in range(5):
+            _make_fitbit_day(user, self._in_baseline(i), wear_min=700, sleep_min=300)
+        summary = compute_wearables_summary(patient)
+        b = summary["baseline"]
+        assert b["valid_week_days"] == 5
+        assert b["valid_weekend_days"] == 0
+        assert b["valid_week_nights"] == 5
+        assert b["valid_weekend_nights"] == 0

--- a/backend/tests/wearables_redcap/test_wearables_redcap_service.py
+++ b/backend/tests/wearables_redcap/test_wearables_redcap_service.py
@@ -600,7 +600,7 @@ class TestFindFirstMeasurementDate:
     def test_returns_earliest_date(self):
         user, _ = _make_patient()
         _make_fitbit_day(user, datetime(2024, 3, 10, tzinfo=dt_tz.utc))
-        _make_fitbit_day(user, datetime(2024, 3, 5, tzinfo=dt_tz.utc))   # ← earliest
+        _make_fitbit_day(user, datetime(2024, 3, 5, tzinfo=dt_tz.utc))  # ← earliest
         _make_fitbit_day(user, datetime(2024, 3, 15, tzinfo=dt_tz.utc))
         assert _find_first_measurement_date(user) == datetime(2024, 3, 5).date()
 
@@ -666,8 +666,8 @@ class TestWindowBoundaries:
     def test_day_7_excluded_day_8_included(self):
         user, patient = _make_patient()
         self._anchor(user)
-        _make_fitbit_day(user, self._day(7), steps=9999, wear_min=700)   # excluded
-        _make_fitbit_day(user, self._day(8), steps=1000, wear_min=700)   # included
+        _make_fitbit_day(user, self._day(7), steps=9999, wear_min=700)  # excluded
+        _make_fitbit_day(user, self._day(8), steps=1000, wear_min=700)  # included
         summary = compute_wearables_summary(patient)
         assert summary["baseline"]["fitbit_steps"] == 1000
 

--- a/backend/tests/wearables_redcap/test_wearables_redcap_view.py
+++ b/backend/tests/wearables_redcap/test_wearables_redcap_view.py
@@ -10,7 +10,7 @@ Coverage
 --------
   - 405 for non-POST methods
   - 404 when patient_id is unknown
-  - 400 when patient has no reha_end_date (ValueError from service)
+  - 400 when patient has no Fitbit data (WearablesSyncError from service)
   - 400 when patient has no project set (ValueError from service)
   - 502 when REDCap API returns an error (RedcapError from service)
   - 200 with results + summary on success
@@ -104,13 +104,14 @@ def test_patient_not_found():
     assert resp.json()["error"] == "Patient not found"
 
 
-def test_missing_reha_end_date_returns_400():
+def test_no_fitbit_data_returns_400():
+    # Patient exists but has never worn the device — no FitbitData records
     patient = _make_patient(reha_end_date=None)
     resp = client.post(URL(patient.id), **AUTH)
     assert resp.status_code == 400
     body = resp.json()
-    assert "Rehabilitation End Date" in body["error"]
-    assert body["code"] == "wearables_missing_reha_end_date"
+    assert "No Fitbit data" in body["error"]
+    assert body["code"] == "wearables_no_fitbit_data"
 
 
 def test_missing_project_returns_400():
@@ -143,16 +144,16 @@ def test_wearables_sync_error_returns_code():
     with patch(
         "core.views.wearables_redcap_view.compute_wearables_summary",
         side_effect=WearablesSyncError(
-            "Patient P-X is missing the Rehabilitation End Date.",
-            code="wearables_missing_reha_end_date",
+            "No Fitbit data found for patient P-X.",
+            code="wearables_no_fitbit_data",
         ),
     ):
         resp = client.post(URL(patient.id), **AUTH)
 
     assert resp.status_code == 400
     body = resp.json()
-    assert body["code"] == "wearables_missing_reha_end_date"
-    assert "Rehabilitation End Date" in body["error"]
+    assert body["code"] == "wearables_no_fitbit_data"
+    assert "No Fitbit data" in body["error"]
 
 
 def test_redcap_error_returns_502():

--- a/docs/wearables_redcap_sync.md
+++ b/docs/wearables_redcap_sync.md
@@ -8,31 +8,74 @@ Automatically exports Fitbit wearables data (steps, activity, inactivity, sleep)
 
 For each patient the pipeline:
 
-1. Identifies two monitoring periods (baseline + follow-up) using the patient's rehab dates
-2. Within each period selects the ISO week with the **highest total wear time** (`wear_time_minutes`)
-3. Averages the Fitbit metrics across that week
-4. Writes the record into REDCap via the API, then marks the form as **Unverified** (`wearables_complete = 1`) for researcher review
+1. Finds the **first Fitbit measurement date** (the earliest day any data was recorded)
+2. Computes two **fixed monitoring windows** relative to that date (baseline: Day 8–28; follow-up: Day 150–180)
+3. Within each window, identifies **valid** activity days (≥ 10 h wear time) and sleep nights (≥ 3 h sleep) — independently
+4. Selects the **earliest** valid days: up to 5 weekdays + 2 weekend days per window
+5. Computes **means** over the selected days
+6. Writes the record into REDCap via the API and marks the form as **Unverified** (`wearables_complete = 1`) for researcher review
 
 ---
 
-## Period definitions
+## Monitoring windows
 
-The baseline window direction depends on the project's `baseline_anchor` setting:
+Both windows are anchored to the **first Fitbit measurement date** (Day 1 = date of the first stored `FitbitData` record), not to `reha_end_date`.
 
-| Project | Baseline start | Baseline end | Rationale |
-|---|---|---|---|
-| **COMPASS** | `reha_end_date` | `reha_end_date + 4 weeks` | Outpatient rehab — data collected after discharge |
-| **COPAIN** | `reha_end_date − 4 weeks` | `reha_end_date` | In-hospital stay — data collected before discharge |
+| Period | REDCap event | Start | End | Rationale |
+|---|---|---|---|---|
+| **Baseline** | `visit_baseline` | Day 8 | Day 28 | First 7 days excluded — device habituation period |
+| **Follow-up** | `visit_6m` | Day 150 | Day 180 | Approx. 6-month mark |
 
-| Period | Start | End |
+`monitoring_start` and `monitoring_end` in REDCap always reflect these **window boundaries**, not the dates of the earliest and latest data points within the window.
+
+**Example:** First Fitbit measurement = 2025-01-01
+
+| | Start | End |
 |---|---|---|
-| **Follow-up** | `study_end_date − 4 weeks` | `study_end_date` |
+| Baseline | 2025-01-08 (Day 8) | 2025-01-28 (Day 28) |
+| Follow-up | 2025-05-30 (Day 150) | 2025-06-29 (Day 180) |
 
-If `study_end_date` is not set, the system defaults to `reha_end_date + 26 weeks` (≈ 6 months).
+---
 
-A patient is skipped silently if:
-- `reha_end_date` is not set (no baseline anchor)
-- No Fitbit data exists in the period (result = `"skipped"`)
+## Valid day / night definitions
+
+Activity and sleep are processed **independently**. A day can qualify for one without qualifying for the other.
+
+### Valid activity day
+
+A calendar day is valid for activity aggregation if:
+
+```
+wear_time_minutes >= 600   (10 hours of device wear)
+```
+
+Days where the device was not worn or worn less than 10 hours are excluded from activity means. This prevents zero-activity days (e.g. before device activation) from diluting the average.
+
+### Valid sleep night
+
+A calendar night is valid for sleep aggregation if:
+
+```
+minutes_asleep >= 180   (3 hours of recorded sleep)
+```
+
+Falls back to `sleep_duration_ms / 60 000` for older records where `minutes_asleep` is absent.
+
+---
+
+## Day selection
+
+Within each monitoring window, valid days are sorted chronologically and greedily selected:
+
+| Type | Target | Maximum |
+|---|---|---|
+| Weekdays (Mon–Fri) | 5 | 5 |
+| Weekend days (Sat–Sun) | 2 | 2 |
+| **Total** | **7** | **7** |
+
+If fewer valid days exist, all available valid days are used. Selected days do not need to be consecutive.
+
+The same selection logic applies independently to sleep nights.
 
 ---
 
@@ -40,35 +83,54 @@ A patient is skipped silently if:
 
 | REDCap field | Source | Notes |
 |---|---|---|
-| `monitoring_start` | Best week's first day | `DD-MM-YYYY` (date_dmy) |
-| `monitoring_end` | Best week's last day | `DD-MM-YYYY` (date_dmy) |
-| `monitoring_days` | Record count in best week | integer |
-| `fitbit_pa` | avg `active_minutes` | Active Zone Minutes (moderate×1 + vigorous×2) |
-| `fitbit_inactivity` | avg `inactivity_minutes` | minutes/day |
-| `fitbit_steps` | avg `steps` | steps/day |
-| `sleep_duration` | avg sleep from `SleepData.sleep_duration` | format varies by project (see below) |
-| `wearables_complete` | always `"1"` | Unverified — researcher marks Complete |
+| `monitoring_start` | Window start (Day 8 or Day 150) | `YYYY-MM-DD` |
+| `monitoring_end` | Window end (Day 28 or Day 180) | `YYYY-MM-DD` |
+| `valid_week_days` | Count of selected valid weekday activity days | integer, max 5 |
+| `valid_weekend_days` | Count of selected valid weekend activity days | integer, max 2 |
+| `valid_week_nights` | Count of selected valid weekday sleep nights | integer, max 5 |
+| `valid_weekend_nights` | Count of selected valid weekend sleep nights | integer, max 2 |
+| `fitbit_pa` | Mean `active_minutes` over selected activity days | Active Zone Minutes: moderate × 1 + vigorous × 2 |
+| `fitbit_inactivity` | Mean `inactivity_minutes` over selected activity days | minutes/day |
+| `fitbit_steps` | Mean `steps` over selected activity days | steps/day |
+| `sleep_duration` | Mean sleep duration over selected sleep nights | format varies by project (see below) |
+| `sleep_score` | Not yet available | Reserved as `None`; Fitbit and Google Health REST APIs do not expose sleep score for standard OAuth apps |
+| `wearables_complete` | Always `"1"` | Unverified — researcher marks Complete after review |
 
 ### `sleep_duration` format per project
 
 | Project | REDCap type | Format written | Example |
 |---|---|---|---|
-| COMPASS | `text (integer, Max: 24)` | Integer hours | `8` |
+| COMPASS | `text (integer, Max: 24)` | Integer hours (rounded) | `8` |
 | COPAIN | `text (time, Max: 23:59)` | `HH:MM` | `07:30` |
 
 ---
 
-## REDCap event names
+## Duplicate protection
 
-The wearables instrument appears in two events per project:
+By default (`skip_if_populated=True`), if `monitoring_start` is already populated in REDCap for a given event, that period is **skipped**. This prevents the nightly Celery run from overwriting previously reviewed data.
+
+The manual "Sync Wearables" button in the UI respects the same default.
+
+To force a recalculation (e.g. after correcting Fitbit data), use the API with `force=true` (see [Manual trigger (API)](#manual-trigger-api) below) or call `export_wearables_to_redcap(patient, skip_if_populated=False)` directly.
+
+### Interpreting results
+
+| Result | Meaning |
+|---|---|
+| `ok` | Valid days found in window; record exported to REDCap |
+| `skipped` | No valid Fitbit data in window, OR event already populated and `skip_if_populated=True` |
+| `error: ...` | REDCap API rejected the write; details in the error string |
+
+---
+
+## REDCap event names
 
 | Project | Baseline event | Follow-up event |
 |---|---|---|
 | **COMPASS** | `visit_baseline_arm_1` | `visit_6m_arm_1` |
 | **COPAIN** | `t0_at_disch_arm_1` | `t2_six_months_afte_arm_1` |
 
-These defaults are hard-coded in `_PROJECT_CONFIG` inside
-`backend/core/services/wearables_redcap_service.py`.
+These defaults are set in `_PROJECT_CONFIG` in `backend/core/services/wearables_redcap_service.py`.
 
 ### Overriding event names
 
@@ -87,38 +149,32 @@ POST /api/wearables/sync-to-redcap/<patient_id>/
 }
 ```
 
-Priority order: **API body argument > env var > per-project default**.
+Priority: **API body argument > env var > per-project default**.
 
 ---
 
 ## Prerequisites
 
-1. The patient must have `reha_end_date` set in the platform
+1. The patient must have at least one `FitbitData` record (the first date anchors both windows)
 2. The patient must have a `project` field set (`COPAIN` or `COMPASS`)
-3. The REDCap API token must have **Data Import/Update** permission enabled
-   (ask the REDCap admin to tick the box on the token page)
+3. The REDCap API token must have **Data Import/Update** permission
 4. The environment must have the correct token variable set:
    ```
    REDCAP_TOKEN_COMPASS=<token>
    REDCAP_TOKEN_COPAIN=<token>
    ```
 
+> **Note:** `reha_end_date` is no longer required for window calculation. It was previously used as the baseline anchor but the algorithm now uses the first Fitbit measurement date instead.
+
 ---
 
 ## Manual trigger (therapist UI)
 
-Open the **Patient popup** for any patient that has a REDCap project assigned.
-The **"Sync Wearables"** button appears in the footer (view mode only, not while editing).
+Open the **Patient popup** for any patient that has a REDCap project assigned. The **"Sync Wearables"** button appears in the footer (view mode only, not while editing).
 
 - The button is disabled while a sync is in progress
-- On success a green alert shows the per-period result (`ok` / `skipped`)
-- The success alert also shows the per-period payload (`sent_payloads`) that was prepared/sent to REDCap
+- On success a green alert shows the per-period result (`ok` / `skipped`) and the payload sent to REDCap
 - On failure a red alert shows the error message
-
-### Interpreting `ok` vs `skipped`
-
-- `ok`: a best-monitoring week was found for that period and exported to REDCap.
-- `skipped`: the patient is eligible, but no Fitbit records existed in that period, so nothing is written.
 
 ---
 
@@ -131,6 +187,14 @@ curl -X POST https://<host>/api/wearables/sync-to-redcap/<patient_id>/ \
      -d '{}'
 ```
 
+To force recalculation even if already populated:
+```bash
+curl -X POST https://<host>/api/wearables/sync-to-redcap/<patient_id>/ \
+     -H "Authorization: Bearer <jwt>" \
+     -H "Content-Type: application/json" \
+     -d '{"force": true}'
+```
+
 Example success response:
 ```json
 {
@@ -141,13 +205,16 @@ Example success response:
   },
   "summary": {
     "baseline": {
-      "monitoring_start": "03-01-2024",
-      "monitoring_end": "09-01-2024",
-      "monitoring_days": 7,
-      "fitbit_steps": 6843,
-      "fitbit_pa": 42,
-      "fitbit_inactivity": 891,
-      "sleep_duration": "07:30"
+      "monitoring_start": "2025-01-08",
+      "monitoring_end":   "2025-01-28",
+      "valid_week_days":    5,
+      "valid_weekend_days": 2,
+      "valid_week_nights":  4,
+      "valid_weekend_nights": 2,
+      "fitbit_steps":       8432,
+      "fitbit_pa":          38,
+      "fitbit_inactivity":  820,
+      "sleep_duration":     "07:22"
     },
     "followup": null
   },
@@ -155,16 +222,19 @@ Example success response:
     "baseline": {
       "status": "sent",
       "record": {
-        "record_id": "123",
-        "monitoring_start": "03-01-2024",
-        "monitoring_end": "09-01-2024",
-        "monitoring_days": "7",
-        "fitbit_steps": "6843",
-        "fitbit_pa": "42",
-        "fitbit_inactivity": "891",
-        "sleep_duration": "07:30",
-        "wearables_complete": "1",
-        "redcap_event_name": "visit_baseline_arm_1"
+        "record_id":            "934-1",
+        "monitoring_start":     "2025-01-08",
+        "monitoring_end":       "2025-01-28",
+        "valid_week_days":      "5",
+        "valid_weekend_days":   "2",
+        "valid_week_nights":    "4",
+        "valid_weekend_nights": "2",
+        "fitbit_steps":         "8432",
+        "fitbit_pa":            "38",
+        "fitbit_inactivity":    "820",
+        "sleep_duration":       "07:22",
+        "wearables_complete":   "1",
+        "redcap_event_name":    "visit_baseline_arm_1"
       }
     },
     "followup": {
@@ -179,24 +249,9 @@ Possible error responses:
 
 | Status | Cause |
 |---|---|
-| 400 | Patient has no `reha_end_date`, or no `project` set |
+| 400 | Patient has no Fitbit data yet, or no `project` set |
 | 404 | `patient_id` not found |
-| 502 | REDCap API rejected the write (check `detail` field for the REDCap error message) |
-
----
-
-## Fitbit connection and data visibility
-
-- Fitbit OAuth can be successfully connected while daily wearable data is still empty.
-- The backend now avoids creating placeholder Fitbit rows when no upstream Fitbit payload is returned.
-- This prevents misleading "synced" records with all-zero values.
-- `GET /api/fitbit/status/<id>/` accepts both `Patient.id` and `User.id` and returns:
-  - `connected`: token exists
-  - `has_data`: at least one stored Fitbit row exists
-  - `last_data`: latest stored Fitbit timestamp (or `null`)
-
-Practical implication:
-- If `connected=true` and `has_data=false`, OAuth is linked but Fitbit has not provided wearable payload yet (or permissions/scopes/device wear are missing).
+| 502 | REDCap API rejected the write (check `detail` field) |
 
 ---
 
@@ -204,22 +259,27 @@ Practical implication:
 
 The task `core.tasks.sync_wearables_to_redcap_all` runs every night at **02:30 UTC**.
 
-It queries all patients where `project != ""` and `reha_end_date != null`, then calls
-`export_wearables_to_redcap` for each one. Patients with no data in a period produce
-`"skipped"` results; patients that raise errors are logged as warnings and do not block
-the rest of the run.
+It queries all patients where `project != ""`, then calls `export_wearables_to_redcap` for each one. Patients with no Fitbit data, or whose monitoring windows have not yet been reached, produce `"skipped"` results. Patients that raise errors are logged as warnings and do not block the rest of the run.
 
-To trigger the nightly task manually (from a Django shell or Celery worker):
+Because `skip_if_populated=True` by default, patients whose baseline was already exported will not be re-exported on subsequent nights.
+
+To trigger manually:
 ```python
 from core.tasks import sync_wearables_to_redcap_all
 sync_wearables_to_redcap_all.delay()
-```
 
-To trigger for a single patient:
-```python
+# Single patient
 from core.tasks import sync_wearables_to_redcap_patient
 sync_wearables_to_redcap_patient.delay("<patient_mongo_id>")
 ```
+
+---
+
+## Fitbit data availability
+
+- A patient is skipped silently on the nightly run if they have no `FitbitData` records at all.
+- If the device was not worn on a given day, that day will have `wear_time_minutes < 600` and is excluded from activity aggregation — it does not pull down the average to zero.
+- If the baseline window has not yet elapsed (e.g. the patient is still in Day 1–7), the period returns `None` and is skipped.
 
 ---
 
@@ -227,13 +287,13 @@ sync_wearables_to_redcap_patient.delay("<patient_mongo_id>")
 
 | File | Purpose |
 |---|---|
-| `backend/core/services/wearables_redcap_service.py` | Core logic: period selection, averaging, REDCap write |
-| `backend/core/views/wearables_redcap_view.py` | Manual trigger API endpoint |
-| `backend/core/tasks.py` | `sync_wearables_to_redcap_patient` and `sync_wearables_to_redcap_all` Celery tasks |
-| `backend/api/settings/base.py` | Celery beat schedule (02:30 UTC daily) |
-| `frontend/src/stores/patientPopupStore.ts` | `syncWearablesToRedcap()` MobX action |
-| `frontend/src/components/TherapistPatientPage/PatientPopup.tsx` | "Sync Wearables" button and result display |
-| `backend/tests/wearables_redcap/` | Test suite (46 tests) |
+| [backend/core/services/wearables_redcap_service.py](../backend/core/services/wearables_redcap_service.py) | Core logic: window calculation, day selection, averaging, REDCap write |
+| [backend/core/views/wearables_redcap_view.py](../backend/core/views/wearables_redcap_view.py) | Manual trigger API endpoint |
+| [backend/core/tasks.py](../backend/core/tasks.py) | `sync_wearables_to_redcap_patient` and `sync_wearables_to_redcap_all` Celery tasks |
+| [backend/api/settings/base.py](../backend/api/settings/base.py) | Celery beat schedule (02:30 UTC daily) |
+| [frontend/src/stores/patientPopupStore.ts](../frontend/src/stores/patientPopupStore.ts) | `syncWearablesToRedcap()` MobX action |
+| [frontend/src/components/TherapistPatientPage/PatientPopup.tsx](../frontend/src/components/TherapistPatientPage/PatientPopup.tsx) | "Sync Wearables" button and result display |
+| [backend/tests/wearables_redcap/](../backend/tests/wearables_redcap/) | Test suite (66 tests) |
 
 ---
 
@@ -245,13 +305,21 @@ sync_wearables_to_redcap_patient.delay("<patient_mongo_id>")
        "baseline": "baseline_event_arm_1",
        "followup":  "followup_event_arm_1",
        "sleep_duration_format": "hours_int",  # or "hhmm"
-       "baseline_anchor": "after_reha_end",   # or "before_reha_end"
    },
    ```
-2. Choose `baseline_anchor`:
-   - `"after_reha_end"` — monitoring starts at discharge (outpatient / home rehab)
-   - `"before_reha_end"` — monitoring is during the hospital stay (in-patient)
-3. Verify the `sleep_duration` field type in the REDCap data dictionary:
-   - `text (integer, Max: 24)` → use `"hours_int"`
-   - `text (time, Max: 23:59)` → use `"hhmm"`
-4. Add `REDCAP_TOKEN_NEWPROJECT=<token>` to the environment
+2. Choose `sleep_duration_format`:
+   - `"hours_int"` — REDCap field is `text (integer, Max: 24)`
+   - `"hhmm"` — REDCap field is `text (time, Max: 23:59)`
+3. Add `REDCAP_TOKEN_NEWPROJECT=<token>` to the environment.
+4. Ensure the REDCap Wearables instrument for the new project contains all required fields:
+   `monitoring_start`, `monitoring_end`, `valid_week_days`, `valid_weekend_days`,
+   `valid_week_nights`, `valid_weekend_nights`, `fitbit_steps`, `fitbit_pa`,
+   `fitbit_inactivity`, `sleep_duration`, `wearables_complete`.
+
+---
+
+## Known limitations
+
+- **`sleep_score`** — not available via Fitbit or Google Health REST APIs for standard OAuth apps. The field is reserved in the code (`None`) for future use.
+- **Missing REDCap fields** — if a project's REDCap instrument does not contain a field (e.g. `valid_week_days` added later), the API returns a 400 error. The service automatically strips the offending field and retries once, so syncs are not fully blocked. Add the field to the instrument to resolve.
+- **Monthly run cadence** — the current Celery schedule is nightly (02:30 UTC). The protocol calls for monthly processing; the nightly run is safe due to duplicate protection but slightly over-scheduled. Adjust `CELERY_BEAT_SCHEDULE` in `base.py` to change frequency.


### PR DESCRIPTION
## Description

Rewrites the wearables → REDCap aggregation logic in `backend/core/services/wearables_redcap_service.py` to match the protocol specification. The old algorithm picked the ISO week with the highest total wear time within a fixed 4-week window anchored to `reha_end_date`, then averaged all days in that week — including days with zero activity (e.g. before the device was activated), which systematically underreported steps and active minutes.

**Root cause confirmed for patient 934-1:** monitoring window started 25 May but the device was only activated 29 May, so 4 zero-activity days were included in the average and halved the reported step count.

---

### New algorithm

**Windows anchored to first Fitbit measurement date** (not `reha_end_date`):

| Period | Window |
|---|---|
| Baseline (`visit_baseline`) | Day 8 – Day 28 (first 7 days excluded for device habituation) |
| Follow-up (`visit_6m`) | Day 150 – Day 180 |

**Valid day / night thresholds:**
- Activity day: `wear_time_minutes ≥ 600` (10 hours)
- Sleep night: `minutes_asleep ≥ 180` (3 hours)

**Day selection (activity and sleep independently):**
- Pick earliest 5 valid weekdays (Mon–Fri) + 2 valid weekend days (Sat–Sun)
- Maximum 7 days per period; fewer used if not enough valid days exist

**Aggregation:**
- `fitbit_steps`, `fitbit_pa`, `fitbit_inactivity` — mean over selected valid activity days
- `sleep_duration` — mean over selected valid sleep nights (COMPASS: integer hours; COPAIN: HH:MM)
- `sleep_score` — reserved as `None`; not available via Fitbit or Google Health REST APIs

**New REDCap fields populated:**
- `valid_week_days`, `valid_weekend_days` — count of selected activity days
- `valid_week_nights`, `valid_weekend_nights` — count of selected sleep nights
- `monitoring_start`, `monitoring_end` — window boundaries (Day 8/28 or Day 150/180), not data boundaries

**Duplicate protection (`skip_if_populated=True` by default):**
If `monitoring_start` is already populated in REDCap for a given event, that period is skipped. This prevents nightly Celery runs from overwriting previously validated data. Pass `skip_if_populated=False` to force recalculation.

---

### How it runs — unchanged

| Trigger | How |
|---|---|
| Automatic | Celery Beat nightly at 02:30 UTC (`sync_wearables_to_redcap_all`) |
| Manual | "Sync wearables" button in therapist UI → `POST /api/wearables/sync-to-redcap/<patient_id>/` |

Both paths call the same `export_wearables_to_redcap` function — only the internal logic changed.

---

### Before this can be merged

The REDCap Wearables instrument needs to be updated to add the four new fields:
`valid_week_days`, `valid_weekend_days`, `valid_week_nights`, `valid_weekend_nights`

The existing `monitoring_start`, `monitoring_end`, `fitbit_steps`, `fitbit_pa`, `fitbit_inactivity`, `sleep_duration`, `wearables_complete` fields remain unchanged.

## Related Issue

[Issue — Wearables REDCap aggregation unclear](../../issues/334) *(patient 934-1 example)*

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Tests

Full test suite rewritten to cover the new algorithm. `pytest tests/wearables_redcap/test_wearables_redcap_service.py` → **46 passed**.

New test coverage includes:
- `_is_valid_activity_day` / `_is_valid_sleep_night` threshold checks
- `_split_weekday_weekend` — correct weekday/weekend splitting, capping at 5+2, earliest-first selection
- Baseline window Day 8–28 and follow-up Day 150–180 enforced correctly
- Pre-device days (outside window) excluded
- Activity and sleep selected independently
- `monitoring_start/end` reflect window boundaries, not data extent
- `valid_week_days` / `valid_weekend_days` counts in output
- Duplicate-protection (`skip_if_populated`) skips and allows forced recalculation
- COMPASS (integer hours) and COPAIN (HH:MM) sleep formatting
- REDCap 400 invalid-field retry logic

**Test Configuration**: `docker exec django pytest tests/wearables_redcap/ -q`

## Checklist

- [x] I have read the contributing guidelines.
- [x] I have read the code of conduct.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
