### PR TITLE
Fix/google oauth verification

### DIFF
--- a/frontend/public/privacy-policy.html
+++ b/frontend/public/privacy-policy.html
@@ -1,0 +1,133 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Privacy Policy – Bearny</title>
+  <style>
+    body { font-family: sans-serif; max-width: 800px; margin: 40px auto; padding: 0 20px; color: #222; line-height: 1.6; }
+    h1 { font-size: 1.8rem; margin-bottom: 0.25rem; }
+    h4 { margin-top: 1.5rem; margin-bottom: 0.25rem; }
+    ul { padding-left: 1.5rem; }
+    a { color: #0070f3; }
+    .app-name { font-weight: bold; }
+    footer { margin-top: 3rem; font-size: 0.85rem; color: #666; border-top: 1px solid #ddd; padding-top: 1rem; }
+  </style>
+</head>
+<body>
+  <h1>Privacy Policy</h1>
+  <p><strong>Application:</strong> <span class="app-name">Bearny – Be Ready After Rehabilitation</span><br />
+     <strong>Operator:</strong> ARTORG Center for Biomedical Engineering Research, University of Bern<br />
+     <strong>Website:</strong> <a href="https://reha-advisor.ch">https://reha-advisor.ch</a><br />
+     <strong>Effective Date:</strong> May 9, 2025<br />
+     <strong>Last Updated:</strong> June 16, 2026</p>
+
+  <p>This web application is operated for <strong>research and clinical telerehabilitation purposes</strong>. We are
+  committed to protecting your privacy and ensuring transparency in how your data is used.</p>
+
+  <h4>1. Data Collection</h4>
+  <p>We collect only the information necessary for research and rehabilitation care, such as:</p>
+  <ul>
+    <li>Basic demographic data (e.g., age, sex, education)</li>
+    <li>Your responses to research-related questionnaires or activities</li>
+    <li>Technical logs to maintain system integrity (e.g., IP address, device type)</li>
+    <li>Wearable health data collected via connected third-party services (see Section 7)</li>
+  </ul>
+  <p>We do <strong>not</strong> collect personal identifiers such as names, addresses, or financial data unless
+  explicitly requested and consented to.</p>
+
+  <h4>2. Use of Data</h4>
+  <p>Collected data is used <strong>solely for research, academic analysis, and direct patient care</strong> within
+  the Bearny telerehabilitation platform. It will not be sold, rented, or shared for marketing purposes. All data
+  is anonymized or pseudonymized before analysis where feasible.</p>
+
+  <h4>3. Data Storage</h4>
+  <p>Data is stored securely on servers located in <strong>Switzerland</strong>, in compliance with ethical research
+  standards and applicable Swiss and European data protection law. Access is limited to authorized research and
+  clinical personnel only.</p>
+
+  <h4>4. Consent</h4>
+  <p>By using this application, you provide your <strong>informed consent</strong> to the collection and use of data
+  as described in this policy. If you do not agree, please do not continue to use the application.</p>
+
+  <h4>5. Your Rights</h4>
+  <p>You may:</p>
+  <ul>
+    <li>Request to view the data you provided</li>
+    <li>Withdraw from the study at any time</li>
+    <li>Request deletion of your data (where identifiable)</li>
+    <li>Revoke access to third-party connected services (e.g., Google Health) at any time</li>
+  </ul>
+  <p>To exercise any of these rights, contact the research team through the contact form or email listed in the app.</p>
+
+  <h4>6. Changes to This Policy</h4>
+  <p>We may update this policy as needed to reflect legal or methodological changes. Any updates will be posted
+  within the application and on this page.</p>
+
+  <h4>7. Google Health &amp; Fitness API Data</h4>
+  <p>Bearny integrates with the <strong>Google Fit / Google Health REST API</strong> to collect wearable health
+  metrics for rehabilitation monitoring. This section explains how we handle data obtained through Google APIs.</p>
+
+  <p><strong>Scopes requested and their purpose:</strong></p>
+  <ul>
+    <li>
+      <strong><code>https://www.googleapis.com/auth/fitness.activity.read</code></strong> —
+      Provides daily step count, walking distance, calories burned, and active minutes. Used to track whether the
+      patient is meeting their prescribed movement goals during rehabilitation.
+    </li>
+    <li>
+      <strong><code>https://www.googleapis.com/auth/fitness.heart_rate.read</code></strong> —
+      Provides resting heart rate and time spent in heart rate zones (fat-burn, cardio, peak). Used by the
+      physiotherapist to verify that the patient is exercising at the correct intensity as specified in their
+      rehabilitation plan.
+    </li>
+    <li>
+      <strong><code>https://www.googleapis.com/auth/fitness.sleep.read</code></strong> —
+      Provides sleep duration, time actually asleep, and number of awakenings. Sleep quality is a key recovery
+      indicator in post-surgical rehabilitation.
+    </li>
+    <li>
+      <strong><code>https://www.googleapis.com/auth/fitness.body.read</code></strong> —
+      Provides body weight data. Tracked alongside other health metrics where clinically relevant to the patient's
+      rehabilitation outcome.
+    </li>
+    <li>
+      <strong><code>https://www.googleapis.com/auth/fitness.oxygen_saturation.read</code></strong> —
+      Provides blood oxygen saturation (SpO2). For patients recovering from cardiopulmonary conditions, SpO2 is an
+      important safety and recovery metric.
+    </li>
+    <li>
+      <strong><code>https://www.googleapis.com/auth/fitness.body_temperature.read</code></strong> —
+      Provides skin temperature data. Elevated temperature can be an early indicator of post-operative infection or
+      inflammation.
+    </li>
+  </ul>
+
+  <p><strong>How Google Health data is used:</strong></p>
+  <ul>
+    <li>Data is displayed on the Bearny health dashboard and is accessible only to the patient and their assigned physiotherapist.</li>
+    <li>Aggregated, anonymised data may be used for research analysis as part of approved clinical studies.</li>
+    <li>Bearny accesses Google Health data in <strong>read-only</strong> mode — we never write, modify, or delete data in your Google account.</li>
+  </ul>
+
+  <p><strong>Data protection commitments for Google Health data:</strong></p>
+  <ul>
+    <li>Google Health data is <strong>not sold, rented, transferred, or shared</strong> with any third party for any purpose other than direct patient care and approved research.</li>
+    <li>Google Health data is <strong>not used for advertising</strong> or any commercial purposes.</li>
+    <li>Data is stored on servers located in <strong>Switzerland</strong> and is subject to the same access controls as all other Bearny data.</li>
+    <li>We only store the minimum data necessary to provide the rehabilitation monitoring feature.</li>
+    <li>Bearny's use of Google API data is limited to the purposes described in this policy and does not extend to any use prohibited by the <a href="https://developers.google.com/terms/api-services-user-data-policy" target="_blank" rel="noopener noreferrer">Google API Services User Data Policy</a>.</li>
+  </ul>
+
+  <p><strong>Revoking Google Health access:</strong></p>
+  <p>You can revoke Bearny's access to your Google Health data at any time by visiting your
+  <a href="https://myaccount.google.com/permissions" target="_blank" rel="noopener noreferrer">Google Account permissions page</a>
+  and removing Bearny from the list of connected apps. You may also contact us directly to request deletion of any
+  Google Health data stored in Bearny.</p>
+
+  <footer>
+    &copy; <script>document.write(new Date().getFullYear())</script>2026 Bearny – ARTORG Center, University of Bern.
+    &nbsp;|&nbsp; <a href="https://reha-advisor.ch">reha-advisor.ch</a>
+  </footer>
+</body>
+</html>

--- a/frontend/src/components/common/Footer.tsx
+++ b/frontend/src/components/common/Footer.tsx
@@ -59,9 +59,9 @@ const Footer: FunctionComponent = () => {
                 <NavLink to="/terms" className="text-sm">
                   {t('Terms & Conditions')}
                 </NavLink>
-                <NavLink to="/privacypolicy" className="text-sm">
+                <a href="/privacy-policy.html" className="text-sm">
                   {t('Privacy Policy')}
-                </NavLink>
+                </a>
               </div>
               <div className="text-sm">
                 &copy; {new Date().getFullYear()} {t('YourCompanyName')}. {t('Allrightsreserved')}

--- a/frontend/src/pages/PrivacyPolicy.tsx
+++ b/frontend/src/pages/PrivacyPolicy.tsx
@@ -84,8 +84,8 @@ const PrivacyPolicy: React.FC = () => {
           movement goals during rehabilitation.
         </li>
         <li>
-          <strong>fitness.heart_rate.read</strong> — Resting heart rate and time spent in heart
-          rate zones (fat-burn, cardio, peak). Used to verify that the patient is exercising at the
+          <strong>fitness.heart_rate.read</strong> — Resting heart rate and time spent in heart rate
+          zones (fat-burn, cardio, peak). Used to verify that the patient is exercising at the
           correct intensity as specified in their rehabilitation plan.
         </li>
         <li>
@@ -101,8 +101,8 @@ const PrivacyPolicy: React.FC = () => {
           important safety and recovery metric for patients with cardiopulmonary conditions.
         </li>
         <li>
-          <strong>fitness.body_temperature.read</strong> — Skin temperature data. An early
-          indicator of post-operative infection or inflammation.
+          <strong>fitness.body_temperature.read</strong> — Skin temperature data. An early indicator
+          of post-operative infection or inflammation.
         </li>
       </ul>
       <p>

--- a/frontend/src/pages/PrivacyPolicy.tsx
+++ b/frontend/src/pages/PrivacyPolicy.tsx
@@ -67,6 +67,72 @@ const PrivacyPolicy: React.FC = () => {
         We may update this policy as needed to reflect legal or methodological changes. Any updates
         will be posted within the application.
       </p>
+
+      <h4>7. Google Health &amp; Fitness API Data</h4>
+      <p>
+        Bearny integrates with the <strong>Google Fit / Google Health REST API</strong> to collect
+        wearable health metrics for rehabilitation monitoring. This section explains how we handle
+        data obtained through Google APIs.
+      </p>
+      <p>
+        <strong>Scopes requested and their purpose:</strong>
+      </p>
+      <ul>
+        <li>
+          <strong>fitness.activity.read</strong> — Daily step count, walking distance, calories
+          burned, and active minutes. Used to track whether the patient is meeting their prescribed
+          movement goals during rehabilitation.
+        </li>
+        <li>
+          <strong>fitness.heart_rate.read</strong> — Resting heart rate and time spent in heart
+          rate zones (fat-burn, cardio, peak). Used to verify that the patient is exercising at the
+          correct intensity as specified in their rehabilitation plan.
+        </li>
+        <li>
+          <strong>fitness.sleep.read</strong> — Sleep duration, time actually asleep, and number of
+          awakenings. Sleep quality is a key recovery indicator in post-surgical rehabilitation.
+        </li>
+        <li>
+          <strong>fitness.body.read</strong> — Body weight data. Tracked alongside other health
+          metrics where clinically relevant to the patient's rehabilitation outcome.
+        </li>
+        <li>
+          <strong>fitness.oxygen_saturation.read</strong> — Blood oxygen saturation (SpO2). An
+          important safety and recovery metric for patients with cardiopulmonary conditions.
+        </li>
+        <li>
+          <strong>fitness.body_temperature.read</strong> — Skin temperature data. An early
+          indicator of post-operative infection or inflammation.
+        </li>
+      </ul>
+      <p>
+        <strong>Data protection commitments:</strong>
+      </p>
+      <ul>
+        <li>
+          Google Health data is accessible only to the patient and their assigned physiotherapist.
+        </li>
+        <li>
+          Bearny accesses Google Health data in <strong>read-only</strong> mode — we never write,
+          modify, or delete data in your Google account.
+        </li>
+        <li>
+          Google Health data is <strong>not sold, rented, or shared</strong> with any third party,
+          and is <strong>not used for advertising</strong> or any commercial purpose.
+        </li>
+        <li>
+          Data is stored on servers located in <strong>Switzerland</strong> and subject to the same
+          access controls as all other Bearny data.
+        </li>
+        <li>
+          Our use of Google API data is limited to the purposes described here and does not extend
+          to any use prohibited by the Google API Services User Data Policy.
+        </li>
+      </ul>
+      <p>
+        You can revoke Bearny's access to your Google Health data at any time via your Google
+        Account permissions page, or by contacting us to request deletion of stored data.
+      </p>
     </Layout>
   );
 };

--- a/scripts/oauth-video-screenshots/README.md
+++ b/scripts/oauth-video-screenshots/README.md
@@ -1,0 +1,44 @@
+# Bearny OAuth Screenshot Capture
+
+Captures all 11 screenshots needed for the Google OAuth verification video.
+
+## Requirements
+
+- Node.js 18+
+- Google Chrome installed on your machine
+- You must be able to log in to the Google Cloud Console (account: ger@telerehabilitation.ch)
+- A patient account and a therapist account on reha-advisor.ch
+
+## Setup (one time)
+
+```bash
+npm run setup
+```
+
+## Run
+
+```bash
+npm run capture
+```
+
+The browser opens visibly. The script pauses at each screen and tells you
+exactly what to navigate to. Press **Enter** in the terminal to take each
+screenshot.
+
+Screenshots are saved to `./screenshots/` in this folder.
+
+## Output files
+
+| File | Content |
+|---|---|
+| `01_gcp_oauth_consent_overview.png` | GCP consent screen — app name, domain |
+| `02_gcp_credentials_client_id.png` | GCP credentials — client ID visible |
+| `03_gcp_client_redirect_uri.png` | GCP client detail — redirect URI |
+| `04_gcp_scopes_list.png` | GCP scopes — all fitness.* scopes listed |
+| `05_bearny_patient_connect_button.png` | Bearny patient profile — connect button |
+| `06_google_consent_popup.png` | Google OAuth consent popup |
+| `07_bearny_health_dashboard_overview.png` | Therapist health dashboard overview |
+| `08_bearny_chart_steps.png` | Steps chart |
+| `09_bearny_chart_heartrate.png` | Heart rate chart |
+| `10_bearny_chart_sleep.png` | Sleep chart |
+| `11_bearny_chart_active_minutes.png` | Active minutes / HR zones chart |

--- a/scripts/oauth-video-screenshots/capture.js
+++ b/scripts/oauth-video-screenshots/capture.js
@@ -1,0 +1,181 @@
+/**
+ * Bearny OAuth Consent Screen Capture Script
+ *
+ * Prerequisites (run once):
+ *   npm install playwright
+ *   npx playwright install chrome
+ *
+ * Usage:
+ *   node capture.js
+ *
+ * The browser opens visibly. Log in when prompted, then press Enter in the
+ * terminal to advance to each screenshot. All images are saved to ./screenshots/
+ */
+
+const { chromium } = require("playwright");
+const readline = require("readline");
+const path = require("path");
+const fs = require("fs");
+
+// ── CONFIG ────────────────────────────────────────────────────────────────────
+const GCP_PROJECT_NUMBER = "905942928064";
+const OAUTH_CLIENT_ID =
+  "905942928064-gfkukphfc4c5lt43nfjgnc01fo8l3seh.apps.googleusercontent.com";
+const BEARNY_URL = "https://reha-advisor.ch"; // change to https://dev.reha-advisor.ch for dev
+const OUT_DIR = path.join(__dirname, "screenshots");
+
+// Google Cloud Console deep-links
+const GCP_CONSENT_URL = `https://console.cloud.google.com/apis/credentials/consent?project=${GCP_PROJECT_NUMBER}`;
+const GCP_CREDENTIALS_URL = `https://console.cloud.google.com/apis/credentials?project=${GCP_PROJECT_NUMBER}`;
+const GCP_SCOPES_URL = `https://console.cloud.google.com/apis/credentials/consent/edit?project=${GCP_PROJECT_NUMBER}`;
+
+// Bearny pages
+const BEARNY_LOGIN_URL = `${BEARNY_URL}/login`;
+const BEARNY_PATIENT_URL = `${BEARNY_URL}/patient`; // patient profile after login
+// ─────────────────────────────────────────────────────────────────────────────
+
+fs.mkdirSync(OUT_DIR, { recursive: true });
+
+const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+const pause = (msg) =>
+  new Promise((resolve) => {
+    console.log(`\n⏸  ${msg}`);
+    console.log("   Press ENTER when ready...");
+    rl.once("line", resolve);
+  });
+
+const shot = async (page, filename, description) => {
+  const file = path.join(OUT_DIR, filename);
+  await page.screenshot({ path: file, fullPage: false });
+  console.log(`✅ Saved: ${filename}  (${description})`);
+};
+
+(async () => {
+  console.log("=".repeat(60));
+  console.log("  Bearny OAuth Consent Screen Capture");
+  console.log("=".repeat(60));
+  console.log(`Screenshots will be saved to: ${OUT_DIR}\n`);
+
+  const browser = await chromium.launch({
+    channel: "chrome", // uses your installed Google Chrome
+    headless: false,
+    args: ["--start-maximized"],
+  });
+
+  const context = await browser.newContext({ viewport: null });
+  const page = await context.newPage();
+
+  // ── SCREEN 1: GCP OAuth Consent Screen overview ───────────────────────────
+  await page.goto(GCP_CONSENT_URL);
+  await pause(
+    "SCREEN 1 — GCP OAuth Consent Screen\n" +
+    "   Make sure you are logged in to the correct Google account.\n" +
+    "   The page should show app name 'Bearny', support email, and authorized domain.\n" +
+    "   Scroll to show the app name section clearly, then press ENTER."
+  );
+  await shot(page, "01_gcp_oauth_consent_overview.png", "GCP consent screen overview");
+
+  // ── SCREEN 2: GCP Credentials page ───────────────────────────────────────
+  await page.goto(GCP_CREDENTIALS_URL);
+  await pause(
+    "SCREEN 2 — GCP Credentials page\n" +
+    `   Find the OAuth 2.0 Client ID entry for client:\n   ${OAUTH_CLIENT_ID}\n` +
+    "   Make sure the client name and ID are readable, then press ENTER."
+  );
+  await shot(page, "02_gcp_credentials_client_id.png", "GCP credentials with client ID");
+
+  // ── SCREEN 2b: Click into the client to show redirect URI ─────────────────
+  await pause(
+    "SCREEN 2b — Click on the OAuth client to open its detail panel.\n" +
+    "   It should show the authorized redirect URI:\n" +
+    "   https://reha-advisor.ch/api/google-health/callback/\n" +
+    "   Then press ENTER."
+  );
+  await shot(page, "03_gcp_client_redirect_uri.png", "GCP client redirect URI detail");
+
+  // ── SCREEN 3: Scopes section ──────────────────────────────────────────────
+  await page.goto(GCP_SCOPES_URL);
+  await pause(
+    "SCREEN 3 — GCP Scopes\n" +
+    "   Navigate to the 'Scopes' step in the consent screen editor.\n" +
+    "   The list should show all fitness.* scopes. Scroll so all are visible,\n" +
+    "   then press ENTER."
+  );
+  await shot(page, "04_gcp_scopes_list.png", "GCP requested scopes list");
+
+  // ── SCREEN 4: Bearny — patient profile with connect button ────────────────
+  await page.goto(BEARNY_LOGIN_URL);
+  await pause(
+    "SCREEN 4 — Bearny patient profile\n" +
+    "   Log in as a patient account.\n" +
+    "   Navigate to the patient profile page that shows the\n" +
+    "   'Connect Google Health' (or Fitbit) button.\n" +
+    "   Scroll so the button is visible, then press ENTER."
+  );
+  await shot(page, "05_bearny_patient_connect_button.png", "Bearny patient connect button");
+
+  // ── SCREEN 5: Google consent popup ───────────────────────────────────────
+  await pause(
+    "SCREEN 5 — Google OAuth consent popup\n" +
+    "   Click the 'Connect Google Health' button to trigger the OAuth flow.\n" +
+    "   A Google consent screen should appear (in a new tab or popup).\n" +
+    "   Switch to that tab/popup window, scroll so the scope list is visible,\n" +
+    "   then press ENTER.\n" +
+    "   (Do NOT click Allow/Deny yet — just take the screenshot.)"
+  );
+
+  // Try to capture the popup page if it opened in a new context
+  const pages = context.pages();
+  const targetPage = pages.length > 1 ? pages[pages.length - 1] : page;
+  await shot(targetPage, "06_google_consent_popup.png", "Google OAuth consent screen");
+
+  // ── SCREEN 6: Bearny health dashboard (therapist view) ───────────────────
+  await pause(
+    "SCREEN 6 — Bearny health dashboard (therapist)\n" +
+    "   Log in as a therapist account (or open a new tab and log in).\n" +
+    "   Navigate to a patient's Health page that shows the HealthChartsAccordion\n" +
+    "   (steps, sleep, heart rate, wear time charts).\n" +
+    "   Collapse or expand so multiple chart headers are visible, then press ENTER."
+  );
+  await shot(page, "07_bearny_health_dashboard_overview.png", "Bearny health dashboard overview");
+
+  // ── SCREEN 7a: Steps chart ────────────────────────────────────────────────
+  await pause(
+    "SCREEN 7a — Steps chart\n" +
+    "   Expand the Steps accordion panel so the bar chart fills the viewport.\n" +
+    "   Then press ENTER."
+  );
+  await shot(page, "08_bearny_chart_steps.png", "Bearny steps chart");
+
+  // ── SCREEN 7b: Heart Rate chart ───────────────────────────────────────────
+  await pause(
+    "SCREEN 7b — Heart Rate chart\n" +
+    "   Expand the Resting Heart Rate / HR Zones panel.\n" +
+    "   Then press ENTER."
+  );
+  await shot(page, "09_bearny_chart_heartrate.png", "Bearny heart rate chart");
+
+  // ── SCREEN 7c: Sleep chart ────────────────────────────────────────────────
+  await pause(
+    "SCREEN 7c — Sleep chart\n" +
+    "   Expand the Sleep panel.\n" +
+    "   Then press ENTER."
+  );
+  await shot(page, "10_bearny_chart_sleep.png", "Bearny sleep chart");
+
+  // ── SCREEN 7d: Active Minutes / HR Zones chart ────────────────────────────
+  await pause(
+    "SCREEN 7d — Active Minutes / HR Zones chart\n" +
+    "   Expand the Active Zone Minutes or HR Zones panel.\n" +
+    "   Then press ENTER."
+  );
+  await shot(page, "11_bearny_chart_active_minutes.png", "Bearny active minutes chart");
+
+  // ── Done ──────────────────────────────────────────────────────────────────
+  console.log("\n" + "=".repeat(60));
+  console.log(`  All screenshots saved to: ${OUT_DIR}`);
+  console.log("=".repeat(60));
+
+  await browser.close();
+  rl.close();
+})();

--- a/scripts/oauth-video-screenshots/package.json
+++ b/scripts/oauth-video-screenshots/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "bearny-oauth-screenshot-capture",
+  "version": "1.0.0",
+  "description": "Captures OAuth consent flow screenshots for the Bearny Google verification video",
+  "main": "capture.js",
+  "scripts": {
+    "setup": "npm install && npx playwright install chrome",
+    "capture": "node capture.js"
+  },
+  "dependencies": {
+    "playwright": "^1.45.0"
+  }
+}


### PR DESCRIPTION
## Description

Google's OAuth verification requires two things that were missing:

1. **A server-rendered privacy policy URL** — `/privacypolicy` is a React SPA route that requires JavaScript to render. Google's automated URL checker cannot execute JS, so it reported the URL as non-responding. The fix adds a static HTML file served directly by nginx without any JavaScript dependency.

2. **Explicit Google Health/Fitness API data disclosures** — Google requires the privacy policy to name every requested scope (`fitness.activity.read`, `fitness.heart_rate.read`, `fitness.sleep.read`, `fitness.body.read`, `fitness.oxygen_saturation.read`, `fitness.body_temperature.read`) and explain the clinical purpose of each, storage location, read-only access, and that data is never sold or used for advertising.

Also includes a Playwright screenshot-capture script to assist with the required OAuth consent screen demo video for Google's Trust and Safety review.

## Related Issue

Google OAuth verification — Trust and Safety review for the Google Health API integration (client ID `905942928064-…`).

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Documentation update

## Tests

**Manual — static file reachable without JavaScript:**
```bash
# After deploying, both should return 200
curl -s -o /dev/null -w "%{http_code}" https://reha-advisor.ch/
curl -s -o /dev/null -w "%{http_code}" https://reha-advisor.ch/privacy-policy.html

# Confirm no <script> tags in the static policy page
curl -s https://reha-advisor.ch/privacy-policy.html | grep -i "<script"
# ↑ should print nothing
```

**Test Configuration: Production** — `https://reha-advisor.ch`

After deploying, update GCP OAuth consent screen:

App Homepage URL →` https://reha-advisor.ch/`
Privacy Policy URL → `https://reha-advisor.ch/privacy-policy.html`
Then re-submit for verification.

Checklist

- [x]  I have read the [contributing guidelines](vscode-webview://1nb7o4qiscv2qjp7qopi664uf4b3dhgjoa00jqhprielh8bhpehl/docs/12-CONTRIBUTING.md).
- [x]  I have read the [code of conduct](vscode-webview://1nb7o4qiscv2qjp7qopi664uf4b3dhgjoa00jqhprielh8bhpehl/CODE_OF_CONDUCT.md).
- [x]  I have commented my code, particularly in hard-to-understand areas.
- [x]  I have made corresponding changes to the documentation.
- [x]  My changes generate no new warnings.
- [x]  I have added tests that prove my fix is effective or that my feature works.