### PR TITLE
Fix: preserve uploaded images when Excel is re-imported

### DIFF
--- a/backend/core/views/intervention_import.py
+++ b/backend/core/views/intervention_import.py
@@ -966,17 +966,23 @@ def import_interventions_from_excel(
                     merged.append(new_media)
                 else:
                     # No explicit slot — replace the primary entry (slot=None) with the
-                    # new one and preserve any numbered slots.
+                    # new one, but preserve:
+                    #   • numbered slots (any kind)
+                    #   • uploaded files (kind="file", path contains "/" — written by the
+                    #     media-upload endpoint as "images/YYYYMMDD_…"; raw Excel filenames
+                    #     never contain a slash and are safe to replace)
                     seen_keys: set = set()
                     merged = []
-                    # Keep numbered-slot media intact
                     for m in existing_media:
                         existing_kind = _norm(getattr(m, "kind", ""))
                         if existing_kind == "external":
                             existing_url = _norm(getattr(m, "url", ""))
                             if existing_url and not _is_http_url(existing_url):
                                 continue  # drop old broken entries
-                        if getattr(m, "media_slot", None) is not None:
+                        slot = getattr(m, "media_slot", None)
+                        fp = getattr(m, "file_path", "") or ""
+                        is_uploaded_file = existing_kind == "file" and "/" in fp
+                        if slot is not None or is_uploaded_file:
                             k = _media_key(m)
                             if k not in seen_keys:
                                 merged.append(m)

--- a/backend/tests/intervention_import_views/test_intervention_import_view.py
+++ b/backend/tests/intervention_import_views/test_intervention_import_view.py
@@ -435,3 +435,46 @@ def test_import_slot2_replaces_existing_slot2():
         assert len(doc.media) == 1
         assert doc.media[0].media_slot == 2
         assert "new_slot2" in doc.media[0].url
+
+
+def test_excel_reimport_preserves_uploaded_images():
+    """Re-importing an Excel row must NOT wipe images that were uploaded via the
+    media-upload endpoint.  Uploaded files have a folder-prefixed path (e.g.
+    "images/20260609_143022_foo.jpg"); raw Excel filenames never contain a slash."""
+    # Seed an intervention that already has an uploaded image (kind="file", path with /)
+    Intervention(
+        external_id="7200_gfx",
+        language="de",
+        title="Spaziergang",
+        description="Desc",
+        content_type="Graphics",
+        media=[
+            InterventionMedia(
+                kind="file",
+                media_type="image",
+                file_path="images/20260609_143022_spaziergang.jpg",
+                mime="image/jpeg",
+                media_slot=None,
+            )
+        ],
+    ).save()
+
+    # Re-import Excel with the same row (link = raw filename, as Excel originally had)
+    with tempfile.TemporaryDirectory() as td:
+        p = Path(td) / "update.xlsx"
+        wb = openpyxl.Workbook()
+        ws = wb.active
+        ws.title = "Content"
+        ws.append(["intervention_id", "title", "description", "content_type", "link"])
+        ws.append(["7200_gfx_de", "Spaziergang", "Desc", "Graphics", "7200_gfx_de.jpg"])
+        wb.save(p)
+
+        result = import_interventions_from_excel(str(p), dry_run=False)
+        assert result["updated"] == 1
+
+    doc = Intervention.objects(external_id="7200_gfx", language="de").first()
+    assert doc is not None
+
+    file_paths = [m.file_path for m in (doc.media or []) if getattr(m, "kind", "") == "file"]
+    # The uploaded image must still be present
+    assert "images/20260609_143022_spaziergang.jpg" in file_paths


### PR DESCRIPTION
## Problem

When uploading an updated version of the Excel file, all images disappear
afterward even though the `external_id` is unchanged — they have to be
re-uploaded manually every time.

**Root cause** — `import_interventions_from_excel` uses a slot-based merge
when updating existing interventions. For primary-slot entries
(`media_slot = None`) it kept only numbered slots and replaced everything
else with the new link from the Excel row. Images uploaded via
`POST /api/interventions/import/media/` are stored as `kind = "file"` with
a folder-prefixed path (e.g. `images/20260609_143022_spaziergang.jpg`) at
`media_slot = None` — so they were silently dropped on every re-import.

## Fix

In the slot-`None` merge path in `intervention_import.py`, also preserve
existing `kind = "file"` entries whose `file_path` contains a `/`.

Uploaded files are always saved by `_save_file()` under a subfolder
(`images/…`, `audio/…`, etc.), so their path always contains a slash.
Raw Excel-specified filenames (e.g. `40008_gfx_de.jpg`) never do — they
are still replaced as before.

```python
is_uploaded_file = existing_kind == "file" and "/" in fp
if slot is not None or is_uploaded_file:
    # preserve numbered slots AND uploaded files
```

### Test
Added test_excel_reimport_preserves_uploaded_images:

- Seeds an intervention that already has an uploaded image (images/20260609_143022_spaziergang.jpg, media_slot = None)
- Re-imports the same Excel row (link column = raw filename)
- Asserts the uploaded file path is still present in doc.media
- All 15 intervention-import tests pass.

### Test plan

1.  Upload an Excel file containing a gfx (or any image) row
2.  Upload a .jpg for that intervention via the media-upload UI
3.  Re-upload the same Excel file
4.  Open the intervention detail — image must still be visible (was previously gone after step 3)