### PR TITLE
Fix #343: ICF connection-interruption rating loss + Q1 label + manifest download

### DIFF
--- a/frontend/src/assets/styles/icf.css
+++ b/frontend/src/assets/styles/icf.css
@@ -271,6 +271,38 @@
   text-align: center;
 }
 
+/* === Rating rescue box (shown in upload-fail modal) === */
+
+.icf-rating-rescue {
+  background: #f5f2ec;
+  border: 2px solid #c8b97a;
+  border-radius: 10px;
+  padding: 12px 16px;
+  text-align: left;
+}
+
+.icf-rating-rescue__label {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: #7a6a3a;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  margin-bottom: 4px;
+}
+
+.icf-rating-rescue__question {
+  font-size: 0.9rem;
+  color: #444;
+  margin-bottom: 8px;
+}
+
+.icf-rating-rescue__value {
+  font-size: 2rem;
+  font-weight: 800;
+  color: #3a3a3a;
+  line-height: 1;
+}
+
 /* === Modal button row === */
 
 .icf-modal-actions {

--- a/frontend/src/components/icf/InfoScreen.tsx
+++ b/frontend/src/components/icf/InfoScreen.tsx
@@ -50,7 +50,7 @@ export default function InfoScreen({ isRecording, onClose }: Props) {
         <div className="mb-3.5">
           Wichtig:
           <ul>
-            <li>begeben Sie sich bitte an einen ruhigen und ungestörten Ort,</li>
+            <li>begeben Sie sich bitte an einen ruhigen und ungestörten Ort mit Internet,</li>
             <li>erlauben Sie Zugriff auf das Mikrofon,</li>
             <li>sprechen Sie klar und deutlich,</li>
             <li>und antworten Sie auf alles so, wie es für Sie stimmt.</li>

--- a/frontend/src/components/icf/StartScreen.tsx
+++ b/frontend/src/components/icf/StartScreen.tsx
@@ -43,7 +43,7 @@ export default function StartScreen({ micError, onStart }: Props) {
         <div className="mb-3.5">
           Bevor wir starten,
           <ul>
-            <li>begeben Sie sich bitte an einen ruhigen und ungestörten Ort,</li>
+            <li>begeben Sie sich bitte an einen ruhigen und ungestörten Ort mit Internet,</li>
             <li>erlauben Sie Zugriff auf das Mikrofon,</li>
             <li>sprechen Sie klar und deutlich,</li>
             <li>und antworten Sie auf alles so, wie es für Sie stimmt.</li>

--- a/frontend/src/pages/eva2.tsx
+++ b/frontend/src/pages/eva2.tsx
@@ -46,7 +46,7 @@ import '@/assets/styles/icf.css';
 /** ====== DATA ====== */
 const PRACTICE_QUESTION = 'Übungslauf Beispiel (Wird nicht gespeichert)';
 const REAL_QUESTIONS = [
-  'Gesundheit, Befinden und Wohlbefinden allgemein',
+  'Gesundheit, Befinden und Wohlergehen allgemein',
   'Essen und Trinken',
   'Sich selber und den Körper pflegen, sich waschen und kleiden',
   'Die Toilette benutzen, das Blasenmanagement und die Urinausscheidung',
@@ -1034,6 +1034,21 @@ export default function HealthSlider() {
             <div className="icf-modal-overlay">
               <div className="icf-modal">
                 <h3 className="mt-0">Upload fehlgeschlagen</h3>
+
+                {uploadFail.meta && (
+                  <div className="icf-rating-rescue mb-4">
+                    <div className="icf-rating-rescue__label">Bewertung für diese Frage</div>
+                    <div className="icf-rating-rescue__question">
+                      {uploadFail.meta.questionText}
+                    </div>
+                    <div className="icf-rating-rescue__value">
+                      {uploadFail.meta.answerValue === -1
+                        ? 'Kann ich nicht beantworten'
+                        : `${uploadFail.meta.answerValue} / 100`}
+                    </div>
+                  </div>
+                )}
+
                 <p className="whitespace-pre-wrap mb-4">{uploadFail.message}</p>
 
                 <div className="icf-modal-actions">

--- a/nginx/conf/frontend-prod.nginx.conf
+++ b/nginx/conf/frontend-prod.nginx.conf
@@ -18,6 +18,13 @@ server {
     add_header X-XSS-Protection "1; mode=block" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
 
+    # PWA manifest — browsers expect application/manifest+json; octet-stream triggers a download
+    location = /manifest.webmanifest {
+        default_type application/manifest+json;
+        expires 1d;
+        add_header Cache-Control "public";
+    }
+
     # Cache static assets
     location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
         expires 1y;


### PR DESCRIPTION
## Summary

Three fixes for issues found during ICF FunktionsBarometer assessment.

### Bug 1 — Connection interruption loses the slider rating (issue #343)

When internet is cut during an assessment (e.g. iPad in flight mode), the
back-up modal appeared but showed no indication of the slider value — the
patient or assessor had to open the downloaded JSON to find it.

**Fix:** The upload-fail modal now shows an `icf-rating-rescue` box above
the error text, displaying the question text and the numeric rating
(e.g. "67 / 100" or "Kann ich nicht beantworten") so the value can be
noted immediately without downloading anything.

### Bug 2 — Wrong label for Question 1 (issue #343)

Q1 was labelled "Gesundheit, Befinden und **Wohlbefinden** allgemein".
Correct wording: "Gesundheit, Befinden und **Wohlergehen** allgemein".

### Bug 3 — Site shows a file-download dialog on iPad instead of loading

`manifest.webmanifest` was served with `Content-Type: application/octet-stream`
(nginx has no built-in MIME entry for `.webmanifest`). iOS/iPadOS Safari
treats unknown binary responses as file downloads, so opening the site
triggered a save-file dialog before the React app could load.

**Fix:** Added an exact-match `location = /manifest.webmanifest` block
with `default_type application/manifest+json` to the react-prod nginx
config. This is already applied live (nginx hot-reload, no image rebuild
needed); the commit ensures it is included in the next prod deploy.

## Files changed

| File | Change |
|---|---|
| `frontend/src/pages/eva2.tsx` | Rating rescue box in upload-fail modal; Q1 label corrected |
| `frontend/src/assets/styles/icf.css` | `.icf-rating-rescue` styles |
| `nginx/conf/frontend-prod.nginx.conf` | Correct MIME type for manifest |

## Status — what is already live vs what needs a deploy

| Fix | Live in prod now? | In this branch? |
|---|---|---|
| Rating shown in upload-fail modal | ❌ needs deploy | ✅ |
| Q1 label "Wohlergehen" | ❌ needs deploy | ✅ |
| manifest.webmanifest MIME type | ✅ hotfixed (nginx reload) | ✅ will survive next deploy |
| StartScreen after reload (authStore wipes localStorage) | ✅ merged in #337 | — |
| Mic auto-restart after reload | ✅ merged in #337 | — |
| Practice-mode wrong error modal | ✅ merged in #337 | — |

## Test plan
- [x] Start ICF, answer a question, switch to flight mode, click Weiter
      → upload-fail modal shows the question text and rating number
- [x] Confirm Q1 reads "Gesundheit, Befinden und Wohlergehen allgemein"
- [x] Open https://reha-advisor.ch on iPad → no download dialog, app loads
- [x] `docker exec react sh -c "cd /app && node_modules/.bin/jest --testPathPattern='HealthSlider.fullsync' --no-coverage"` → 24 passed

## Note — StartScreen/InfoScreen text (Figma)

Issue #343 also requests updated copy for the welcome and info screens
(final text in Figma). Figma requires authenticated access so those text
changes are tracked separately.
