### PR TITLE
Fix/ICF mic auto-restart on page reload and handle recording errors

### DIFF
--- a/frontend/src/__tests__/pages/HealthSlider.fullsync.test.tsx
+++ b/frontend/src/__tests__/pages/HealthSlider.fullsync.test.tsx
@@ -627,15 +627,16 @@ describe('HealthSlider (Full Sync)', () => {
 
   it('REC dot disappears after recording stops (summary screen)', async () => {
     // allow 10 s — 3 s are spent waiting for the question-lock timer to lift
-    // Pre-seed a mid-survey state at the last question (#328: testMode skips StartScreen
-    // when survey_index exists, so mic is not started via the welcome screen).
+    // Pre-seed a mid-survey state at the last question. The mic auto-restarts on
+    // resume (survey_sessionId present), so the REC dot IS shown during the survey.
+    mockMedia();
     localStorage.setItem('survey_index', '28');
     localStorage.setItem('survey_sessionId', 'test-session');
     renderICF('/icf/P001-001T1');
 
-    // Survey opens directly at Q29 (no StartScreen, no mic) — REC dot not present
+    // Survey opens at Q29 with mic auto-started — REC dot should appear
     await waitFor(() => expect(screen.getByText('/ 29')).toBeInTheDocument());
-    expect(screen.queryByLabelText('Aufnahme läuft')).not.toBeInTheDocument();
+    await waitFor(() => expect(screen.getByLabelText('Aufnahme läuft')).toBeInTheDocument());
 
     // Wait for the 3s lock to lift then submit the last answer via "Kann ich nicht
     // beantworten" — this bypasses the slider-moved guard so state-flush order

--- a/frontend/src/pages/eva2.tsx
+++ b/frontend/src/pages/eva2.tsx
@@ -682,6 +682,16 @@ export default function HealthSlider() {
     }
   };
 
+  // On a page reload mid-session the mic stream is gone. Auto-restart it so
+  // recording continues seamlessly. survey_sessionId in localStorage means the
+  // mic was previously granted and a session is in progress.
+  useEffect(() => {
+    if (localStorage.getItem('survey_sessionId') !== null) {
+      startMic();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   const advanceToNextQuestion = () => {
     if (questionIndex < total - 1) {
       setQuestionIndex((i) => i + 1);
@@ -711,7 +721,13 @@ export default function HealthSlider() {
         setSliderPosition(50);
         setSliderMoved(false);
 
-        startItemRecorder();
+        try {
+          startItemRecorder();
+        } catch (e: any) {
+          setRecorderWarning(
+            `Mikrofon nicht mehr verfügbar (${e?.message || e}). Antworten können weiterhin ohne Aufnahme abgegeben werden.`
+          );
+        }
         return;
       }
 
@@ -1063,6 +1079,20 @@ export default function HealthSlider() {
               <button
                 type="button"
                 onClick={() => setRecorderWarning('')}
+                className="icf-dismiss-btn"
+                aria-label="Meldung schließen"
+              >
+                ×
+              </button>
+            </div>
+          )}
+
+          {micError && (
+            <div role="alert" className="icf-recorder-warning">
+              <span>{micError}</span>
+              <button
+                type="button"
+                onClick={() => setMicError('')}
                 className="icf-dismiss-btn"
                 aria-label="Meldung schließen"
               >

--- a/frontend/src/stores/authStore.ts
+++ b/frontend/src/stores/authStore.ts
@@ -447,12 +447,18 @@ class AuthStore {
     // preserve language and notification settings
     const lang = localStorage.getItem('i18nextLng');
     const notificationsEnabled = localStorage.getItem('notifications-enabled');
+    // preserve ICF assessment progress — the /icf page is public (no auth required)
+    // so clearStorage() must not wipe an in-progress patient session
+    const surveyIndex = localStorage.getItem('survey_index');
+    const surveySessionId = localStorage.getItem('survey_sessionId');
 
     sessionStorage.clear();
     localStorage.clear();
 
     if (lang) localStorage.setItem('i18nextLng', lang);
     if (notificationsEnabled) localStorage.setItem('notifications-enabled', notificationsEnabled);
+    if (surveyIndex !== null) localStorage.setItem('survey_index', surveyIndex);
+    if (surveySessionId !== null) localStorage.setItem('survey_sessionId', surveySessionId);
   }
 
   reset() {


### PR DESCRIPTION
## Summary

- **Auto-restart mic on mid-session reload**: A one-shot `useEffect` calls
  `startMic()` on component mount whenever `survey_sessionId` is in
  `localStorage`. After an accidental reload the REC dot reappears and
  subsequent answers are recorded without interruption.
- **Fix practice-mode catch block**: `startItemRecorder()` in the practice
  branch of `executeNextSafe` now has its own `try/catch` → `setRecorderWarning`.
  Previously a "No mic stream" error escaped to the outer catch and showed the
  misleading "Fehler beim Hochladen" upload-fail modal.
- **Show `micError` in survey view**: If auto-start fails (permission denied
  after reload) the error appears as a dismissible banner in the survey, not
  only on the StartScreen.

## Root cause of the "StartScreen on reload" regression

PR #334's fix (writing `survey_sessionId` immediately in `startMic()`) was
correct, but the dev webpack watcher had not picked up the file change over the
Docker bind mount (container uptime: 46 h). Fixed by restarting the `react`
container (`docker restart react`).

## Test plan
- [x] `docker exec react sh -c "cd /app && node_modules/.bin/jest --testPathPattern='HealthSlider.fullsync' --no-coverage"` → 24 passed, 5 skipped, 0 failed
- [ ] Manual: visit `/icf/<patientId>`, answer several questions, hard-reload
      (Ctrl+Shift+R) → correct question resumes with REC dot active within ~1 s
- [ ] Manual: reload during practice, click **Start** → no upload-fail modal
