### PR TITLE
Feat: device tracking, ICF assessment device capture, and exercise assistance question

### DIFF
--- a/backend/core/models.py
+++ b/backend/core/models.py
@@ -729,6 +729,7 @@ class HealthSliderEntry(Document):
 
     answered_at = DateTimeField(default=timezone.now)
     device_type = StringField(max_length=20, required=False, null=True)
+    assistance = StringField(max_length=20, required=False, null=True)  # "alone" or "with_help"
 
     meta = {
         "indexes": [

--- a/backend/core/views/eva_view.py
+++ b/backend/core/views/eva_view.py
@@ -301,8 +301,10 @@ def list_healthslider_items(request):
                 "hasAudio": it.has_audio,
                 "audioSize": size,
                 "audioName": it.audio_name,
-                "audioMime": it.audio_mime,  # ✅ include to help UI if needed
+                "audioMime": it.audio_mime,
                 "answeredAt": it.answered_at.strftime("%Y-%m-%dT%H:%M:%SZ") if it.answered_at else None,
+                "deviceType": it.device_type or None,
+                "assistance": it.assistance or None,
             }
         )
 

--- a/backend/core/views/eva_view.py
+++ b/backend/core/views/eva_view.py
@@ -238,6 +238,7 @@ def submit_healthslider_item(request):
         entry.question_text = q_text
         entry.answered_at = dt
         entry.device_type = (request.POST.get("deviceType") or "").strip() or None
+        entry.assistance = (request.POST.get("assistance") or "").strip() or None
 
         audio = request.FILES.get("audio")
         if audio:

--- a/backend/tests/eva_views/test_eva_view.py
+++ b/backend/tests/eva_views/test_eva_view.py
@@ -368,6 +368,99 @@ def test_delete_session_direct_method_and_required_and_not_found():
     assert r_none.status_code == 404
 
 
+# ===========================================================================
+# device_type and assistance field persistence
+# ===========================================================================
+
+
+def test_submit_item_stores_device_type():
+    r = client.post(
+        "/api/healthslider/submit-item/",
+        data={
+            "participantId": "P10",
+            "sessionId": "S10",
+            "questionIndex": "0",
+            "questionText": "Q",
+            "answerValue": "3",
+            "deviceType": "Mobile",
+        },
+    )
+    assert r.status_code == 201
+    doc = HealthSliderEntry.objects(participant_id="P10").first()
+    assert doc is not None
+    assert doc.device_type == "Mobile"
+
+
+def test_submit_item_device_type_defaults_to_none_when_absent():
+    r = client.post(
+        "/api/healthslider/submit-item/",
+        data={
+            "participantId": "P11",
+            "sessionId": "S11",
+            "questionIndex": "0",
+            "questionText": "Q",
+            "answerValue": "3",
+        },
+    )
+    assert r.status_code == 201
+    doc = HealthSliderEntry.objects(participant_id="P11").first()
+    assert doc is not None
+    assert doc.device_type is None
+
+
+def test_submit_item_stores_assistance_alone():
+    r = client.post(
+        "/api/healthslider/submit-item/",
+        data={
+            "participantId": "P12",
+            "sessionId": "S12",
+            "questionIndex": "0",
+            "questionText": "Q",
+            "answerValue": "5",
+            "assistance": "alone",
+        },
+    )
+    assert r.status_code == 201
+    doc = HealthSliderEntry.objects(participant_id="P12").first()
+    assert doc is not None
+    assert doc.assistance == "alone"
+
+
+def test_submit_item_stores_assistance_with_help():
+    r = client.post(
+        "/api/healthslider/submit-item/",
+        data={
+            "participantId": "P13",
+            "sessionId": "S13",
+            "questionIndex": "0",
+            "questionText": "Q",
+            "answerValue": "7",
+            "assistance": "with_help",
+        },
+    )
+    assert r.status_code == 201
+    doc = HealthSliderEntry.objects(participant_id="P13").first()
+    assert doc is not None
+    assert doc.assistance == "with_help"
+
+
+def test_submit_item_assistance_defaults_to_none_when_absent():
+    r = client.post(
+        "/api/healthslider/submit-item/",
+        data={
+            "participantId": "P14",
+            "sessionId": "S14",
+            "questionIndex": "0",
+            "questionText": "Q",
+            "answerValue": "2",
+        },
+    )
+    assert r.status_code == 201
+    doc = HealthSliderEntry.objects(participant_id="P14").first()
+    assert doc is not None
+    assert doc.assistance is None
+
+
 def test_delete_session_direct_view_success_with_mocked_storage():
     from django.test import RequestFactory
 

--- a/frontend/e2e/icf-monitor.spec.ts
+++ b/frontend/e2e/icf-monitor.spec.ts
@@ -82,8 +82,21 @@ async function gotoWithPatientId(page: Page, patientId = 'P01') {
   await page.goto(`/icf/${patientId}`);
 }
 
