### PR TITLE
Fix/347 multilingual intervention duplicates

### DIFF
--- a/backend/core/views/patient_views.py
+++ b/backend/core/views/patient_views.py
@@ -2580,9 +2580,33 @@ def get_patient_plan_for_therapist(request, patient_id):
             "interventions": [],
         }
 
-        for assignment in plan.interventions:
+        # Group assignments by external_id to avoid showing duplicates when the
+        # same intervention was added in multiple language variants.
+        _seen_ext: dict = {}
+        for _a in plan.interventions:
+            _iv = _a.interventionId
+            _ext = getattr(_iv, "external_id", None) or str(_iv.id)
+            if _ext not in _seen_ext:
+                _seen_ext[_ext] = {
+                    "canonical": _a,
+                    "all_dates": list(_a.dates),
+                    "all_ids": [_iv.id],
+                }
+            else:
+                _existing_days = {_d.date() for _d in _seen_ext[_ext]["all_dates"]}
+                for _d in _a.dates:
+                    if _d.date() not in _existing_days:
+                        _seen_ext[_ext]["all_dates"].append(_d)
+                        _existing_days.add(_d.date())
+                _seen_ext[_ext]["all_ids"].append(_iv.id)
+
+        for _group in _seen_ext.values():
+            assignment = _group["canonical"]
+            all_dates = sorted(_group["all_dates"])
             intervention = assignment.interventionId
-            logs = PatientInterventionLogs.objects(userId=patient, interventionId=intervention)
+            logs = PatientInterventionLogs.objects(
+                userId=patient, interventionId__in=_group["all_ids"]
+            )
 
             completed_dates = {log.date.date() for log in logs if "completed" in (log.status or [])}
 
@@ -2592,7 +2616,7 @@ def get_patient_plan_for_therapist(request, patient_id):
             rating_sum = 0
             rating_count = 0
 
-            for date in assignment.dates:
+            for date in all_dates:
                 log = next((l for l in logs if l.date.date() == date.date()), None)
 
                 if log and "completed" in (log.status or []):
@@ -2674,7 +2698,7 @@ def get_patient_plan_for_therapist(request, patient_id):
                     "frequency": assignment.frequency,
                     "notes": assignment.notes,
                     "dates": intervention_dates,
-                    "totalCount": len(assignment.dates),
+                    "totalCount": len(all_dates),
                     "currentTotalCount": current_total_count,
                     "completedCount": completed_count,
                     "averageRating": (round(rating_sum / rating_count, 1) if rating_count > 0 else 0),

--- a/backend/core/views/patient_views.py
+++ b/backend/core/views/patient_views.py
@@ -2604,7 +2604,17 @@ def get_patient_plan_for_therapist(request, patient_id):
             assignment = _group["canonical"]
             all_dates = sorted(_group["all_dates"])
             intervention = assignment.interventionId
-            logs = PatientInterventionLogs.objects(userId=patient, interventionId__in=_group["all_ids"])
+            # Query logs across ALL language variants of this external_id (not
+            # just the ones that happen to be assigned) so that logs recorded
+            # under a different variant are still counted.
+            _ext_id = getattr(intervention, "external_id", None)
+            if _ext_id:
+                _all_variant_ids = [
+                    _v.id for _v in Intervention.objects(external_id=_ext_id).only("id")
+                ]
+            else:
+                _all_variant_ids = _group["all_ids"]
+            logs = PatientInterventionLogs.objects(userId=patient, interventionId__in=_all_variant_ids)
 
             completed_dates = {log.date.date() for log in logs if "completed" in (log.status or [])}
 

--- a/backend/core/views/patient_views.py
+++ b/backend/core/views/patient_views.py
@@ -2609,9 +2609,7 @@ def get_patient_plan_for_therapist(request, patient_id):
             # under a different variant are still counted.
             _ext_id = getattr(intervention, "external_id", None)
             if _ext_id:
-                _all_variant_ids = [
-                    _v.id for _v in Intervention.objects(external_id=_ext_id).only("id")
-                ]
+                _all_variant_ids = [_v.id for _v in Intervention.objects(external_id=_ext_id).only("id")]
             else:
                 _all_variant_ids = _group["all_ids"]
             logs = PatientInterventionLogs.objects(userId=patient, interventionId__in=_all_variant_ids)

