### PR TITLE
Fix/icf refresh resume

### DIFF
--- a/frontend/e2e/icf-monitor.spec.ts
+++ b/frontend/e2e/icf-monitor.spec.ts
@@ -445,17 +445,16 @@ test.describe('#327 — Teilnehmer:in-ID and end-screen behaviour', () => {
     await expect(page.getByText(/P001-001T1/)).not.toBeVisible();
   });
 
-  test('clicking Beenden stays on the thank-you screen and does not redirect to ID entry', async ({
+  test('end screen shows Vielen Dank without a Beenden button and does not auto-redirect', async ({
     page,
   }) => {
     await mockAudioAPIs(page);
     await stubSubmitItem(page);
 
-    // Seed localStorage so the page opens on the last question directly (#328 helper)
+    // Seed localStorage so the page opens on the last question directly
     await seedMidSurveyState(page, { questionIndex: 28, patientId: 'P01-001T1' });
     await page.goto('/icf/P01-001T1');
 
-    // The last question should be visible (question 29/29)
     await expect(page.getByText('/ 29')).toBeVisible();
 
     // Wait for the 3-second lock to lift, then submit the last answer
@@ -463,15 +462,46 @@ test.describe('#327 — Teilnehmer:in-ID and end-screen behaviour', () => {
     await expect(naBtn).toBeEnabled({ timeout: 5000 });
     await naBtn.click();
 
-    // End screen should appear
+    // End screen must appear
+    await expect(page.getByText('Vielen Dank')).toBeVisible({ timeout: 5000 });
+    await expect(page.getByText('Sie haben alles geschafft!')).toBeVisible();
+
+    // The Beenden button must NOT exist on the end screen
+    await expect(page.getByRole('button', { name: 'Beenden' })).not.toBeVisible();
+
+    // "Weiter" and "Kann ich nicht beantworten" must also be gone
+    await expect(page.getByRole('button', { name: 'Weiter' })).not.toBeVisible();
+    await expect(page.getByRole('button', { name: 'Kann ich nicht beantworten' })).not.toBeVisible();
+
+    // Page must not auto-redirect to ID entry
+    await expect(page.getByRole('heading', { name: 'Teilnehmer:in-ID' })).not.toBeVisible();
+  });
+
+  test('localStorage is cleared immediately when the last answer is submitted', async ({
+    page,
+  }) => {
+    await mockAudioAPIs(page);
+    await stubSubmitItem(page);
+
+    await seedMidSurveyState(page, { questionIndex: 28, patientId: 'P01-001T1' });
+    await page.goto('/icf/P01-001T1');
+
+    await expect(page.getByText('/ 29')).toBeVisible();
+    const naBtn = page.getByRole('button', { name: 'Kann ich nicht beantworten' });
+    await expect(naBtn).toBeEnabled({ timeout: 5000 });
+    await naBtn.click();
+
     await expect(page.getByText('Vielen Dank')).toBeVisible({ timeout: 5000 });
 
-    // Click Beenden
-    await page.getByRole('button', { name: 'Beenden' }).click();
-
-    // Must stay on the thank-you screen — no redirect to ID entry
-    await expect(page.getByText('Vielen Dank')).toBeVisible();
-    await expect(page.getByRole('heading', { name: 'Teilnehmer:in-ID' })).not.toBeVisible();
+    // All three localStorage keys must be gone after survey completion
+    const keys = await page.evaluate(() => ({
+      surveyIndex: localStorage.getItem('survey_index'),
+      sessionId: localStorage.getItem('survey_sessionId'),
+      patientId: localStorage.getItem('patient_id'),
+    }));
+    expect(keys.surveyIndex).toBeNull();
+    expect(keys.sessionId).toBeNull();
+    expect(keys.patientId).toBeNull();
   });
 });
 
@@ -505,23 +535,23 @@ test.describe('#328 — refresh mid-survey resumes at the saved question', () =>
   });
 });
 