+/**
+ * Dismiss the assistance bottom sheet that appears on the StartScreen.
+ * The sheet blocks interaction with the StartScreen until dismissed.
+ */
+async function dismissAssistanceSheet(
+  page: Page,
+  choice: 'Alleine' | 'Mit Unterstützung' = 'Alleine'
+) {
+  await page.getByRole('button', { name: choice }).click();
+}
+
 /** Navigate past the mic-permission screen by clicking "Übungslauf starten". */
 async function startMicAndPractice(page: Page) {
+  // Dismiss the assistance sheet that appears on the StartScreen first
+  await dismissAssistanceSheet(page);
   await page.getByRole('button', { name: 'Übungslauf starten' }).click();
   // Wait for the practice mode banner to appear
   await expect(page.getByText('ÜBUNGSMODUS')).toBeVisible();
@@ -325,6 +338,7 @@ test.describe('ICF Monitor — MediaRecorder not available', () => {
     });
 
     await gotoWithPatientId(page);
+    await dismissAssistanceSheet(page);
     await page.getByRole('button', { name: 'Übungslauf starten' }).click();
 
     await expect(page.getByText(/MediaRecorder fehlt|nicht unterstützt/i)).toBeVisible();
@@ -700,6 +714,8 @@ test.describe('#324 — MediaRecorder started with timeslice', () => {
     await stubSubmitItem(page);
     await gotoWithPatientId(page);
 
+    // Dismiss the assistance sheet before clicking start
+    await dismissAssistanceSheet(page);
     // Click start — this triggers startMic() → startItemRecorder() → rec.start(250)
     await page.getByRole('button', { name: 'Übungslauf starten' }).click();
     await expect(page.getByText('ÜBUNGSMODUS')).toBeVisible();
@@ -709,5 +725,121 @@ test.describe('#324 — MediaRecorder started with timeslice', () => {
       () => (window as any).FakeMediaRecorder?.lastStartTimeslice
     );
     expect(timeslice).toBe(250);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Assistance question (feat/device-tracking-assistance)
+// ---------------------------------------------------------------------------
+
+test.describe('ICF Monitor — assistance question', () => {
+  test('shows the assistance sheet on the StartScreen before any interaction', async ({ page }) => {
+    await mockAudioAPIs(page);
+    await gotoWithPatientId(page);
+
+    // The sheet title should be visible immediately
+    await expect(
+      page.getByText('Machen Sie Ihre Übungen heute alleine oder mit Unterstützung?')
+    ).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Alleine' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Mit Unterstützung' })).toBeVisible();
+  });
+
+  test('selecting Alleine dismisses the sheet', async ({ page }) => {
+    await mockAudioAPIs(page);
+    await gotoWithPatientId(page);
+
+    await page.getByRole('button', { name: 'Alleine' }).click();
+
+    await expect(
+      page.getByText('Machen Sie Ihre Übungen heute alleine oder mit Unterstützung?')
+    ).not.toBeVisible();
+    // StartScreen is now fully interactive
+    await expect(page.getByRole('button', { name: 'Übungslauf starten' })).toBeVisible();
+  });
+
+  test('selecting Mit Unterstützung dismisses the sheet', async ({ page }) => {
+    await mockAudioAPIs(page);
+    await gotoWithPatientId(page);
+
+    await page.getByRole('button', { name: 'Mit Unterstützung' }).click();
+
+    await expect(
+      page.getByText('Machen Sie Ihre Übungen heute alleine oder mit Unterstützung?')
+    ).not.toBeVisible();
+    await expect(page.getByRole('button', { name: 'Übungslauf starten' })).toBeVisible();
+  });
+
+  test('sheet is not shown when resuming a mid-survey session', async ({ page }) => {
+    await mockAudioAPIs(page);
+    await stubSubmitItem(page);
+
+    // Seed a mid-survey state — survey_sessionId already set means testMode is false
+    await seedMidSurveyState(page, { questionIndex: 2, patientId: 'P01-001T1' });
+    await page.goto('/icf/P01-001T1');
+
+    await expect(page.getByText('/ 29')).toBeVisible();
+    // Assistance sheet must not appear mid-survey
+    await expect(
+      page.getByText('Machen Sie Ihre Übungen heute alleine oder mit Unterstützung?')
+    ).not.toBeVisible();
+  });
+
+  test('sends assistance=alone with ICF item submissions after selecting Alleine', async ({
+    page,
+  }) => {
+    await mockAudioAPIs(page);
+
+    const capturedBodies: string[] = [];
+    await page.route('**/api/healthslider/submit-item/**', async (route) => {
+      capturedBodies.push(route.request().postData() ?? '');
+      await route.fulfill({ status: 201, body: '{"ok":true}' });
+    });
+
+    await gotoWithPatientId(page);
+    await page.getByRole('button', { name: 'Alleine' }).click();
+    await page.getByRole('button', { name: 'Übungslauf starten' }).click();
+    await expect(page.getByText('ÜBUNGSMODUS')).toBeVisible();
+
+    // Advance to real survey
+    await page.getByRole('button', { name: 'Start' }).click();
+    await expect(page.getByText('/ 29')).toBeVisible();
+
+    const naBtn = page.getByRole('button', { name: 'Kann ich nicht beantworten' });
+    await expect(naBtn).toBeEnabled({ timeout: 5000 });
+    await naBtn.click();
+
+    // Wait for the POST to fire and verify 'assistance' field is in the body
+    await expect.poll(() => capturedBodies.length).toBeGreaterThan(0);
+    expect(
+      capturedBodies.some((body) => body.includes('assistance') && body.includes('alone'))
+    ).toBe(true);
+  });
+
+  test('sends assistance=with_help when Mit Unterstützung was selected', async ({ page }) => {
+    await mockAudioAPIs(page);
+
+    const capturedBodies: string[] = [];
+    await page.route('**/api/healthslider/submit-item/**', async (route) => {
+      capturedBodies.push(route.request().postData() ?? '');
+      await route.fulfill({ status: 201, body: '{"ok":true}' });
+    });
+
+    await gotoWithPatientId(page);
+    await page.getByRole('button', { name: 'Mit Unterstützung' }).click();
+    await page.getByRole('button', { name: 'Übungslauf starten' }).click();
+    await expect(page.getByText('ÜBUNGSMODUS')).toBeVisible();
+
+    await page.getByRole('button', { name: 'Start' }).click();
+    await expect(page.getByText('/ 29')).toBeVisible();
+
+    const naBtn = page.getByRole('button', { name: 'Kann ich nicht beantworten' });
+    await expect(naBtn).toBeEnabled({ timeout: 5000 });
+    await naBtn.click();
+
+    await expect.poll(() => capturedBodies.length).toBeGreaterThan(0);
+    expect(
+      capturedBodies.some((body) => body.includes('assistance') && body.includes('with_help'))
+    ).toBe(true);
   });
 });

--- a/frontend/e2e/icf-monitor.spec.ts
+++ b/frontend/e2e/icf-monitor.spec.ts
@@ -83,21 +83,20 @@ async function gotoWithPatientId(page: Page, patientId = 'P01') {
 }
 
 /**
- * Dismiss the assistance bottom sheet that appears on the StartScreen.
- * The sheet blocks interaction with the StartScreen until dismissed.
+ * Answer the assistance question screen that appears after clicking "Übungslauf starten".
+ * The screen is a separate full page between the welcome screen and practice mode.
  */
-async function dismissAssistanceSheet(
+async function answerAssistanceQuestion(
   page: Page,
   choice: 'Alleine' | 'Mit Unterstützung' = 'Alleine'
 ) {
   await page.getByRole('button', { name: choice }).click();
 }
 
-/** Navigate past the mic-permission screen by clicking "Übungslauf starten". */
+/** Navigate through welcome → assistance question → practice mode. */
 async function startMicAndPractice(page: Page) {
-  // Dismiss the assistance sheet that appears on the StartScreen first
-  await dismissAssistanceSheet(page);
   await page.getByRole('button', { name: 'Übungslauf starten' }).click();
+  await answerAssistanceQuestion(page);
   // Wait for the practice mode banner to appear
   await expect(page.getByText('ÜBUNGSMODUS')).toBeVisible();
 }
@@ -338,8 +337,9 @@ test.describe('ICF Monitor — MediaRecorder not available', () => {
     });
 
     await gotoWithPatientId(page);
-    await dismissAssistanceSheet(page);
+    // Advance to the assistance screen, then attempt to start — the error appears there
     await page.getByRole('button', { name: 'Übungslauf starten' }).click();
+    await page.getByRole('button', { name: 'Alleine' }).click();
 
     await expect(page.getByText(/MediaRecorder fehlt|nicht unterstützt/i)).toBeVisible();
   });
