### PR TITLE
Feature: show per-clinic contact email on patient profile

### DIFF
--- a/backend/core/views/auth_views.py
+++ b/backend/core/views/auth_views.py
@@ -1051,6 +1051,8 @@ def get_user_info(request, user_id):
         specialisation = ""
         function = ""
         preferred_language = "en"
+        clinic = ""
+        project = ""
 
         if user.role == "Therapist":
             therapist = Therapist.objects.filter(userId=user).first()
@@ -1066,6 +1068,8 @@ def get_user_info(request, user_id):
                 last_name = patient.name
                 function = patient.function
                 preferred_language = getattr(patient, "preferred_language", None) or "en"
+                clinic = getattr(patient, "clinic", None) or ""
+                project = getattr(patient, "project", None) or ""
 
         else:  # Admin fallback
             first_name = user.username
@@ -1078,6 +1082,8 @@ def get_user_info(request, user_id):
                 "function": function,
                 "role": user.role,
                 "preferred_language": preferred_language,
+                "clinic": clinic,
+                "project": project,
             },
             status=200,
         )

--- a/frontend/src/config/config.json
+++ b/frontend/src/config/config.json
@@ -12,6 +12,16 @@
     "email": "forschung.respo@insel.ch",
     "phone": ""
   },
+  "contactEmails": {
+    "COPAIN": {
+      "Inselspital": "copain@insel.ch",
+      "Berner Reha Centrum": "copain@insel.ch"
+    },
+    "COMPASS": {
+      "Bern": "forschung-respo@insel.ch",
+      "Inselspital": "forschung-respo@insel.ch"
+    }
+  },
   "patientInfo": {
     "sex": ["Male", "Female"],
     "functionPat": {

--- a/frontend/src/config/config.json
+++ b/frontend/src/config/config.json
@@ -19,7 +19,11 @@
     },
     "COMPASS": {
       "Bern": "forschung-respo@insel.ch",
-      "Inselspital": "forschung-respo@insel.ch"
+      "Inselspital": "forschung-respo@insel.ch",
+      "Leuven": "cvep@kuleuven.be",
+      "Lisbon": "compass@medicina.ulisboa.pt",
+      "Lumezzane": "compass.lumezzane@icsmaugeri.it",
+      "Milano": "compass@dongnocchi.it"
     }
   },
   "patientInfo": {

--- a/frontend/src/pages/PatientProfile.tsx
+++ b/frontend/src/pages/PatientProfile.tsx
@@ -25,6 +25,11 @@ const PatientProfile: React.FC = observer(() => {
   const patientId = localStorage.getItem('id') || authStore.id || '';
   const displayName = authStore.firstName || t('Profile');
 
+  const contactEmail =
+    (config.contactEmails as Record<string, Record<string, string>>)[authStore.project]?.[
+      authStore.clinic
+    ] ?? config.contact.email;
+
   const partnerLogos = [
     {
       src: '/artorg_unibern_logo.gif',
@@ -91,14 +96,14 @@ const PatientProfile: React.FC = observer(() => {
             <div className="font-bold text-lg leading-6 text-zinc-800">
               {t('Research Project Contact')}
             </div>
-            {config.contact.email && (
+            {contactEmail && (
               <Badge variant="card">
                 <a
-                  href={`mailto:${config.contact.email}`}
+                  href={`mailto:${contactEmail}`}
                   className="flex items-center gap-1 no-underline text-brand"
                 >
                   <Mail className="w-4 h-4" />
-                  <span>{config.contact.email}</span>
+                  <span>{contactEmail}</span>
                 </a>
               </Badge>
             )}

--- a/frontend/src/stores/authStore.ts
+++ b/frontend/src/stores/authStore.ts
@@ -23,6 +23,8 @@ class AuthStore {
   firstName = '';
   specialisations: string[] = [];
   preferredLanguage = '';
+  clinic = '';
+  project = '';
 
   // 2FA
   partialLogin = false;
@@ -151,6 +153,14 @@ class AuthStore {
         const specs = this._parseSpecialisationsFromPayload(data);
         if (specs.length) this.setSpecialisations(specs);
         if (data.preferred_language) this.setPreferredLanguage(String(data.preferred_language));
+        if (data.clinic !== undefined) {
+          this.clinic = String(data.clinic || '');
+          localStorage.setItem('clinic', this.clinic);
+        }
+        if (data.project !== undefined) {
+          this.project = String(data.project || '');
+          localStorage.setItem('project', this.project);
+        }
       });
     } catch (err) {
       console.warn('Failed to fetch user info:', err);
@@ -342,6 +352,8 @@ class AuthStore {
         : [];
 
       this.preferredLanguage = localStorage.getItem('preferredLanguage') || '';
+      this.clinic = localStorage.getItem('clinic') || '';
+      this.project = localStorage.getItem('project') || '';
       this.partialLogin = false;
       this.loginErrorMessage = '';
     });
@@ -472,6 +484,8 @@ class AuthStore {
       this.firstName = '';
       this.specialisations = [];
       this.preferredLanguage = '';
+      this.clinic = '';
+      this.project = '';
       this.partialLogin = false;
     });
   }


### PR DESCRIPTION
Each clinic/project combination now shows its own research contact address instead of the single global email.

- backend: get_user_info returns clinic + project for Patient users
- authStore: store and restore clinic/project from localStorage
- config.json: add contactEmails map (project → clinic → email) · COPAIN / Inselspital & BRZ → copain@insel.ch · COMPASS / Bern & Inselspital → forschung-respo@insel.ch · TBD clinics (Leuven, Lisbon, Lumezzane, Milano) fall back to the default config.contact.email until addresses are confirmed
- PatientProfile: resolve contactEmail from authStore.project/clinic, falling back to config.contact.email when no mapping is defined

## Type of change

For a new feature, please create an issue first to discuss it with us before submitting a pull request.
- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have read the [contributing guidelines](/docs/12-CONTRIBUTING.md).
- [x] I have read the [code of conduct](/CODE_OF_CONDUCT.md).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
