### PR TITLE
Fix/health-slider access

### DIFF
--- a/nginx/conf/prod.reha-advisor.nginx.conf
+++ b/nginx/conf/prod.reha-advisor.nginx.conf
@@ -46,7 +46,7 @@ server {
         add_header Cache-Control "public";
     }
 
-    location /health {
+    location = /health {
         access_log off;
         return 200 "healthy\n";
         add_header Content-Type text/plain;


### PR DESCRIPTION
Root cause: location /health is a prefix match in nginx — it caught /healthslider-downloads before the location / proxy pass ever ran. The response was return 200 "healthy\n" with nginx's default_type application/octet-stream, which browsers treat as a file download.

Fix: Changed to location = /health (exact match) in [nginx/conf/prod.reha-advisor.nginx.conf](vscode-webview://1nb7o4qiscv2qjp7qopi664uf4b3dhgjoa00jqhprielh8bhpehl/nginx/conf/prod.reha-advisor.nginx.conf). The change is already live — nginx-prod was reloaded and verified:

/healthslider-downloads → Content-Type: text/html ✅
/health → still returns 200 ✅