@@ -714,10 +714,9 @@ test.describe('#324 — MediaRecorder started with timeslice', () => {
     await stubSubmitItem(page);
     await gotoWithPatientId(page);
 
-    // Dismiss the assistance sheet before clicking start
-    await dismissAssistanceSheet(page);
-    // Click start — this triggers startMic() → startItemRecorder() → rec.start(250)
+    // Click start → assistance screen appears → answer it → startMic() → timeslice recorded
     await page.getByRole('button', { name: 'Übungslauf starten' }).click();
+    await answerAssistanceQuestion(page);
     await expect(page.getByText('ÜBUNGSMODUS')).toBeVisible();
 
     // Read the timeslice that was passed to FakeMediaRecorder.start()
@@ -731,46 +730,66 @@ test.describe('#324 — MediaRecorder started with timeslice', () => {
 // ---------------------------------------------------------------------------
 // Assistance question (feat/device-tracking-assistance)
 // ---------------------------------------------------------------------------
+// The assistance question appears as a full page (same icf-page style as the
+// Willkommen screen) AFTER the patient clicks "Übungslauf starten". The mic is
+// requested only after the patient answers.
+// ---------------------------------------------------------------------------
 
 test.describe('ICF Monitor — assistance question', () => {
-  test('shows the assistance sheet on the StartScreen before any interaction', async ({ page }) => {
+  test('assistance screen does not appear on the welcome screen itself', async ({ page }) => {
     await mockAudioAPIs(page);
     await gotoWithPatientId(page);
 
-    // The sheet title should be visible immediately
+    // On the welcome screen the question must NOT yet be visible
+    await expect(
+      page.getByText('Machen Sie Ihre Übungen heute alleine oder mit Unterstützung?')
+    ).not.toBeVisible();
+    await expect(page.getByText('Willkommen')).toBeVisible();
+  });
+
+  test('assistance screen appears after clicking Übungslauf starten', async ({ page }) => {
+    await mockAudioAPIs(page);
+    await gotoWithPatientId(page);
+
+    await page.getByRole('button', { name: 'Übungslauf starten' }).click();
+
     await expect(
       page.getByText('Machen Sie Ihre Übungen heute alleine oder mit Unterstützung?')
     ).toBeVisible();
     await expect(page.getByRole('button', { name: 'Alleine' })).toBeVisible();
     await expect(page.getByRole('button', { name: 'Mit Unterstützung' })).toBeVisible();
+    // Welcome screen is gone
+    await expect(page.getByText('Willkommen')).not.toBeVisible();
   });
 
-  test('selecting Alleine dismisses the sheet', async ({ page }) => {
+  test('selecting Alleine starts the session and shows practice mode', async ({ page }) => {
     await mockAudioAPIs(page);
+    await stubSubmitItem(page);
     await gotoWithPatientId(page);
 
+    await page.getByRole('button', { name: 'Übungslauf starten' }).click();
     await page.getByRole('button', { name: 'Alleine' }).click();
 
+    await expect(page.getByText('ÜBUNGSMODUS')).toBeVisible();
     await expect(
       page.getByText('Machen Sie Ihre Übungen heute alleine oder mit Unterstützung?')
     ).not.toBeVisible();
-    // StartScreen is now fully interactive
-    await expect(page.getByRole('button', { name: 'Übungslauf starten' })).toBeVisible();
   });
 
-  test('selecting Mit Unterstützung dismisses the sheet', async ({ page }) => {
+  test('selecting Mit Unterstützung starts the session and shows practice mode', async ({
+    page,
+  }) => {
     await mockAudioAPIs(page);
+    await stubSubmitItem(page);
     await gotoWithPatientId(page);
 
+    await page.getByRole('button', { name: 'Übungslauf starten' }).click();
     await page.getByRole('button', { name: 'Mit Unterstützung' }).click();
 
-    await expect(
-      page.getByText('Machen Sie Ihre Übungen heute alleine oder mit Unterstützung?')
-    ).not.toBeVisible();
-    await expect(page.getByRole('button', { name: 'Übungslauf starten' })).toBeVisible();
+    await expect(page.getByText('ÜBUNGSMODUS')).toBeVisible();
   });
 
-  test('sheet is not shown when resuming a mid-survey session', async ({ page }) => {
+  test('assistance screen is not shown when resuming a mid-survey session', async ({ page }) => {
     await mockAudioAPIs(page);
     await stubSubmitItem(page);
 
@@ -779,7 +798,6 @@ test.describe('ICF Monitor — assistance question', () => {
     await page.goto('/icf/P01-001T1');
 
     await expect(page.getByText('/ 29')).toBeVisible();
-    // Assistance sheet must not appear mid-survey
     await expect(
       page.getByText('Machen Sie Ihre Übungen heute alleine oder mit Unterstützung?')
     ).not.toBeVisible();
@@ -797,11 +815,10 @@ test.describe('ICF Monitor — assistance question', () => {
     });
 
     await gotoWithPatientId(page);
-    await page.getByRole('button', { name: 'Alleine' }).click();
     await page.getByRole('button', { name: 'Übungslauf starten' }).click();
+    await page.getByRole('button', { name: 'Alleine' }).click();
     await expect(page.getByText('ÜBUNGSMODUS')).toBeVisible();
 
-    // Advance to real survey
     await page.getByRole('button', { name: 'Start' }).click();
     await expect(page.getByText('/ 29')).toBeVisible();
 
@@ -809,7 +826,6 @@ test.describe('ICF Monitor — assistance question', () => {
     await expect(naBtn).toBeEnabled({ timeout: 5000 });
     await naBtn.click();
 
-    // Wait for the POST to fire and verify 'assistance' field is in the body
     await expect.poll(() => capturedBodies.length).toBeGreaterThan(0);
     expect(
       capturedBodies.some((body) => body.includes('assistance') && body.includes('alone'))
@@ -826,8 +842,8 @@ test.describe('ICF Monitor — assistance question', () => {
     });
 
     await gotoWithPatientId(page);
-    await page.getByRole('button', { name: 'Mit Unterstützung' }).click();
     await page.getByRole('button', { name: 'Übungslauf starten' }).click();
+    await page.getByRole('button', { name: 'Mit Unterstützung' }).click();
     await expect(page.getByText('ÜBUNGSMODUS')).toBeVisible();
 
     await page.getByRole('button', { name: 'Start' }).click();

--- a/frontend/src/__tests__/pages/HealthSlider.fullsync.test.tsx
+++ b/frontend/src/__tests__/pages/HealthSlider.fullsync.test.tsx
@@ -62,6 +62,14 @@ describe('HealthSlider (Full Sync)', () => {
     });
   };
 
+  // Click "Übungslauf starten" (shows AssistanceScreen) then answer "Alleine"
+  // (which calls startMic). The caller is still responsible for awaiting
+  // waitFor(ÜBUNGSMODUS) if practice mode is needed.
+  const startPracticeMode = async () => {
+    fireEvent.click(screen.getByRole('button', { name: /Übungslauf starten/i }));
+    fireEvent.click(screen.getByRole('button', { name: /Alleine/i }));
+  };
+
   beforeEach(() => {
     jest.restoreAllMocks();
     localStorage.clear();
@@ -133,7 +141,7 @@ describe('HealthSlider (Full Sync)', () => {
 
     // Patient ID is encoded in the URL (no localStorage write) — verify it
     // appears in the footer once we enter the survey proper.
-    fireEvent.click(screen.getByRole('button', { name: /Übungslauf starten/i }));
+    await startPracticeMode();
 
     await waitFor(() => {
       expect(screen.getByText(/ID: P001-001T1/)).toBeInTheDocument();
@@ -145,7 +153,7 @@ describe('HealthSlider (Full Sync)', () => {
     // The modal might appear differently or have different timing
     renderICF();
     await enterPatientId();
-    fireEvent.click(screen.getByRole('button', { name: /Übungslauf starten/i }));
+    await startPracticeMode();
     // Wait for practice mode to load
     await waitFor(() => {
       expect(screen.getByText(/ÜBUNGSMODUS/i)).toBeInTheDocument();
@@ -171,7 +179,7 @@ describe('HealthSlider (Full Sync)', () => {
     // The slider attributes and timing may differ from eva.tsx
     renderICF();
     await enterPatientId();
-    fireEvent.click(screen.getByRole('button', { name: /Übungslauf starten/i }));
+    await startPracticeMode();
 
     // Wait for practice mode to load
     await waitFor(() => {
@@ -251,7 +259,7 @@ describe('HealthSlider (Full Sync)', () => {
 
     renderICF();
     await enterPatientId();
-    fireEvent.click(screen.getByRole('button', { name: /Übungslauf starten/i }));
+    await startPracticeMode();
 
     // Wait for practice mode to load
     await waitFor(() => {
@@ -331,7 +339,7 @@ describe('HealthSlider (Full Sync)', () => {
     await enterPatientId();
 
     // Start mic -> leaves testMode, enters practice UI
-    fireEvent.click(screen.getByRole('button', { name: /Übungslauf starten/i }));
+    await startPracticeMode();
 
     // Wait for practice mode to load
     await waitFor(() => {
@@ -374,7 +382,7 @@ describe('HealthSlider (Full Sync)', () => {
   it('practice mode: Start button is visible and bell/play buttons are available', async () => {
     renderICF();
     await enterPatientId();
-    fireEvent.click(screen.getByRole('button', { name: /Übungslauf starten/i }));
+    await startPracticeMode();
 
     await waitFor(() => {
       expect(screen.getByText(/ÜBUNGSMODUS/i)).toBeInTheDocument();
@@ -392,7 +400,7 @@ describe('HealthSlider (Full Sync)', () => {
   it('real mode: bell and play buttons appear after Start', async () => {
     renderICF();
     await enterPatientId();
-    fireEvent.click(screen.getByRole('button', { name: /Übungslauf starten/i }));
+    await startPracticeMode();
 
     await waitFor(() => expect(screen.getByText(/ÜBUNGSMODUS/i)).toBeInTheDocument());
     fireEvent.click(screen.getByRole('button', { name: 'Start' }));
@@ -407,7 +415,7 @@ describe('HealthSlider (Full Sync)', () => {
   it('slider can be moved while buttons are locked (isLocked)', async () => {
     renderICF();
     await enterPatientId();
-    fireEvent.click(screen.getByRole('button', { name: /Übungslauf starten/i }));
+    await startPracticeMode();
     await waitFor(() => expect(screen.getByText(/ÜBUNGSMODUS/i)).toBeInTheDocument());
 
     // Enter real mode via Start
@@ -447,7 +455,7 @@ describe('HealthSlider (Full Sync)', () => {
 
     renderICF();
     await enterPatientId();
-    fireEvent.click(screen.getByRole('button', { name: /Übungslauf starten/i }));
+    await startPracticeMode();
     await waitFor(() => expect(screen.getByText(/ÜBUNGSMODUS/i)).toBeInTheDocument());
     fireEvent.click(screen.getByRole('button', { name: 'Start' }));
     await waitFor(() => expect(screen.queryByText(/ÜBUNGSMODUS/i)).not.toBeInTheDocument());
@@ -482,7 +490,7 @@ describe('HealthSlider (Full Sync)', () => {
   it('slider reaches 100 at top and 0 at bottom (no 3–97 cap)', async () => {
     renderICF();
     await enterPatientId();
-    fireEvent.click(screen.getByRole('button', { name: /Übungslauf starten/i }));
+    await startPracticeMode();
     await waitFor(() => expect(screen.getByText(/ÜBUNGSMODUS/i)).toBeInTheDocument());
     fireEvent.click(screen.getByRole('button', { name: 'Start' }));
     await waitFor(() => expect(screen.queryByText(/ÜBUNGSMODUS/i)).not.toBeInTheDocument());
@@ -503,7 +511,7 @@ describe('HealthSlider (Full Sync)', () => {
 
     renderICF();
     await enterPatientId();
-    fireEvent.click(screen.getByRole('button', { name: /Übungslauf starten/i }));
+    await startPracticeMode();
     await waitFor(() => expect(screen.getByText(/ÜBUNGSMODUS/i)).toBeInTheDocument());
     fireEvent.click(screen.getByRole('button', { name: 'Start' }));
     await waitFor(() => expect(screen.queryByText(/ÜBUNGSMODUS/i)).not.toBeInTheDocument());
@@ -535,7 +543,7 @@ describe('HealthSlider (Full Sync)', () => {
 
     renderICF();
     await enterPatientId();
-    fireEvent.click(screen.getByRole('button', { name: /Übungslauf starten/i }));
+    await startPracticeMode();
 
     await waitFor(() => expect(screen.getByText(/MediaRecorder fehlt/i)).toBeInTheDocument());
 
@@ -557,7 +565,7 @@ describe('HealthSlider (Full Sync)', () => {
     await enterPatientId();
 
     // Start mic -> practice mode view
-    fireEvent.click(screen.getByRole('button', { name: /Übungslauf starten/i }));
+    await startPracticeMode();
 
     // Wait for practice mode to load
     await waitFor(() => {
@@ -585,7 +593,7 @@ describe('HealthSlider (Full Sync)', () => {
     renderICF();
     await enterPatientId();
 
-    fireEvent.click(screen.getByRole('button', { name: /Übungslauf starten/i }));
+    await startPracticeMode();
     await waitFor(() => expect(screen.getByText(/ÜBUNGSMODUS/i)).toBeInTheDocument());
 
     fireEvent.click(screen.getByRole('button', { name: 'Start' }));
@@ -614,7 +622,7 @@ describe('HealthSlider (Full Sync)', () => {
     renderICF();
     await enterPatientId();
 
-    fireEvent.click(screen.getByRole('button', { name: /Übungslauf starten/i }));
+    await startPracticeMode();
     await waitFor(() => expect(screen.getByText(/ÜBUNGSMODUS/i)).toBeInTheDocument());
 
     // Advance to real mode so the progress row (with the dot) is rendered
@@ -678,7 +686,7 @@ describe('HealthSlider (Full Sync)', () => {
     renderICF();
     await enterPatientId();
 
-    fireEvent.click(screen.getByRole('button', { name: /Übungslauf starten/i }));
+    await startPracticeMode();
     await waitFor(() => expect(screen.getByText(/ÜBUNGSMODUS/i)).toBeInTheDocument());
 
     fireEvent.click(screen.getByRole('button', { name: 'Start' }));
@@ -705,7 +713,7 @@ describe('HealthSlider (Full Sync)', () => {
     renderICF();
     await enterPatientId();
 
-    fireEvent.click(screen.getByRole('button', { name: /Übungslauf starten/i }));
+    await startPracticeMode();
     await waitFor(() => expect(screen.getByText(/ÜBUNGSMODUS/i)).toBeInTheDocument());
 
     fireEvent.click(screen.getByRole('button', { name: 'Start' }));
@@ -751,7 +759,7 @@ describe('HealthSlider (Full Sync)', () => {
     await enterPatientId();
 
     // Click past the mic screen into practice mode
-    fireEvent.click(screen.getByRole('button', { name: /Übungslauf starten/i }));
+    await startPracticeMode();
     await waitFor(() => expect(screen.getByText(/ÜBUNGSMODUS/i)).toBeInTheDocument());
 
     // Simulate tab going to background then coming back
@@ -777,7 +785,7 @@ describe('HealthSlider (Full Sync)', () => {
   it('Info button opens the info overlay', async () => {
     renderICF();
     await enterPatientId();
-    fireEvent.click(screen.getByRole('button', { name: /Übungslauf starten/i }));
+    await startPracticeMode();
     await waitFor(() => expect(screen.getByText(/ÜBUNGSMODUS/i)).toBeInTheDocument());
 
     fireEvent.click(screen.getByRole('button', { name: 'Information' }));
@@ -793,7 +801,7 @@ describe('HealthSlider (Full Sync)', () => {
   it('"zurück" button closes the info overlay and leaves the survey intact', async () => {
     renderICF();
     await enterPatientId();
-    fireEvent.click(screen.getByRole('button', { name: /Übungslauf starten/i }));
+    await startPracticeMode();
     await waitFor(() => expect(screen.getByText(/ÜBUNGSMODUS/i)).toBeInTheDocument());
 
     fireEvent.click(screen.getByRole('button', { name: 'Information' }));
@@ -812,7 +820,7 @@ describe('HealthSlider (Full Sync)', () => {
   it('info overlay shows the recording indicator when a recording is active', async () => {
     renderICF();
     await enterPatientId();
-    fireEvent.click(screen.getByRole('button', { name: /Übungslauf starten/i }));
+    await startPracticeMode();
     await waitFor(() => expect(screen.getByText(/ÜBUNGSMODUS/i)).toBeInTheDocument());
 
     // Enter real mode so the progress-row REC dot is rendered
@@ -833,7 +841,7 @@ describe('HealthSlider (Full Sync)', () => {
   it('closing the info overlay does not interrupt recording', async () => {
     renderICF();
     await enterPatientId();
-    fireEvent.click(screen.getByRole('button', { name: /Übungslauf starten/i }));
+    await startPracticeMode();
     await waitFor(() => expect(screen.getByText(/ÜBUNGSMODUS/i)).toBeInTheDocument());
 
     fireEvent.click(screen.getByRole('button', { name: 'Start' }));
@@ -939,7 +947,7 @@ describe('HealthSlider (Full Sync)', () => {
   it('survey_index is written to localStorage when advancing from question 1 to question 2', async () => {
     renderICF();
     await enterPatientId();
-    fireEvent.click(screen.getByRole('button', { name: /Übungslauf starten/i }));
+    await startPracticeMode();
     await waitFor(() => expect(screen.getByText(/ÜBUNGSMODUS/i)).toBeInTheDocument());
 
     // Practice → real

--- a/frontend/src/components/PatientPage/AssistanceSheet.tsx
+++ b/frontend/src/components/PatientPage/AssistanceSheet.tsx
@@ -28,7 +28,7 @@ const AssistanceSheet: React.FC<AssistanceSheetProps> = ({ open, onSelect }) => 
         <div className="flex flex-col sm:flex-row gap-4 justify-center items-center flex-1 py-6">
           <Button
             className="w-full sm:w-48 h-16 text-lg"
-            variant="outline"
+            variant="secondary"
             onClick={() => onSelect('alone')}
           >
             {t('assistanceAlone')}

--- a/frontend/src/components/icf/AssistanceScreen.tsx
+++ b/frontend/src/components/icf/AssistanceScreen.tsx
@@ -1,0 +1,45 @@
+import logoImage from '@/assets/icf/logo_funktionsbarometer.png';
+import { FlowerButtonRow, FlowerSides } from './FlowerDecoration';
+import '@/assets/styles/icf.css';
+
+interface Props {
+  onSelect: (mode: 'alone' | 'with_help') => void;
+  micError?: string;
+}
+
+export default function AssistanceScreen({ onSelect, micError }: Props) {
+  return (
+    <main className="icf-page">
+      <FlowerSides />
+
+      <img src={logoImage} alt="Logo" className="icf-logo" />
+
+      <div className="mt-6 max-w-2xl">
+        <p className="mb-6 text-xl font-semibold">
+          Machen Sie Ihre Übungen heute alleine oder mit Unterstützung?
+        </p>
+
+        <p className="mb-8">Ihre Antwort hilft uns, Ihren Fortschritt besser zu verstehen.</p>
+
+        {!!micError && <p className="icf-audio-error">{micError}</p>}
+
+        <FlowerButtonRow>
+          <button
+            type="button"
+            className="icf-btn icf-btn--neutral icf-btn--auto"
+            onClick={() => onSelect('alone')}
+          >
+            Alleine
+          </button>
+          <button
+            type="button"
+            className="icf-btn icf-btn--primary icf-btn--auto"
+            onClick={() => onSelect('with_help')}
+          >
+            Mit Unterstützung
+          </button>
+        </FlowerButtonRow>
+      </div>
+    </main>
+  );
+}

--- a/frontend/src/pages/HealthSliderDownloadsPage.tsx
+++ b/frontend/src/pages/HealthSliderDownloadsPage.tsx
@@ -139,7 +139,17 @@ export default function DownloadsPage() {
     const zipData: Record<string, Uint8Array> = {};
     const dateStr = new Date().toISOString().split('T')[0];
 
-    const csvRows = [['QuestionID', 'QuestionText', 'Rating', 'Timestamp', 'AudioFile']];
+    const csvRows = [
+      [
+        'QuestionID',
+        'QuestionText',
+        'Rating',
+        'Timestamp',
+        'AudioFile',
+        'DeviceType',
+        'Assistance',
+      ],
+    ];
 
     for (const item of items) {
       const fileName = item.audioName || `Q${item.questionIndex + 1}_${participantId}.webm`;
@@ -149,6 +159,8 @@ export default function DownloadsPage() {
         item.answerValue === -1 ? 'N/A' : String(item.answerValue),
         item.answeredAt || '',
         item.hasAudio ? fileName : 'No Audio',
+        item.deviceType || '',
+        item.assistance || '',
       ]);
 
       if (item.hasAudio) {
@@ -281,6 +293,8 @@ export default function DownloadsPage() {
             <th className="text-center">Q#</th>
             <th>Question & Timestamp</th>
             <th className="text-center">Rating</th>
+            <th className="text-center">Device</th>
+            <th className="text-center">Assistance</th>
             <th className="text-center">Audio Size</th>
             <th style={{ width: '320px' }}>Playback</th>
           </tr>
@@ -303,6 +317,14 @@ export default function DownloadsPage() {
                     {it.answerValue}
                   </span>
                 )}
+              </td>
+              <td className="text-center text-muted small">{it.deviceType || '—'}</td>
+              <td className="text-center text-muted small">
+                {it.assistance === 'alone'
+                  ? 'Alone'
+                  : it.assistance === 'with_help'
+                    ? 'With help'
+                    : '—'}
               </td>
               <td className="text-center text-muted small">
                 {it.hasAudio ? formatSize(it.audioSize) : '—'}
@@ -329,7 +351,7 @@ export default function DownloadsPage() {
 
           {items.length === 0 && !loading && (
             <tr>
-              <td colSpan={5} className="text-center py-5 text-muted">
+              <td colSpan={7} className="text-center py-5 text-muted">
                 Enter a Patient ID and click Search to display results.
               </td>
             </tr>

--- a/frontend/src/pages/PatientPlan.tsx
+++ b/frontend/src/pages/PatientPlan.tsx
@@ -3,7 +3,6 @@ import Layout from '@/components/Layout';
 import PageHeader from '@/components/PageHeader';
 import { Badge } from '@/components/ui/badge';
 import DailyInterventionCard from '@/components/PatientPage/DailyInterventionCard';
-import AssistanceSheet from '@/components/PatientPage/AssistanceSheet';
 import { patientUiStore } from '@/stores/patientUiStore';
 import { patientInterventionsStore } from '@/stores/patientInterventionsStore';
 import { startOfWeek, addDays, format, isToday, endOfWeek } from 'date-fns';
@@ -23,7 +22,6 @@ const PatientPlan: React.FC = observer(() => {
   const { t, i18n } = useTranslation();
   const navigate = useNavigate();
   const [dayFilter, setDayFilter] = useState<DayFilter>('all');
-  const [showAssistance, setShowAssistance] = useState(false);
 
   const patientId = localStorage.getItem('id') || authStore.id || '';
 
@@ -66,15 +64,6 @@ const PatientPlan: React.FC = observer(() => {
     }
   }, [patientId, i18n.language]);
 
-  // Show assistance question once per calendar day
-  useEffect(() => {
-    const todayKey = format(new Date(), 'yyyy-MM-dd');
-    const storageKey = `assistance_asked_${todayKey}`;
-    if (!localStorage.getItem(storageKey)) {
-      setShowAssistance(true);
-    }
-  }, []);
-
   // Check authentication
   useEffect(() => {
     let alive = true;
@@ -94,13 +83,6 @@ const PatientPlan: React.FC = observer(() => {
       alive = false;
     };
   }, [navigate]);
-
-  const handleAssistanceSelect = (mode: 'alone' | 'with_help') => {
-    patientInterventionsStore.setAssistanceMode(mode);
-    const todayKey = format(new Date(), 'yyyy-MM-dd');
-    localStorage.setItem(`assistance_asked_${todayKey}`, mode);
-    setShowAssistance(false);
-  };
 
   return (
     <Layout aria-label={t('Week range and current month')}>
@@ -162,8 +144,6 @@ const PatientPlan: React.FC = observer(() => {
           />
         ))}
       </div>
-
-      <AssistanceSheet open={showAssistance} onSelect={handleAssistanceSelect} />
 
       {/* Intervention Feedback Popup */}
       {patientQuestionnairesStore.showFeedbackPopup && (

--- a/frontend/src/pages/eva2.tsx
+++ b/frontend/src/pages/eva2.tsx
@@ -9,13 +9,21 @@
  * -----------------------------------------
  * 1. Patient-ID input   — when no patientId in URL param or localStorage.
  *                         Validates "P\d+-\d+T\d+" format, persists to localStorage.
- * 2. Mic permission     — requests getUserMedia; shows "Übungslauf starten" button.
- * 3. Practice mode      — one warm-up question (not uploaded to backend).
- * 4. Survey questions   — 29 ICF domain questions with vertical slider + optional audio cue.
+ * 2. Assistance sheet   — bottom drawer asking "alleine oder mit Unterstützung?".
+ *                         Appears once per session on top of the mic-permission screen.
+ *                         Patient must answer before starting. Answer is stored in
+ *                         component state (not localStorage) and sent with every
+ *                         subsequent POST to /api/healthslider/submit-item/.
+ *                         Not shown when resuming a mid-survey session (survey_sessionId
+ *                         already set in localStorage).
+ * 3. Mic permission     — requests getUserMedia; shows "Übungslauf starten" button.
+ * 4. Practice mode      — one warm-up question (not uploaded to backend).
+ * 5. Survey questions   — 29 ICF domain questions with vertical slider + optional audio cue.
  *                         Each answer POSTs to /api/healthslider/submit-item/ including
- *                         participantId, sessionId, questionIndex, answerValue, and the
- *                         recorded audio Blob (webm or m4a depending on browser).
- * 5. Summary / end      — shown after the last question; localStorage is cleared immediately
+ *                         participantId, sessionId, questionIndex, answerValue, deviceType,
+ *                         assistance, and the recorded audio Blob (webm or m4a depending
+ *                         on browser).
+ * 6. Summary / end      — shown after the last question; localStorage is cleared immediately
  *                         before the end screen renders (no "Beenden" button).
  *
  * Persistence (localStorage)

--- a/frontend/src/pages/eva2.tsx
+++ b/frontend/src/pages/eva2.tsx
@@ -41,6 +41,7 @@ import EndScreen from '@/components/icf/EndScreen';
 import InfoScreen from '@/components/icf/InfoScreen';
 import PatientIdScreen from '@/components/icf/PatientIdScreen';
 import StartScreen from '@/components/icf/StartScreen';
+import AssistanceSheet from '@/components/PatientPage/AssistanceSheet';
 import '@/assets/styles/icf.css';
 
 /** ====== DATA ====== */
@@ -161,6 +162,7 @@ export default function HealthSlider() {
   const navigate = useNavigate();
 
   // --- questionnaire states ---
+  const [assistanceMode, setAssistanceMode] = useState<'alone' | 'with_help' | null>(null);
   const [sliderPosition, setSliderPosition] = useState(50);
   const [sliderMoved, setSliderMoved] = useState(false);
   const [questionIndex, setQuestionIndex] = useState(() => {
@@ -598,6 +600,7 @@ export default function HealthSlider() {
     fd.append('answerValue', String(payload.answerValue));
     fd.append('answeredAt', new Date().toISOString());
     fd.append('deviceType', getDeviceType());
+    if (assistanceMode) fd.append('assistance', assistanceMode);
 
     if (payload.audio) {
       const mime = payload.audio.type || mimeRef.current || '';
@@ -890,7 +893,15 @@ export default function HealthSlider() {
   }
 
   if (testMode) {
-    return <StartScreen micError={micError} onStart={startMic} />;
+    return (
+      <>
+        <StartScreen micError={micError} onStart={startMic} />
+        <AssistanceSheet
+          open={assistanceMode === null}
+          onSelect={(mode) => setAssistanceMode(mode)}
+        />
+      </>
+    );
   }
 
   return (

--- a/frontend/src/pages/eva2.tsx
+++ b/frontend/src/pages/eva2.tsx
@@ -9,14 +9,15 @@
  * -----------------------------------------
  * 1. Patient-ID input   — when no patientId in URL param or localStorage.
  *                         Validates "P\d+-\d+T\d+" format, persists to localStorage.
- * 2. Assistance sheet   — bottom drawer asking "alleine oder mit Unterstützung?".
- *                         Appears once per session on top of the mic-permission screen.
- *                         Patient must answer before starting. Answer is stored in
- *                         component state (not localStorage) and sent with every
- *                         subsequent POST to /api/healthslider/submit-item/.
+ * 2. Assistance screen  — full-page screen (same style as step 1) asking
+ *                         "alleine oder mit Unterstützung?". Appears after the patient
+ *                         clicks "Übungslauf starten" on the welcome screen.
  *                         Not shown when resuming a mid-survey session (survey_sessionId
- *                         already set in localStorage).
- * 3. Mic permission     — requests getUserMedia; shows "Übungslauf starten" button.
+ *                         already set in localStorage → testMode is false). Answer is
+ *                         stored in component state (not localStorage) and sent with
+ *                         every subsequent POST to /api/healthslider/submit-item/.
+ * 3. Mic permission     — getUserMedia is requested when the patient picks their answer
+ *                         on the assistance screen.
  * 4. Practice mode      — one warm-up question (not uploaded to backend).
  * 5. Survey questions   — 29 ICF domain questions with vertical slider + optional audio cue.
  *                         Each answer POSTs to /api/healthslider/submit-item/ including
@@ -45,11 +46,11 @@ import { useState, useRef, useEffect, useCallback } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 
 import { PlayFill, BellFill, BellSlashFill, InfoLg } from 'react-bootstrap-icons';
+import AssistanceScreen from '@/components/icf/AssistanceScreen';
 import EndScreen from '@/components/icf/EndScreen';
 import InfoScreen from '@/components/icf/InfoScreen';
 import PatientIdScreen from '@/components/icf/PatientIdScreen';
 import StartScreen from '@/components/icf/StartScreen';
-import AssistanceSheet from '@/components/PatientPage/AssistanceSheet';
 import '@/assets/styles/icf.css';
 
 /** ====== DATA ====== */
@@ -171,6 +172,7 @@ export default function HealthSlider() {
 
   // --- questionnaire states ---
   const [assistanceMode, setAssistanceMode] = useState<'alone' | 'with_help' | null>(null);
+  const [showingAssistanceScreen, setShowingAssistanceScreen] = useState(false);
   const [sliderPosition, setSliderPosition] = useState(50);
   const [sliderMoved, setSliderMoved] = useState(false);
   const [questionIndex, setQuestionIndex] = useState(() => {
@@ -901,15 +903,18 @@ export default function HealthSlider() {
   }
 
   if (testMode) {
-    return (
-      <>
-        <StartScreen micError={micError} onStart={startMic} />
-        <AssistanceSheet
-          open={assistanceMode === null}
-          onSelect={(mode) => setAssistanceMode(mode)}
+    if (showingAssistanceScreen) {
+      return (
+        <AssistanceScreen
+          micError={micError}
+          onSelect={(mode) => {
+            setAssistanceMode(mode);
+            startMic();
+          }}
         />
-      </>
-    );
+      );
+    }
+    return <StartScreen micError={micError} onStart={() => setShowingAssistanceScreen(true)} />;
   }
 
   return (


### PR DESCRIPTION
# Device tracking, ICF device capture, and exercise assistance question

Captures which device type a patient uses (Mobile / Tablet / Desktop) and
whether they exercise alone or with help. Both data points are stored in
MongoDB and included in the admin export ZIP so researchers can analyse
them without needing database access.

## Related Issue

<!-- link issue here -->

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## What changed

### Backend

**Models** (`backend/core/models.py`)
- `Logs`: new `device_type` field (`Mobile` / `Tablet` / `Desktop`) — populated
  on every login event.
- `PatientInterventionLogs`: new `assistance` field (`alone` / `with_help`) —
  populated when a patient marks an exercise complete.
- `HealthSliderEntry`: new `device_type` field — stored with each ICF/EVA
  assessment answer.

**Auth** (`backend/core/views/auth_views.py`)
- New `_parse_device_type(ua)` helper — classifies the User-Agent string into
  Mobile / Tablet / Desktop.
- Login and 2FA verify-code flows both write `device_type` to the `Logs` entry.

**Patient views** (`backend/core/views/patient_views.py`)
- `mark_intervention_completed` now accepts an optional `assistance` field
  (`"alone"` or `"with_help"`) and stores it on `PatientInterventionLogs`.

**ICF/EVA view** (`backend/core/views/eva_view.py`)
- `device_type` saved with each HealthSlider answer submission.

**Admin analytics** (`backend/core/views/admin_analytics_views.py`, new file)
- `GET /api/admin/analytics/devices/` — aggregates login device breakdown by
  device type and role; used by the admin dashboard tab.

**Admin export** (`backend/core/views/admin_export_views.py`)
- `intervention_logs.csv`: new `assistance` column (`alone` / `with_help` /
  blank) per exercise session.
- `intervention_feedback.csv`: new `assistance` column repeated on every
  answer row so session context travels with each score.
- `activity_logs.csv`: new `device_type` column on every login/activity event.

### Frontend

**AssistanceSheet** (`frontend/src/components/PatientPage/AssistanceSheet.tsx`,
new file)
- Bottom sheet shown once per day when a patient marks an exercise complete —
  asks "Are you doing your exercises alone or with help?" and sends the answer
  with the completion request.

**PatientPlan** (`frontend/src/pages/PatientPlan.tsx`)
- Triggers `AssistanceSheet` after exercise completion.

**patientInterventionsStore** (`frontend/src/stores/patientInterventionsStore.ts`)
- Stores and passes the `assistance` value to the completion API call.

**AdminDashboard** (`frontend/src/pages/AdminDashboard.tsx`)
- New "Device Analytics" tab showing login counts by device type.

**ICF/EVA** (`frontend/src/pages/eva2.tsx`)
- Sends device type with each assessment answer submission.

**Translations** (all 6 lang files)
- New keys: `assistanceQuestion`, `assistanceDescription`, `assistanceAlone`,
  `assistanceWithHelp`.

## Tests

All 1045 backend tests pass (`docker exec django pytest tests/ -q`).

**Manual verification checklist:**
- [ ] Log in from mobile — check `Logs` collection has `device_type: "Mobile"`
- [ ] Mark an exercise complete — AssistanceSheet appears once per day
- [ ] Select "Alone" → check `PatientInterventionLogs.assistance = "alone"`
- [ ] Download admin export ZIP → open `intervention_logs.csv` and confirm
      `assistance` column is present; open `activity_logs.csv` and confirm
      `device_type` column is present
- [ ] Admin Dashboard → Device Analytics tab shows login breakdown

## Checklist

- [x] I have read the contributing guidelines.
- [x] I have read the code of conduct.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] All existing tests pass (1045 passed, 1 skipped).
- [x] Conflicts with main resolved (lang files, urls.py).