--- a/backend/core/views/patient_views.py
+++ b/backend/core/views/patient_views.py
@@ -2604,9 +2604,7 @@ def get_patient_plan_for_therapist(request, patient_id):
             assignment = _group["canonical"]
             all_dates = sorted(_group["all_dates"])
             intervention = assignment.interventionId
-            logs = PatientInterventionLogs.objects(
-                userId=patient, interventionId__in=_group["all_ids"]
-            )
+            logs = PatientInterventionLogs.objects(userId=patient, interventionId__in=_group["all_ids"])
 
             completed_dates = {log.date.date() for log in logs if "completed" in (log.status or [])}
 

--- a/backend/core/views/recomendation_views.py
+++ b/backend/core/views/recomendation_views.py
@@ -892,7 +892,13 @@ def get_intervention_detail(request, intervention_id):
                 intervention = picked
 
         feedbacks = []
-        patient_logs = PatientInterventionLogs.objects.filter(interventionId=intervention)
+        # Query across ALL language variants so logs recorded under a different
+        # language variant of the same intervention are included.
+        if external_id:
+            _variant_ids = [v.id for v in Intervention.objects(external_id=external_id).only("id")]
+            patient_logs = PatientInterventionLogs.objects.filter(interventionId__in=_variant_ids)
+        else:
+            patient_logs = PatientInterventionLogs.objects.filter(interventionId=base_doc)
         for log in patient_logs:
             for entry in log.feedback or []:
                 feedbacks.append(
@@ -984,7 +990,7 @@ def list_all_interventions(request, patient_id=None):
                 seen.add(k)
             return out
 
-        def serialize(item, available_languages=None):
+        def serialize(item, available_languages=None, all_docs=None):
             aim_val = getattr(item, "aim", None)
             aims = [aim_val.strip()] if isinstance(aim_val, str) and aim_val.strip() else []
 
@@ -994,6 +1000,12 @@ def list_all_interventions(request, patient_id=None):
             keywords = _safe_list(getattr(item, "keywords", None))
             tags = _dedup_keep_order(topic + where + setting + keywords)
 
+            _all_titles = list({
+                getattr(d, "title", None)
+                for d in (all_docs or [item])
+                if getattr(d, "title", None)
+            })
+
             return {
                 "_id": str(item.pk),
                 "external_id": getattr(item, "external_id", None),
@@ -1001,6 +1013,7 @@ def list_all_interventions(request, patient_id=None):
                 "available_languages": available_languages or [],
                 "provider": getattr(item, "provider", None),
                 "title": getattr(item, "title", None),
+                "all_titles": _all_titles,
                 "description": getattr(item, "description", None),
                 "content_type": getattr(item, "content_type", None),
                 "aims": aims,
@@ -1053,7 +1066,7 @@ def list_all_interventions(request, patient_id=None):
         public_serialized = []
         for external_id, docs in grouped.items():
             chosen, langs = _pick_variant(docs, preferred_lang, fallback_order=["en", "de"])
-            public_serialized.append(serialize(chosen, langs))
+            public_serialized.append(serialize(chosen, langs, all_docs=docs))
 
         all_serialized = private_serialized + public_serialized
 

--- a/backend/core/views/recomendation_views.py
+++ b/backend/core/views/recomendation_views.py
@@ -1000,11 +1000,7 @@ def list_all_interventions(request, patient_id=None):
             keywords = _safe_list(getattr(item, "keywords", None))
             tags = _dedup_keep_order(topic + where + setting + keywords)
 
-            _all_titles = list({
-                getattr(d, "title", None)
-                for d in (all_docs or [item])
-                if getattr(d, "title", None)
-            })
+            _all_titles = list({getattr(d, "title", None) for d in (all_docs or [item]) if getattr(d, "title", None)})
 
             return {
                 "_id": str(item.pk),

--- a/backend/tests/patient_views/TESTING.md
+++ b/backend/tests/patient_views/TESTING.md
@@ -247,6 +247,8 @@ Returns a structured plan with adherence metadata for the therapist dashboard.  
 | `test_get_patient_plan_for_therapist_patient_not_found` | Unknown Patient ObjectId | 404, 'Patient not found' |
 | `test_get_patient_plan_for_therapist_no_plan` | Patient but no plan | 200, 'No rehabilitation plan found' |
 | `test_get_patient_plan_for_therapist_post_method_not_allowed` | POST | 405 |
+| `test_therapist_plan_deduplicates_multilingual_assignments` | Same `external_id` assigned in DE + EN | One entry returned, dates merged (fix #347) |
+| `test_therapist_plan_feedback_visible_for_other_language_variant` | Log under DE variant, EN variant assigned | Session counted as completed (fix #347) |
 
 ---
 

--- a/backend/tests/patient_views/test_get_endpoints.py
+++ b/backend/tests/patient_views/test_get_endpoints.py
@@ -934,3 +934,124 @@ def test_star_rating_absent_when_no_intervention_id(mongo_mock):
     assert "rating_stars_education" not in keys
     assert "rating_stars_exercise" not in keys
     assert "difficulty_scale" in keys, f"Core questions missing: {keys}"
+
+
+# ===========================================================================
+# Regression tests for issue #347 — multilingual intervention bugs
+# ===========================================================================
+
+
+def test_therapist_plan_deduplicates_multilingual_assignments(mongo_mock):
+    """
+    Fix #347 Bug 1: if the same external_id was assigned in two language
+    variants, the therapist plan view must return only ONE entry (not two).
+    Dates from both assignments must be merged so no session is lost.
+    """
+    patient, therapist, _, plan = setup_basic_plan()
+
+    int_de = Intervention(
+        title="Blutdruck Grundlagen",
+        description="DE",
+        content_type="Video",
+        external_id="MULTI-001",
+        language="de",
+    )
+    int_de.save()
+    int_en = Intervention(
+        title="Blood Pressure Basics",
+        description="EN",
+        content_type="Video",
+        external_id="MULTI-001",
+        language="en",
+    )
+    int_en.save()
+
+    tomorrow = datetime.now() + timedelta(days=1)
+    day_after = datetime.now() + timedelta(days=2)
+
+    plan.interventions = [
+        InterventionAssignment(
+            interventionId=int_de,
+            frequency="Daily",
+            notes="",
+            dates=[tomorrow],
+        ),
+        InterventionAssignment(
+            interventionId=int_en,
+            frequency="Daily",
+            notes="",
+            dates=[day_after],
+        ),
+    ]
+    plan.save()
+
+    resp = client.get(
+        f"/api/patients/rehabilitation-plan/therapist/{patient.id}/",
+        HTTP_AUTHORIZATION="Bearer test",
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    interventions = body["interventions"]
+
+    # Must be deduplicated to one entry
+    assert len(interventions) == 1
+    # Both dates must be present (merged)
+    assert interventions[0]["totalCount"] == 2
+
+
+def test_therapist_plan_feedback_visible_for_other_language_variant(mongo_mock):
+    """
+    Fix #347 Bug 3: feedback logged under the DE variant's ObjectId must appear
+    in the therapist plan even when the plan references the EN variant.
+    """
+    patient, therapist, _, plan = setup_basic_plan()
+
+    int_de = Intervention(
+        title="Blutdruck Grundlagen",
+        description="DE",
+        content_type="Video",
+        external_id="FEEDBACK-001",
+        language="de",
+    )
+    int_de.save()
+    int_en = Intervention(
+        title="Blood Pressure Basics",
+        description="EN",
+        content_type="Video",
+        external_id="FEEDBACK-001",
+        language="en",
+    )
+    int_en.save()
+
+    session_date = datetime(2026, 6, 1, 8, 0, 0)
+    plan.interventions = [
+        InterventionAssignment(
+            interventionId=int_en,
+            frequency="Daily",
+            notes="",
+            dates=[session_date],
+        )
+    ]
+    plan.save()
+
+    # Log recorded under the DE variant (different ObjectId)
+    PatientInterventionLogs(
+        userId=patient,
+        interventionId=int_de,
+        rehabilitationPlanId=plan,
+        date=session_date,
+        status=["completed"],
+        feedback=[],
+        comments="DE variant log",
+    ).save()
+
+    resp = client.get(
+        f"/api/patients/rehabilitation-plan/therapist/{patient.id}/",
+        HTTP_AUTHORIZATION="Bearer test",
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+
+    dates = body["interventions"][0]["dates"]
+    completed = [d for d in dates if d["status"] == "completed"]
+    assert len(completed) == 1, "log under DE variant must count as completed"

--- a/frontend/src/__tests__/utils/filterUtils.test.ts
+++ b/frontend/src/__tests__/utils/filterUtils.test.ts
@@ -265,5 +265,34 @@ describe('filterInterventions', () => {
       });
       expect(result.map((r) => r._id)).toEqual(['b']);
     });
+
+    // Fix #347 Bug 2: searching by a non-primary language title must work
+    it('filters by all_titles — finds German title when English variant is primary', () => {
+      const items = [
+        makeIntervention({
+          _id: 'a',
+          title: 'Walking in the Fresh Air', // EN variant is primary
+          all_titles: ['Walking in the Fresh Air', 'Spaziergang im Freien'],
+        }),
+        makeIntervention({ _id: 'b', title: 'Blood Pressure Basics' }),
+      ];
+      const result = filterInterventions(items, undefined, {
+        ...emptyFilters,
+        searchTerm: 'spaziergang',
+      });
+      expect(result.map((r) => r._id)).toEqual(['a']);
+    });
+
+    it('all_titles absent — falls back to primary title only', () => {
+      const items = [
+        makeIntervention({ _id: 'a', title: 'Walking in the Fresh Air' }),
+        makeIntervention({ _id: 'b', title: 'Blood Pressure Basics' }),
+      ];
+      const result = filterInterventions(items, undefined, {
+        ...emptyFilters,
+        searchTerm: 'spaziergang',
+      });
+      expect(result).toHaveLength(0);
+    });
   });
 });

--- a/frontend/src/utils/filterUtils.ts
+++ b/frontend/src/utils/filterUtils.ts
@@ -65,7 +65,12 @@ export const filterInterventions = (
     result = result.filter((rec) => {
       const originalTitle = rec.title.toLowerCase();
       const translatedTitle = translatedTitles?.[rec._id]?.title?.toLowerCase();
-      return originalTitle.includes(searchLower) || translatedTitle?.includes(searchLower);
+      const allTitles: string[] = (rec as any).all_titles ?? [];
+      return (
+        originalTitle.includes(searchLower) ||
+        translatedTitle?.includes(searchLower) ||
+        allTitles.some((t) => t.toLowerCase().includes(searchLower))
+      );
     });
   }
 


### PR DESCRIPTION
# Description

Fixes three bugs affecting multi-language interventions (same `external_id`, multiple language variants stored as separate documents).

**Bug 1 — Therapist plan view shows duplicate entries**
When the same exercise was assigned in both DE and EN, it appeared twice in the patient's plan. Fixed in `get_patient_plan_for_therapist` by grouping assignments by `external_id` before building the response and merging dates across all variants in the group.

**Bug 2 — Searching by a non-primary language title returns no results**
If the English variant was chosen as the canonical document, searching for the German title found nothing. Fixed by adding an `all_titles` field to the catalog serialization (titles from all language variants) and extending the frontend search to check `all_titles` alongside the primary and translated title.

**Bug 3 — Feedback/completion invisible for multilingual interventions**
In `get_intervention_detail`, the view switched to the "best language" variant before querying `PatientInterventionLogs`, so logs recorded under a sibling variant were missed. Fixed by querying logs across all variant IDs for the same `external_id`.

A secondary bug was also caught by tests: `get_patient_plan_for_therapist` only queried logs for assigned variant IDs. If a log existed under an unassigned sibling variant (e.g. DE assigned, log recorded under EN), it was lost. Fixed by fetching all variant IDs from the DB for the `external_id` at query time.

## Related Issue
[#347 – Multilingual intervention duplicates, search and feedback bugs](https://github.com/ARTORG-GERONTECHNOLOGY/Bearny-RehaAdvisor/issues/347)

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Tests

Two backend regression tests added to `backend/tests/patient_views/test_get_endpoints.py`:
- `test_therapist_plan_deduplicates_multilingual_assignments` — assigns same `external_id` in DE + EN, verifies 1 entry returned with merged date count
- `test_therapist_plan_feedback_visible_for_other_language_variant` — logs completion under DE variant, EN variant assigned; verifies session counted as completed

Two frontend unit tests added to `frontend/src/__tests__/utils/filterUtils.test.ts`:
- `filters by all_titles — finds German title when English variant is primary`
- `all_titles absent — falls back to primary title only`

**Test Configuration**: `docker exec django pytest tests/patient_views/ -v` — 939 passed, 0 failed

## Checklist

- [x] I have read the [contributing guidelines](/docs/12-CONTRIBUTING.md).
- [x] I have read the [code of conduct](/CODE_OF_CONDUCT.md).
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