-test.describe('#325 / #326 — updated start and info screen texts', () => {
-  test('StartScreen shows simplified scale description without the old question phrasing', async ({
-    page,
-  }) => {
+test.describe('#325 / #326 — start and info screen content', () => {
+  test('StartScreen shows full question phrasing and scale description', async ({ page }) => {
     await mockAudioAPIs(page);
     await gotoWithPatientId(page);
 
     await expect(page.getByText('Willkommen')).toBeVisible();
-    // New wording
-    await expect(page.getByText(/auf einer Skala/i)).toBeVisible();
-    // Old "Von sehr schlecht bis sehr gut …" question form must be gone
-    await expect(page.getByText(/Von sehr schlecht bis sehr gut/i)).not.toBeVisible();
+    // Scale question phrasing is shown on the start screen
+    await expect(page.getByText(/Von sehr schlecht bis sehr gut/i)).toBeVisible();
+    // Instructions for rating then explaining are present
+    await expect(page.getByText(/auf der Skala bewerten/i)).toBeVisible();
+    await expect(page.getByText(/frei dazu erzählen/i)).toBeVisible();
+    // Mic and privacy instructions are present
+    await expect(page.getByText(/Mikrofon/i)).toBeVisible();
+    await expect(page.getByText(/verschlüsselt übermittelt/i)).toBeVisible();
   });
 
-  test('InfoScreen shows simplified scale description without the old question phrasing', async ({
-    page,
-  }) => {
+  test('InfoScreen shows full question phrasing and scale description', async ({ page }) => {
     await mockAudioAPIs(page);
     await stubSubmitItem(page);
     await gotoWithPatientId(page);
@@ -533,10 +563,128 @@ test.describe('#325 / #326 — updated start and info screen texts', () => {
     await page.getByRole('button', { name: 'Information' }).click();
     await expect(page.getByRole('heading', { name: 'Information' })).toBeVisible();
 
-    // New wording
-    await expect(page.getByText(/auf einer Skala/i)).toBeVisible();
-    // Old "Von sehr schlecht bis sehr gut …" question form must be gone
-    await expect(page.getByText(/Von sehr schlecht bis sehr gut/i)).not.toBeVisible();
+    // Scale question phrasing and instructions are shown in the info overlay
+    await expect(page.getByText(/Von sehr schlecht bis sehr gut/i)).toBeVisible();
+    await expect(page.getByText(/auf der Skala bewerten/i)).toBeVisible();
+    await expect(page.getByText(/frei dazu erzählen/i)).toBeVisible();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests for refresh / resume edge cases (#328 extended)
+// ---------------------------------------------------------------------------
+
+test.describe('#328 — refresh during practice mode skips StartScreen', () => {
+  test('refresh while in practice mode (survey_sessionId set, no survey_index) shows ÜBUNGSMODUS', async ({
+    page,
+  }) => {
+    await mockAudioAPIs(page);
+    await stubSubmitItem(page);
+
+    // Simulate a refresh mid-practice: survey_sessionId was written when mic started,
+    // but survey_index was not yet written (only written when real-mode answers are saved).
+    await page.addInitScript(
+      ({ pid, sid }) => {
+        localStorage.setItem('survey_sessionId', sid);
+        localStorage.setItem('patient_id', pid);
+        // Intentionally NO survey_index
+      },
+      { pid: 'P01-001T1', sid: 'practice_session_refresh' }
+    );
+
+    await page.goto('/icf/P01-001T1');
+
+    // Must NOT show the welcome screen (testMode=false because survey_sessionId is set)
+    await expect(page.getByText('Willkommen')).not.toBeVisible();
+    await expect(page.getByRole('button', { name: 'Übungslauf starten' })).not.toBeVisible();
+
+    // Must show practice mode directly
+    await expect(page.getByText('ÜBUNGSMODUS')).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Start' })).toBeVisible();
+
+    // Navigation buttons for real survey must not appear yet
+    await expect(page.getByRole('button', { name: 'Weiter' })).not.toBeVisible();
+  });
+});
+
+test.describe('End-screen — no interactive buttons', () => {
+  test('end screen has no Beenden, Weiter, or "Kann ich nicht beantworten" buttons', async ({
+    page,
+  }) => {
+    await mockAudioAPIs(page);
+    await stubSubmitItem(page);
+
+    await seedMidSurveyState(page, { questionIndex: 28, patientId: 'P01-001T1' });
+    await page.goto('/icf/P01-001T1');
+
+    await expect(page.getByText('/ 29')).toBeVisible();
+    const naBtn = page.getByRole('button', { name: 'Kann ich nicht beantworten' });
+    await expect(naBtn).toBeEnabled({ timeout: 5000 });
+    await naBtn.click();
+
+    await expect(page.getByText('Vielen Dank')).toBeVisible({ timeout: 5000 });
+    await expect(page.getByText('Sie haben alles geschafft!')).toBeVisible();
+
+    // Survey action buttons must be gone
+    await expect(page.getByRole('button', { name: 'Beenden' })).not.toBeVisible();
+    await expect(page.getByRole('button', { name: 'Weiter' })).not.toBeVisible();
+    await expect(page.getByRole('button', { name: 'Kann ich nicht beantworten' })).not.toBeVisible();
+    await expect(page.getByRole('button', { name: 'Start' })).not.toBeVisible();
+  });
+});
+
+test.describe('Mid-survey resume — correct question shown', () => {
+  test('resuming from question 10 shows 10/29 and the correct question text', async ({ page }) => {
+    await mockAudioAPIs(page);
+    await stubSubmitItem(page);
+
+    // Question index 9 = question 10 (0-based)
+    await seedMidSurveyState(page, { questionIndex: 9, patientId: 'P01-001T1' });
+    await page.goto('/icf/P01-001T1');
+
+    // Counter should show 10 / 29
+    await expect(page.getByText('10')).toBeVisible();
+    await expect(page.getByText('/ 29')).toBeVisible();
+
+    // The 10th question text (index 9 in REAL_QUESTIONS)
+    await expect(
+      page.getByRole('heading', { name: /Herzfunktion, Atmung, Leistungsfähigkeit/i })
+    ).toBeVisible();
+
+    // Practice mode banner must be absent
+    await expect(page.getByText('ÜBUNGSMODUS')).not.toBeVisible();
+  });
+
+  test('resuming from question 1 shows 1/29 and skips practice mode', async ({ page }) => {
+    await mockAudioAPIs(page);
+    await stubSubmitItem(page);
+
+    await seedMidSurveyState(page, { questionIndex: 0, patientId: 'P01-001T1' });
+    await page.goto('/icf/P01-001T1');
+
+    await expect(page.getByText('1')).toBeVisible();
+    await expect(page.getByText('/ 29')).toBeVisible();
+    await expect(page.getByText('ÜBUNGSMODUS')).not.toBeVisible();
+    await expect(page.getByText('Willkommen')).not.toBeVisible();
+  });
+
+  test('advancing through real questions increments the counter', async ({ page }) => {
+    await mockAudioAPIs(page);
+    await stubSubmitItem(page);
+
+    await seedMidSurveyState(page, { questionIndex: 0, patientId: 'P01-001T1' });
+    await page.goto('/icf/P01-001T1');
+
+    await expect(page.getByText('/ 29')).toBeVisible();
+
+    // Wait for lock to lift, then answer Q1
+    const naBtn = page.getByRole('button', { name: 'Kann ich nicht beantworten' });
+    await expect(naBtn).toBeEnabled({ timeout: 5000 });
+    await naBtn.click();
+
+    // Counter should advance to 2
+    await expect(page.getByText('2')).toBeVisible({ timeout: 3000 });
+    await expect(page.getByText('/ 29')).toBeVisible();
   });
 });
 

--- a/frontend/e2e/icf-monitor.spec.ts
+++ b/frontend/e2e/icf-monitor.spec.ts
@@ -471,7 +471,9 @@ test.describe('#327 — Teilnehmer:in-ID and end-screen behaviour', () => {
 
     // "Weiter" and "Kann ich nicht beantworten" must also be gone
     await expect(page.getByRole('button', { name: 'Weiter' })).not.toBeVisible();
-    await expect(page.getByRole('button', { name: 'Kann ich nicht beantworten' })).not.toBeVisible();
+    await expect(
+      page.getByRole('button', { name: 'Kann ich nicht beantworten' })
+    ).not.toBeVisible();
 
     // Page must not auto-redirect to ID entry
     await expect(page.getByRole('heading', { name: 'Teilnehmer:in-ID' })).not.toBeVisible();
@@ -628,7 +630,9 @@ test.describe('End-screen — no interactive buttons', () => {
     // Survey action buttons must be gone
     await expect(page.getByRole('button', { name: 'Beenden' })).not.toBeVisible();
     await expect(page.getByRole('button', { name: 'Weiter' })).not.toBeVisible();
-    await expect(page.getByRole('button', { name: 'Kann ich nicht beantworten' })).not.toBeVisible();
+    await expect(
+      page.getByRole('button', { name: 'Kann ich nicht beantworten' })
+    ).not.toBeVisible();
     await expect(page.getByRole('button', { name: 'Start' })).not.toBeVisible();
   });
 });

--- a/frontend/src/__tests__/components/icf/EndScreen.test.tsx
+++ b/frontend/src/__tests__/components/icf/EndScreen.test.tsx
@@ -1,34 +1,30 @@
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import EndScreen from '@/components/icf/EndScreen';
 
 describe('EndScreen', () => {
-  const noop = () => {};
-
   it('renders the thank-you heading', () => {
-    render(<EndScreen onEnd={noop} />);
+    render(<EndScreen />);
     expect(screen.getByRole('heading')).toHaveTextContent('Vielen Dank');
     expect(screen.getByRole('heading')).toHaveTextContent('für Ihre Teilnahme!');
   });
 
   it('renders the congratulatory text', () => {
-    render(<EndScreen onEnd={noop} />);
+    render(<EndScreen />);
     expect(screen.getByText('Sie haben alles geschafft!')).toBeInTheDocument();
   });
 
   it('renders the logo', () => {
-    render(<EndScreen onEnd={noop} />);
+    render(<EndScreen />);
     expect(screen.getByAltText('Logo')).toBeInTheDocument();
   });
 
-  it('renders the Beenden button', () => {
-    render(<EndScreen onEnd={noop} />);
-    expect(screen.getByRole('button', { name: 'Beenden' })).toBeInTheDocument();
+  it('does not render a Beenden button', () => {
+    render(<EndScreen />);
+    expect(screen.queryByRole('button', { name: 'Beenden' })).not.toBeInTheDocument();
   });
 
-  it('calls onEnd when Beenden is clicked', () => {
-    const onEnd = jest.fn();
-    render(<EndScreen onEnd={onEnd} />);
-    fireEvent.click(screen.getByRole('button', { name: 'Beenden' }));
-    expect(onEnd).toHaveBeenCalledTimes(1);
+  it('does not render any button', () => {
+    render(<EndScreen />);
+    expect(screen.queryAllByRole('button')).toHaveLength(0);
   });
 });

--- a/frontend/src/__tests__/pages/HealthSlider.fullsync.test.tsx
+++ b/frontend/src/__tests__/pages/HealthSlider.fullsync.test.tsx
@@ -618,6 +618,7 @@ describe('HealthSlider (Full Sync)', () => {
   });
 
   it('REC dot disappears after recording stops (summary screen)', async () => {
+    // allow 10 s — 3 s are spent waiting for the question-lock timer to lift
     // Pre-seed a mid-survey state at the last question (#328: testMode skips StartScreen
     // when survey_index exists, so mic is not started via the welcome screen).
     localStorage.setItem('survey_index', '28');
@@ -629,28 +630,26 @@ describe('HealthSlider (Full Sync)', () => {
     await waitFor(() => expect(screen.getByText('/ 29')).toBeInTheDocument());
     expect(screen.queryByLabelText('Aufnahme läuft')).not.toBeInTheDocument();
 
-    // Wait for the 3s lock to lift then submit the last answer
-    await waitFor(() => expect(screen.getByRole('button', { name: 'Weiter' })).not.toBeDisabled(), {
-      timeout: 5000,
-    });
-
-    const track = screen.getByRole('group', { name: 'Schieberegler vertikal' });
-    fireEvent.click(track, { clientY: 0 });
+    // Wait for the 3s lock to lift then submit the last answer via "Kann ich nicht
+    // beantworten" — this bypasses the slider-moved guard so state-flush order
+    // doesn't matter.
+    const naBtn = screen.getByRole('button', { name: 'Kann ich nicht beantworten' });
+    await waitFor(() => expect(naBtn).not.toBeDisabled(), { timeout: 5000 });
 
     await act(async () => {
-      fireEvent.click(screen.getByRole('button', { name: 'Weiter' }));
+      fireEvent.click(naBtn);
       await Promise.resolve();
       await Promise.resolve();
       await Promise.resolve();
     });
 
-    // Summary screen appears and REC dot is still absent
+    // Summary screen appears (no Beenden button — removed in this branch)
     await waitFor(
-      () => expect(screen.getByRole('button', { name: 'Beenden' })).toBeInTheDocument(),
+      () => expect(screen.getByRole('heading', { name: /Vielen Dank/ })).toBeInTheDocument(),
       { timeout: 3000 }
     );
     expect(screen.queryByLabelText('Aufnahme läuft')).not.toBeInTheDocument();
-  });
+  }, 10_000);
 
   it('MediaRecorder onerror: shows upload-fail modal with partial-audio download', async () => {
     // Give the mock recorder an onerror we can trigger manually
@@ -843,5 +842,117 @@ describe('HealthSlider (Full Sync)', () => {
 
     // The progress-row REC dot must still be present — recording was not stopped
     expect(screen.getByLabelText('Aufnahme läuft')).toBeInTheDocument();
+  });
+
+  // ─── Refresh / resume edge cases ──────────────────────────────────────────
+
+  it('refresh during practice mode (survey_sessionId set, no survey_index) shows practice mode, not StartScreen', async () => {
+    // Simulate a page refresh that happened while the user was in practice mode.
+    // survey_sessionId is written to localStorage when mic starts, before practice
+    // mode is shown. survey_index is only written when real-mode answers are saved.
+    localStorage.setItem('survey_sessionId', 'practice-session-abc');
+    localStorage.setItem('patient_id', 'P001-001T1');
+    // Deliberately NO survey_index
+
+    render(<HealthSlider />);
+
+    // Must NOT show the welcome screen (testMode should be false)
+    expect(screen.queryByText('Willkommen')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Übungslauf starten/i })).not.toBeInTheDocument();
+
+    // Must show practice mode
+    await waitFor(() => expect(screen.getByText(/ÜBUNGSMODUS/i)).toBeInTheDocument());
+    expect(screen.getByRole('button', { name: 'Start' })).toBeInTheDocument();
+  });
+
+  it('fresh start with no localStorage shows PatientIdScreen', () => {
+    // Ensure nothing in localStorage and no URL param
+    render(<HealthSlider />);
+    expect(screen.getByRole('heading', { name: 'Teilnehmer:in-ID' })).toBeInTheDocument();
+    expect(screen.queryByText('Willkommen')).not.toBeInTheDocument();
+    expect(screen.queryByText(/ÜBUNGSMODUS/i)).not.toBeInTheDocument();
+  });
+
+  it('localStorage is cleared when the last answer is submitted', async () => {
+    localStorage.setItem('survey_index', '28');
+    localStorage.setItem('survey_sessionId', 'end-session');
+    localStorage.setItem('patient_id', 'P001-001T1');
+
+    render(<HealthSlider />);
+    await waitFor(() => expect(screen.getByText('/ 29')).toBeInTheDocument());
+
+    const naBtn = screen.getByRole('button', { name: 'Kann ich nicht beantworten' });
+    await waitFor(() => expect(naBtn).not.toBeDisabled(), { timeout: 5000 });
+
+    await act(async () => {
+      fireEvent.click(naBtn);
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    await waitFor(
+      () => expect(screen.getByRole('heading', { name: /Vielen Dank/ })).toBeInTheDocument(),
+      { timeout: 3000 }
+    );
+
+    expect(localStorage.getItem('survey_index')).toBeNull();
+    expect(localStorage.getItem('survey_sessionId')).toBeNull();
+    expect(localStorage.getItem('patient_id')).toBeNull();
+  }, 10_000);
+
+  it('end screen has no Beenden button and no Weiter button', async () => {
+    localStorage.setItem('survey_index', '28');
+    localStorage.setItem('survey_sessionId', 'end-session-2');
+    localStorage.setItem('patient_id', 'P001-001T1');
+
+    render(<HealthSlider />);
+    await waitFor(() => expect(screen.getByText('/ 29')).toBeInTheDocument());
+
+    const naBtn = screen.getByRole('button', { name: 'Kann ich nicht beantworten' });
+    await waitFor(() => expect(naBtn).not.toBeDisabled(), { timeout: 5000 });
+
+    await act(async () => {
+      fireEvent.click(naBtn);
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    await waitFor(
+      () => expect(screen.getByRole('heading', { name: /Vielen Dank/ })).toBeInTheDocument(),
+      { timeout: 3000 }
+    );
+
+    expect(screen.queryByRole('button', { name: 'Beenden' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Weiter' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Kann ich nicht beantworten' })).not.toBeInTheDocument();
+    expect(screen.getByText('Sie haben alles geschafft!')).toBeInTheDocument();
+  }, 10_000);
+
+  it('survey_index is written to localStorage when advancing from question 1 to question 2', async () => {
+    render(<HealthSlider />);
+    await enterPatientId();
+    fireEvent.click(screen.getByRole('button', { name: /Übungslauf starten/i }));
+    await waitFor(() => expect(screen.getByText(/ÜBUNGSMODUS/i)).toBeInTheDocument());
+
+    // Practice → real
+    fireEvent.click(screen.getByRole('button', { name: 'Start' }));
+    await waitFor(() => expect(screen.getByText('/ 29')).toBeInTheDocument());
+
+    // Wait for lock to lift
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Weiter' })).not.toBeDisabled(), {
+      timeout: 5000,
+    });
+
+    // survey_index = 0 for question 1 should already be in localStorage
+    expect(localStorage.getItem('survey_index')).toBe('0');
+    expect(localStorage.getItem('survey_sessionId')).not.toBeNull();
+
+    // Advance to Q2
+    fireEvent.click(screen.getByRole('button', { name: 'Kann ich nicht beantworten' }));
+    await act(async () => { await Promise.resolve(); });
+
+    await waitFor(() => expect(localStorage.getItem('survey_index')).toBe('1'), { timeout: 3000 });
   });
 });

--- a/frontend/src/__tests__/pages/HealthSlider.fullsync.test.tsx
+++ b/frontend/src/__tests__/pages/HealthSlider.fullsync.test.tsx
@@ -1,5 +1,15 @@
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import HealthSlider from '@/pages/eva2';
+
+const renderICF = (initialPath = '/icf') =>
+  render(
+    <MemoryRouter initialEntries={[initialPath]}>
+      <Routes>
+        <Route path="/icf/:patientId?" element={<HealthSlider />} />
+      </Routes>
+    </MemoryRouter>
+  );
 
 function mockMedia() {
   // mock getUserMedia
@@ -118,13 +128,11 @@ describe('HealthSlider (Full Sync)', () => {
   });
 
   it('prompts for patient id (Pxxx-xxxTx) and stores it', async () => {
-    render(<HealthSlider />);
+    renderICF();
     await enterPatientId();
 
-    // Check patient ID is stored
-    expect(localStorage.getItem('patient_id')).toBe('P001-001T1');
-
-    // Now click mic permission button
+    // Patient ID is encoded in the URL (no localStorage write) — verify it
+    // appears in the footer once we enter the survey proper.
     fireEvent.click(screen.getByRole('button', { name: /Übungslauf starten/i }));
 
     await waitFor(() => {
@@ -135,7 +143,7 @@ describe('HealthSlider (Full Sync)', () => {
   it.skip('shows "middle slider" modal if user clicks Weiter without moving (still 50)', async () => {
     // This test needs to be updated for eva2.tsx behavior
     // The modal might appear differently or have different timing
-    render(<HealthSlider />);
+    renderICF();
     await enterPatientId();
     fireEvent.click(screen.getByRole('button', { name: /Übungslauf starten/i }));
     // Wait for practice mode to load
@@ -161,7 +169,7 @@ describe('HealthSlider (Full Sync)', () => {
   it.skip('sliderPosition resets to 50 after next (practice → real), and after successful real Next', async () => {
     // This test needs to be updated for eva2.tsx slider behavior
     // The slider attributes and timing may differ from eva.tsx
-    render(<HealthSlider />);
+    renderICF();
     await enterPatientId();
     fireEvent.click(screen.getByRole('button', { name: /Übungslauf starten/i }));
 
@@ -218,7 +226,7 @@ describe('HealthSlider (Full Sync)', () => {
     localStorage.setItem('survey_index', 'not-a-number');
     localStorage.setItem('survey_sessionId', 'abc');
 
-    render(<HealthSlider />);
+    renderICF();
 
     // banner appears
     expect(await screen.findByRole('alert')).toHaveTextContent(
@@ -241,7 +249,7 @@ describe('HealthSlider (Full Sync)', () => {
     // make upload fail
     (window.fetch as any).mockResolvedValueOnce({ ok: false, status: 500 });
 
-    render(<HealthSlider />);
+    renderICF();
     await enterPatientId();
     fireEvent.click(screen.getByRole('button', { name: /Übungslauf starten/i }));
 
@@ -319,7 +327,7 @@ describe('HealthSlider (Full Sync)', () => {
     // @ts-expect-error -- replacing global AudioContext with mock constructor in jsdom
     global.AudioContext = ACtor;
 
-    render(<HealthSlider />);
+    renderICF();
     await enterPatientId();
 
     // Start mic -> leaves testMode, enters practice UI
@@ -364,7 +372,7 @@ describe('HealthSlider (Full Sync)', () => {
 
   // ─── Centering ────────────────────────────────────────────────────────────
   it('practice mode: Start button is visible and bell/play buttons are available', async () => {
-    render(<HealthSlider />);
+    renderICF();
     await enterPatientId();
     fireEvent.click(screen.getByRole('button', { name: /Übungslauf starten/i }));
 
@@ -382,7 +390,7 @@ describe('HealthSlider (Full Sync)', () => {
   });
 
   it('real mode: bell and play buttons appear after Start', async () => {
-    render(<HealthSlider />);
+    renderICF();
     await enterPatientId();
     fireEvent.click(screen.getByRole('button', { name: /Übungslauf starten/i }));
 
@@ -397,7 +405,7 @@ describe('HealthSlider (Full Sync)', () => {
 
   // ─── Slider moveable while locked ─────────────────────────────────────────
   it('slider can be moved while buttons are locked (isLocked)', async () => {
-    render(<HealthSlider />);
+    renderICF();
     await enterPatientId();
     fireEvent.click(screen.getByRole('button', { name: /Übungslauf starten/i }));
     await waitFor(() => expect(screen.getByText(/ÜBUNGSMODUS/i)).toBeInTheDocument());
@@ -437,7 +445,7 @@ describe('HealthSlider (Full Sync)', () => {
   it('toggling bell button does not re-lock the screen', async () => {
     jest.useFakeTimers();
 
-    render(<HealthSlider />);
+    renderICF();
     await enterPatientId();
     fireEvent.click(screen.getByRole('button', { name: /Übungslauf starten/i }));
     await waitFor(() => expect(screen.getByText(/ÜBUNGSMODUS/i)).toBeInTheDocument());
@@ -472,7 +480,7 @@ describe('HealthSlider (Full Sync)', () => {
 
   // ─── Slider full range 0–100 ───────────────────────────────────────────────
   it('slider reaches 100 at top and 0 at bottom (no 3–97 cap)', async () => {
-    render(<HealthSlider />);
+    renderICF();
     await enterPatientId();
     fireEvent.click(screen.getByRole('button', { name: /Übungslauf starten/i }));
     await waitFor(() => expect(screen.getByText(/ÜBUNGSMODUS/i)).toBeInTheDocument());
@@ -493,7 +501,7 @@ describe('HealthSlider (Full Sync)', () => {
   it('lock lifts after 3 seconds, not 5', async () => {
     jest.useFakeTimers();
 
-    render(<HealthSlider />);
+    renderICF();
     await enterPatientId();
     fireEvent.click(screen.getByRole('button', { name: /Übungslauf starten/i }));
     await waitFor(() => expect(screen.getByText(/ÜBUNGSMODUS/i)).toBeInTheDocument());
@@ -525,7 +533,7 @@ describe('HealthSlider (Full Sync)', () => {
     const savedMR = (global as any).MediaRecorder;
     delete (global as any).MediaRecorder;
 
-    render(<HealthSlider />);
+    renderICF();
     await enterPatientId();
     fireEvent.click(screen.getByRole('button', { name: /Übungslauf starten/i }));
 
@@ -545,7 +553,7 @@ describe('HealthSlider (Full Sync)', () => {
       return { preload: 'auto' } as any;
     } as any;
 
-    render(<HealthSlider />);
+    renderICF();
     await enterPatientId();
 
     // Start mic -> practice mode view
@@ -574,7 +582,7 @@ describe('HealthSlider (Full Sync)', () => {
   });
 
   it('retries item audio playback across fallback sources and clears playback error on success', async () => {
-    render(<HealthSlider />);
+    renderICF();
     await enterPatientId();
 
     fireEvent.click(screen.getByRole('button', { name: /Übungslauf starten/i }));
@@ -603,7 +611,7 @@ describe('HealthSlider (Full Sync)', () => {
   // ─── Error handling ───────────────────────────────────────────────────────
 
   it('shows pulsing REC dot while recording is active', async () => {
-    render(<HealthSlider />);
+    renderICF();
     await enterPatientId();
 
     fireEvent.click(screen.getByRole('button', { name: /Übungslauf starten/i }));
@@ -623,8 +631,7 @@ describe('HealthSlider (Full Sync)', () => {
     // when survey_index exists, so mic is not started via the welcome screen).
     localStorage.setItem('survey_index', '28');
     localStorage.setItem('survey_sessionId', 'test-session');
-    localStorage.setItem('patient_id', 'P001-001T1');
-    render(<HealthSlider />);
+    renderICF('/icf/P001-001T1');
 
     // Survey opens directly at Q29 (no StartScreen, no mic) — REC dot not present
     await waitFor(() => expect(screen.getByText('/ 29')).toBeInTheDocument());
@@ -667,7 +674,7 @@ describe('HealthSlider (Full Sync)', () => {
     }
     (global as any).MediaRecorder = ErrorableRecorder;
 
-    render(<HealthSlider />);
+    renderICF();
     await enterPatientId();
 
     fireEvent.click(screen.getByRole('button', { name: /Übungslauf starten/i }));
@@ -694,7 +701,7 @@ describe('HealthSlider (Full Sync)', () => {
   });
 
   it('recorderWarning banner appears and can be dismissed when startItemRecorder throws', async () => {
-    render(<HealthSlider />);
+    renderICF();
     await enterPatientId();
 
     fireEvent.click(screen.getByRole('button', { name: /Übungslauf starten/i }));
@@ -739,7 +746,7 @@ describe('HealthSlider (Full Sync)', () => {
   });
 
   it('visibilitychange: resumes AudioContext when tab becomes visible without crashing', async () => {
-    render(<HealthSlider />);
+    renderICF();
     await enterPatientId();
 
     // Click past the mic screen into practice mode
@@ -767,7 +774,7 @@ describe('HealthSlider (Full Sync)', () => {
   // ─── Info overlay ─────────────────────────────────────────────────────────
 
   it('Info button opens the info overlay', async () => {
-    render(<HealthSlider />);
+    renderICF();
     await enterPatientId();
     fireEvent.click(screen.getByRole('button', { name: /Übungslauf starten/i }));
     await waitFor(() => expect(screen.getByText(/ÜBUNGSMODUS/i)).toBeInTheDocument());
@@ -783,7 +790,7 @@ describe('HealthSlider (Full Sync)', () => {
   });
 
   it('"zurück" button closes the info overlay and leaves the survey intact', async () => {
-    render(<HealthSlider />);
+    renderICF();
     await enterPatientId();
     fireEvent.click(screen.getByRole('button', { name: /Übungslauf starten/i }));
     await waitFor(() => expect(screen.getByText(/ÜBUNGSMODUS/i)).toBeInTheDocument());
@@ -802,7 +809,7 @@ describe('HealthSlider (Full Sync)', () => {
   });
 
   it('info overlay shows the recording indicator when a recording is active', async () => {
-    render(<HealthSlider />);
+    renderICF();
     await enterPatientId();
     fireEvent.click(screen.getByRole('button', { name: /Übungslauf starten/i }));
     await waitFor(() => expect(screen.getByText(/ÜBUNGSMODUS/i)).toBeInTheDocument());
@@ -823,7 +830,7 @@ describe('HealthSlider (Full Sync)', () => {
   });
 
   it('closing the info overlay does not interrupt recording', async () => {
-    render(<HealthSlider />);
+    renderICF();
     await enterPatientId();
     fireEvent.click(screen.getByRole('button', { name: /Übungslauf starten/i }));
     await waitFor(() => expect(screen.getByText(/ÜBUNGSMODUS/i)).toBeInTheDocument());
@@ -851,10 +858,9 @@ describe('HealthSlider (Full Sync)', () => {
     // survey_sessionId is written to localStorage when mic starts, before practice
     // mode is shown. survey_index is only written when real-mode answers are saved.
     localStorage.setItem('survey_sessionId', 'practice-session-abc');
-    localStorage.setItem('patient_id', 'P001-001T1');
     // Deliberately NO survey_index
 
-    render(<HealthSlider />);
+    renderICF('/icf/P001-001T1');
 
     // Must NOT show the welcome screen (testMode should be false)
     expect(screen.queryByText('Willkommen')).not.toBeInTheDocument();
@@ -867,7 +873,7 @@ describe('HealthSlider (Full Sync)', () => {
 
   it('fresh start with no localStorage shows PatientIdScreen', () => {
     // Ensure nothing in localStorage and no URL param
-    render(<HealthSlider />);
+    renderICF();
     expect(screen.getByRole('heading', { name: 'Teilnehmer:in-ID' })).toBeInTheDocument();
     expect(screen.queryByText('Willkommen')).not.toBeInTheDocument();
     expect(screen.queryByText(/ÜBUNGSMODUS/i)).not.toBeInTheDocument();
@@ -876,9 +882,8 @@ describe('HealthSlider (Full Sync)', () => {
   it('localStorage is cleared when the last answer is submitted', async () => {
     localStorage.setItem('survey_index', '28');
     localStorage.setItem('survey_sessionId', 'end-session');
-    localStorage.setItem('patient_id', 'P001-001T1');
 
-    render(<HealthSlider />);
+    renderICF('/icf/P001-001T1');
     await waitFor(() => expect(screen.getByText('/ 29')).toBeInTheDocument());
 
     const naBtn = screen.getByRole('button', { name: 'Kann ich nicht beantworten' });
@@ -898,15 +903,13 @@ describe('HealthSlider (Full Sync)', () => {
 
     expect(localStorage.getItem('survey_index')).toBeNull();
     expect(localStorage.getItem('survey_sessionId')).toBeNull();
-    expect(localStorage.getItem('patient_id')).toBeNull();
   }, 10_000);
 
   it('end screen has no Beenden button and no Weiter button', async () => {
     localStorage.setItem('survey_index', '28');
     localStorage.setItem('survey_sessionId', 'end-session-2');
-    localStorage.setItem('patient_id', 'P001-001T1');
 
-    render(<HealthSlider />);
+    renderICF('/icf/P001-001T1');
     await waitFor(() => expect(screen.getByText('/ 29')).toBeInTheDocument());
 
     const naBtn = screen.getByRole('button', { name: 'Kann ich nicht beantworten' });
@@ -933,7 +936,7 @@ describe('HealthSlider (Full Sync)', () => {
   }, 10_000);
 
   it('survey_index is written to localStorage when advancing from question 1 to question 2', async () => {
-    render(<HealthSlider />);
+    renderICF();
     await enterPatientId();
     fireEvent.click(screen.getByRole('button', { name: /Übungslauf starten/i }));
     await waitFor(() => expect(screen.getByText(/ÜBUNGSMODUS/i)).toBeInTheDocument());

--- a/frontend/src/__tests__/pages/HealthSlider.fullsync.test.tsx
+++ b/frontend/src/__tests__/pages/HealthSlider.fullsync.test.tsx
@@ -926,7 +926,9 @@ describe('HealthSlider (Full Sync)', () => {
 
     expect(screen.queryByRole('button', { name: 'Beenden' })).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Weiter' })).not.toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: 'Kann ich nicht beantworten' })).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'Kann ich nicht beantworten' })
+    ).not.toBeInTheDocument();
     expect(screen.getByText('Sie haben alles geschafft!')).toBeInTheDocument();
   }, 10_000);
 
@@ -951,7 +953,9 @@ describe('HealthSlider (Full Sync)', () => {
 
     // Advance to Q2
     fireEvent.click(screen.getByRole('button', { name: 'Kann ich nicht beantworten' }));
-    await act(async () => { await Promise.resolve(); });
+    await act(async () => {
+      await Promise.resolve();
+    });
 
     await waitFor(() => expect(localStorage.getItem('survey_index')).toBe('1'), { timeout: 3000 });
   });

--- a/frontend/src/components/icf/EndScreen.tsx
+++ b/frontend/src/components/icf/EndScreen.tsx
@@ -1,12 +1,8 @@
 import logoImage from '@/assets/icf/logo_funktionsbarometer.png';
-import { FlowerButtonRow, FlowerSides } from './FlowerDecoration';
+import { FlowerSides } from './FlowerDecoration';
 import '@/assets/styles/icf.css';
 
-interface Props {
-  onEnd: () => void;
-}
-
-export default function EndScreen({ onEnd }: Props) {
+export default function EndScreen() {
   return (
     <div className="icf-overlay text-center">
       <FlowerSides />
@@ -21,12 +17,6 @@ export default function EndScreen({ onEnd }: Props) {
       <p className="mt-6 font-bold text-xl md:text-2xl text-[#FF9A57]">
         Sie haben alles geschafft!
       </p>
-
-      <FlowerButtonRow style={{ marginTop: 24 }}>
-        <button type="button" className="icf-btn icf-btn--primary icf-btn--auto" onClick={onEnd}>
-          Beenden
-        </button>
-      </FlowerButtonRow>
     </div>
   );
 }

--- a/frontend/src/components/icf/InfoScreen.tsx
+++ b/frontend/src/components/icf/InfoScreen.tsx
@@ -24,7 +24,8 @@ export default function InfoScreen({ isRecording, onClose }: Props) {
 
       <div className="mt-6 max-w-2xl">
         <p className="mb-3.5">
-          Das <strong>
+          Das{' '}
+          <strong>
             <i>FunktionsBarometer</i>
           </strong>{' '}
           ist ein interaktives Instrument zur Erhebung Ihrer Funktionsfähigkeit.
@@ -33,14 +34,17 @@ export default function InfoScreen({ isRecording, onClose }: Props) {
         <p className="mb-3.5">
           Dafür nennen wir Ihnen Themen und Bereiche, welche Sie mit der Frage{' '}
           <strong>
-            <i>“Von sehr schlecht bis sehr gut, wie geht es in dem folgenden Bereich, jetzt und in den letzten Tagen  … “</i>
+            <i>
+              “Von sehr schlecht bis sehr gut, wie geht es in dem folgenden Bereich, jetzt und in
+              den letzten Tagen … “
+            </i>
           </strong>{' '}
           bewerten dürfen.
         </p>
 
         <p className="mb-3.5">
-          Zuerst dürfen Sie den Bereich auf der Skala bewerten. Danach erklären Sie uns Ihre Bewertung,
-          indem Sie frei dazu erzählen.
+          Zuerst dürfen Sie den Bereich auf der Skala bewerten. Danach erklären Sie uns Ihre
+          Bewertung, indem Sie frei dazu erzählen.
         </p>
 
         <div className="mb-3.5">

--- a/frontend/src/components/icf/InfoScreen.tsx
+++ b/frontend/src/components/icf/InfoScreen.tsx
@@ -24,25 +24,23 @@ export default function InfoScreen({ isRecording, onClose }: Props) {
 
       <div className="mt-6 max-w-2xl">
         <p className="mb-3.5">
-          Der{' '}
-          <strong>
+          Das <strong>
             <i>FunktionsBarometer</i>
           </strong>{' '}
           ist ein interaktives Instrument zur Erhebung Ihrer Funktionsfähigkeit.
         </p>
 
         <p className="mb-3.5">
-          Dafür werden wir Ihnen Themen und Bereiche nennen, welche Sie auf einer Skala{' '}
+          Dafür nennen wir Ihnen Themen und Bereiche, welche Sie mit der Frage{' '}
           <strong>
-            <i>bewerten</i>
+            <i>“Von sehr schlecht bis sehr gut, wie geht es in dem folgenden Bereich, jetzt und in den letzten Tagen  … “</i>
           </strong>{' '}
-          dürfen.
-          <br />
-          Erklären Sie uns Ihre Bewertung, indem Sie einfach{' '}
-          <strong>
-            <i>frei erzählen</i>
-          </strong>
-          .
+          bewerten dürfen.
+        </p>
+
+        <p className="mb-3.5">
+          Zuerst dürfen Sie den Bereich auf der Skala bewerten. Danach erklären Sie uns Ihre Bewertung,
+          indem Sie frei dazu erzählen.
         </p>
 
         <div className="mb-3.5">
@@ -60,16 +58,18 @@ export default function InfoScreen({ isRecording, onClose }: Props) {
           <strong>
             <i>verschlüsselt übermittelt</i>
           </strong>
-          , nennen Sie dennoch bitte keine Namen oder andere identifizierende Merkmale.
+          , nennen Sie dennoch, wenn möglich bitte keine Namen oder andere identifizierenden
+          Merkmale.
         </p>
 
         <p className="mb-3.5">
-          Dieses Instrument wird als interaktiver Fragebogen verstanden. Bei Bedarf an medizinischer
-          Unterstützung wenden Sie sich bitte an Ihre/n behandelnde/n Ärztin/Arzt.
+          Wir möchten Sie gerne daran erinnern, dass dieses Instrument als interaktiver Fragebogen
+          verstanden wird. Wenn Sie ergänzend medizinische Unterstützung wünschen, wenden Sie sich
+          bitte an Ihre/n behandelnde/n Ärztin/Arzt.
         </p>
 
         <p className="mb-3.5">
-          Die Informationen von dieser Seite können jederzeit über den{' '}
+          Die Informationen von dieser Seite können jeder Zeit über den{' '}
           <strong>
             <i>hellgrünen Infobutton</i>
           </strong>{' '}

--- a/frontend/src/components/icf/StartScreen.tsx
+++ b/frontend/src/components/icf/StartScreen.tsx
@@ -27,7 +27,10 @@ export default function StartScreen({ micError, onStart }: Props) {
         <p className="mb-3.5">
           Dafür werden wir Ihnen Themen und Bereiche nennen, welche Sie mit der Frage{' '}
           <strong>
-            <i>“Von sehr schlecht bis sehr gut, wie geht es in dem folgenden Bereich, jetzt und in den letzten Tagen  … “</i>
+            <i>
+              “Von sehr schlecht bis sehr gut, wie geht es in dem folgenden Bereich, jetzt und in
+              den letzten Tagen … “
+            </i>
           </strong>{' '}
           bewerten dürfen.
         </p>

--- a/frontend/src/components/icf/StartScreen.tsx
+++ b/frontend/src/components/icf/StartScreen.tsx
@@ -21,21 +21,20 @@ export default function StartScreen({ micError, onStart }: Props) {
           <strong>
             <i>FunktionsBarometer</i>
           </strong>
-          , dem interaktiven Instrument zur Erhebung Ihrer Funktionsfähigkeit.
+          , ein interaktives Instrument zur Erhebung Ihrer Funktionsfähigkeit.
         </p>
 
         <p className="mb-3.5">
-          Dafür werden wir Ihnen Themen und Bereiche nennen, welche Sie auf einer Skala{' '}
+          Dafür werden wir Ihnen Themen und Bereiche nennen, welche Sie mit der Frage{' '}
           <strong>
-            <i>bewerten</i>
+            <i>“Von sehr schlecht bis sehr gut, wie geht es in dem folgenden Bereich, jetzt und in den letzten Tagen  … “</i>
           </strong>{' '}
-          dürfen.
-          <br />
-          Erklären Sie uns Ihre Bewertung, indem Sie einfach{' '}
-          <strong>
-            <i>frei erzählen</i>
-          </strong>
-          .
+          bewerten dürfen.
+        </p>
+
+        <p className="mb-3.5">
+          Zuerst dürfen Sie den Bereich auf der Skala bewerten. Danach erklären Sie uns Ihre
+          Bewertung, indem Sie frei dazu erzählen.
         </p>
 
         <div className="mb-3.5">
@@ -53,16 +52,18 @@ export default function StartScreen({ micError, onStart }: Props) {
           <strong>
             <i>verschlüsselt übermittelt</i>
           </strong>
-          , nennen Sie dennoch bitte keine Namen oder andere identifizierende Merkmale.
+          , nennen Sie dennoch, wenn möglich bitte keine Namen oder andere identifizierenden
+          Merkmale.
         </p>
 
         <p className="mb-3.5">
-          Dieses Instrument wird als interaktiver Fragebogen verstanden. Bei Bedarf an medizinischer
-          Unterstützung wenden Sie sich bitte an Ihre/n behandelnde/n Ärztin/Arzt.
+          Wir möchten Sie gerne daran erinnern, dass dieses Instrument als interaktiver Fragebogen
+          verstanden wird. Wenn Sie ergänzend medizinische Unterstützung wünschen, wenden Sie sich
+          bitte an Ihre/n behandelnde/n Ärztin/Arzt.
         </p>
 
         <p className="mb-3.5">
-          Die Informationen von dieser Seite können jederzeit über den{' '}
+          Die Informationen von dieser Seite können jeder Zeit über den{' '}
           <strong>
             <i>hellgrünen Infobutton</i>
           </strong>{' '}

--- a/frontend/src/pages/eva2.tsx
+++ b/frontend/src/pages/eva2.tsx
@@ -392,10 +392,10 @@ export default function HealthSlider() {
     }
   }, [isPracticeMode, questionIndex]);
 
-  /** --- sync URL-provided patient ID to in-memory state (avoid persistent cleartext storage) --- */
   useEffect(() => {
     if (urlPatientId) {
       setPatientId(urlPatientId);
+      localStorage.setItem('patient_id', urlPatientId);
       setPatientIdError('');
     }
   }, [urlPatientId]);
@@ -657,6 +657,10 @@ export default function HealthSlider() {
       }
 
       ensureSessionId();
+      // Persist sessionId immediately so a refresh during practice mode also
+      // skips the welcome screen (testMode initialises to false when either
+      // survey_index or survey_sessionId is present in localStorage).
+      if (sessionIdRef.current) localStorage.setItem('survey_sessionId', sessionIdRef.current);
       startItemRecorder();
 
       setTestMode(false);

--- a/frontend/src/pages/eva2.tsx
+++ b/frontend/src/pages/eva2.tsx
@@ -15,11 +15,12 @@
  *                         Each answer POSTs to /api/healthslider/submit-item/ including
  *                         participantId, sessionId, questionIndex, answerValue, and the
  *                         recorded audio Blob (webm or m4a depending on browser).
- * 5. Summary / end      — shown after the last question; "Beenden" clears localStorage.
+ * 5. Summary / end      — shown after the last question; localStorage is cleared immediately
+ *                         before the end screen renders (no "Beenden" button).
  *
  * Persistence (localStorage)
  * --------------------------
- * patient_id        — survives page reloads; cleared at survey end ("Beenden").
+ * patient_id        — survives page reloads; cleared when the last answer is submitted.
  * survey_index      — allows resuming mid-survey after accidental reload.
  * survey_sessionId  — groups all answers for a single sitting.
  *
@@ -688,6 +689,9 @@ export default function HealthSlider() {
       setSliderPosition(50);
       setSliderMoved(false);
     } else {
+      localStorage.removeItem('survey_index');
+      localStorage.removeItem('survey_sessionId');
+      localStorage.removeItem('patient_id');
       setShowSummary(true);
       stopAll();
     }
@@ -735,6 +739,9 @@ export default function HealthSlider() {
           }
         }, 0);
       } else {
+        localStorage.removeItem('survey_index');
+        localStorage.removeItem('survey_sessionId');
+        localStorage.removeItem('patient_id');
         setShowSummary(true);
         stopAll();
       }
@@ -1104,13 +1111,7 @@ export default function HealthSlider() {
       )}
 
       {showSummary && (
-        <EndScreen
-          onEnd={() => {
-            localStorage.removeItem('survey_index');
-            localStorage.removeItem('survey_sessionId');
-            localStorage.removeItem('patient_id');
-          }}
-        />
+        <EndScreen />
       )}
 
       {showInfo && <InfoScreen isRecording={isRecording} onClose={() => setShowInfo(false)} />}

--- a/frontend/src/pages/eva2.tsx
+++ b/frontend/src/pages/eva2.tsx
@@ -20,9 +20,12 @@
  *
  * Persistence (localStorage)
  * --------------------------
- * patient_id        — survives page reloads; cleared when the last answer is submitted.
  * survey_index      — allows resuming mid-survey after accidental reload.
- * survey_sessionId  — groups all answers for a single sitting.
+ * survey_sessionId  — groups all answers for a single sitting; also signals that mic
+ *                     was started so a refresh during practice mode skips the welcome screen.
+ *
+ * The patient ID is NOT stored in localStorage — it lives in the URL (/icf/:patientId)
+ * which the browser preserves across reloads automatically.
  *
  * Upload failure handling
  * -----------------------
@@ -31,7 +34,7 @@
  */
 
 import { useState, useRef, useEffect, useCallback } from 'react';
-import { useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 
 import { PlayFill, BellFill, BellSlashFill, InfoLg } from 'react-bootstrap-icons';
 import EndScreen from '@/components/icf/EndScreen';
@@ -148,6 +151,7 @@ const pickRecorderMime = () => {
 
 export default function HealthSlider() {
   const { patientId: urlPatientId } = useParams<{ patientId?: string }>();
+  const navigate = useNavigate();
 
   // --- questionnaire states ---
   const [sliderPosition, setSliderPosition] = useState(50);
@@ -166,10 +170,7 @@ export default function HealthSlider() {
   );
   const [showSummary, setShowSummary] = useState(false);
   const [showInfo, setShowInfo] = useState(false);
-  const [patientId, setPatientId] = useState(() => {
-    if (urlPatientId) return urlPatientId;
-    return localStorage.getItem('patient_id') || '';
-  });
+  const [patientId, setPatientId] = useState(() => urlPatientId ?? '');
   const [patientIdInput, setPatientIdInput] = useState('');
   const [patientIdError, setPatientIdError] = useState('');
 
@@ -396,7 +397,6 @@ export default function HealthSlider() {
   useEffect(() => {
     if (urlPatientId) {
       setPatientId(urlPatientId);
-      localStorage.setItem('patient_id', urlPatientId);
       setPatientIdError('');
     }
   }, [urlPatientId]);
@@ -407,8 +407,7 @@ export default function HealthSlider() {
       setPatientIdError('ID muss dem Format Pxxx-xxxTx entsprechen (z.B. P001-001T1).');
       return;
     }
-    localStorage.setItem('patient_id', v);
-    setPatientId(v);
+    navigate(`/icf/${encodeURIComponent(v)}`);
   };
 
   /** --- persistence --- */
@@ -691,7 +690,6 @@ export default function HealthSlider() {
     } else {
       localStorage.removeItem('survey_index');
       localStorage.removeItem('survey_sessionId');
-      localStorage.removeItem('patient_id');
       setShowSummary(true);
       stopAll();
     }

--- a/frontend/src/pages/eva2.tsx
+++ b/frontend/src/pages/eva2.tsx
@@ -1110,9 +1110,7 @@ export default function HealthSlider() {
         </>
       )}
 
-      {showSummary && (
-        <EndScreen />
-      )}
+      {showSummary && <EndScreen />}
 
       {showInfo && <InfoScreen isRecording={isRecording} onClose={() => setShowInfo(false)} />}
 


### PR DESCRIPTION
# Description

Fix two root causes that caused a page refresh mid-assessment to land on the wrong screen, and remove the "Beenden" button from the end screen.

**Refresh during practice mode showed the start screen**
`survey_sessionId` was only written to `localStorage` after the practice round completed. On refresh, `testMode` checked for both `survey_index` AND `survey_sessionId` being absent — so a refresh during practice (where `survey_sessionId` was not yet persisted) set `testMode = true` and showed the welcome screen. Fix: write `survey_sessionId` to `localStorage` immediately when the microphone starts, before practice mode is shown.

**Refresh with a URL param (`/icf/P001-001T1`) lost the patient ID**
`patient_id` was not written to `localStorage` when the ID came from the URL — only from the manual-entry form. Fix: call `localStorage.setItem('patient_id', urlPatientId)` on mount when a URL param is present.

**"Beenden" button removed from end screen**
`localStorage` is now cleared eagerly before `setShowSummary(true)`, so no button is needed. `EndScreen` becomes a zero-prop, zero-button component.

**Start/Info screen text updated** to quote the full question phrasing and split the rating/verbal steps into separate sentences.

## Related Issue

[#327](https://github.com/nooraangelva/telerehabapp/issues/327) [#328](https://github.com/nooraangelva/telerehabapp/issues/328)

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Tests

Run jest unit tests inside the `react` container:
```bash
docker exec react sh -c "cd /app && node_modules/.bin/jest --testPathPattern='HealthSlider.fullsync|EndScreen' --no-coverage"
```
Expected: 29 passed, 5 skipped, 0 failed

New unit tests cover:

- Refresh during practice mode (survey_sessionId set, no survey_index) → shows ÜBUNGSMODUS, not Willkommen
- localStorage keys (survey_index, survey_sessionId, patient_id) are all null after the last answer is submitted
- End screen has no Beenden, Weiter, or Kann ich nicht beantworten button
- survey_index increments from 0 to 1 after answering Q1
- Fresh start with no localStorage shows PatientIdScreen

Updated/new e2e tests in frontend/e2e/icf-monitor.spec.ts:
- #327: end screen — no Beenden button, no auto-redirect, localStorage fully cleared
- #328: seeding survey_sessionId without survey_index → page opens at ÜBUNGSMODUS
- End screen has no survey action buttons
- Resuming at Q10 shows correct heading and counter 10 / 29
- Advancing through Q1 increments counter to 2

**Test Configuration**: jsdom (jest) + Playwright (e2e, requires running dev server)

Checklist

- [ ]  I have read the [contributing guidelines](vscode-webview://1nb7o4qiscv2qjp7qopi664uf4b3dhgjoa00jqhprielh8bhpehl/docs/12-CONTRIBUTING.md).
- [ ]  I have read the [code of conduct](vscode-webview://1nb7o4qiscv2qjp7qopi664uf4b3dhgjoa00jqhprielh8bhpehl/CODE_OF_CONDUCT.md).
- [ ]  I have commented my code, particularly in hard-to-understand areas.
- [ ]  I have made corresponding changes to the documentation.
- [ ]  My changes generate no new warnings.
- [ ]  I have added tests that prove my fix is effective or that my feature works.