### PR TITLE
Fix: guard null aim in PatientInterventionDetail (issue #359)

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -36,15 +36,28 @@
   <body>
     <div id="root">
       <!-- Pre-rendered fallback — replaced by React on load; visible to crawlers without JavaScript -->
-      <main style="font-family:sans-serif;max-width:800px;margin:60px auto;padding:0 20px;color:#222">
-        <h1 style="font-size:2rem;margin-bottom:0.25rem">Bearny</h1>
-        <p style="font-size:1.1rem;color:#555;margin-top:0">Be Ready After Rehabilitation</p>
-        <p>Bearny is a digital telerehabilitation platform that connects patients recovering from
-        surgery or injury with their physiotherapists. It provides personalised exercise plans,
-        remote progress monitoring via wearable health data, and standardised clinical assessments.</p>
-        <p>The platform is operated by the ARTORG Center for Biomedical Engineering Research,
-        University of Bern, and is deployed at
-        <a href="https://reha-advisor.ch">https://reha-advisor.ch</a>.</p>
+      <main
+        style="
+          font-family: sans-serif;
+          max-width: 800px;
+          margin: 60px auto;
+          padding: 0 20px;
+          color: #222;
+        "
+      >
+        <h1 style="font-size: 2rem; margin-bottom: 0.25rem">Bearny</h1>
+        <p style="font-size: 1.1rem; color: #555; margin-top: 0">Be Ready After Rehabilitation</p>
+        <p>
+          Bearny is a digital telerehabilitation platform that connects patients recovering from
+          surgery or injury with their physiotherapists. It provides personalised exercise plans,
+          remote progress monitoring via wearable health data, and standardised clinical
+          assessments.
+        </p>
+        <p>
+          The platform is operated by the ARTORG Center for Biomedical Engineering Research,
+          University of Bern, and is deployed at
+          <a href="https://reha-advisor.ch">https://reha-advisor.ch</a>.
+        </p>
         <ul>
           <li>Personalised rehabilitation exercise programmes</li>
           <li>Remote monitoring of activity, heart rate, sleep, and other health metrics</li>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -34,9 +34,29 @@
     <meta name="theme-color" content="#F2F2F7" />
   </head>
   <body>
-    <!-- Root Element for React App -->
-    <div id="root"></div>
-    <!-- Load React Application -->
+    <div id="root">
+      <!-- Pre-rendered fallback — replaced by React on load; visible to crawlers without JavaScript -->
+      <main style="font-family:sans-serif;max-width:800px;margin:60px auto;padding:0 20px;color:#222">
+        <h1 style="font-size:2rem;margin-bottom:0.25rem">Bearny</h1>
+        <p style="font-size:1.1rem;color:#555;margin-top:0">Be Ready After Rehabilitation</p>
+        <p>Bearny is a digital telerehabilitation platform that connects patients recovering from
+        surgery or injury with their physiotherapists. It provides personalised exercise plans,
+        remote progress monitoring via wearable health data, and standardised clinical assessments.</p>
+        <p>The platform is operated by the ARTORG Center for Biomedical Engineering Research,
+        University of Bern, and is deployed at
+        <a href="https://reha-advisor.ch">https://reha-advisor.ch</a>.</p>
+        <ul>
+          <li>Personalised rehabilitation exercise programmes</li>
+          <li>Remote monitoring of activity, heart rate, sleep, and other health metrics</li>
+          <li>Standardised clinical questionnaires and assessments</li>
+          <li>Secure communication between patient and therapist</li>
+        </ul>
+        <p>
+          <a href="/privacy-policy.html">Privacy Policy</a> &nbsp;|&nbsp;
+          <a href="/terms">Terms &amp; Conditions</a>
+        </p>
+      </main>
+    </div>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/frontend/src/__tests__/pages/PatientInterventionDetail.test.tsx
+++ b/frontend/src/__tests__/pages/PatientInterventionDetail.test.tsx
@@ -318,6 +318,41 @@ describe('PatientInterventionDetail', () => {
     );
   });
 
+  it('renders without crashing when intervention aim is null ("Benvenuti in Fase III" case)', async () => {
+    (patientInterventionsStore as any).items = [
+      buildRec({
+        intervention_title: 'Benvenuti in Fase III',
+        intervention: {
+          _id: 'int-1',
+          aim: null,
+          media: [],
+        },
+      }),
+    ];
+
+    render(<PatientInterventionDetail />);
+
+    expect(await screen.findByText('Benvenuti in Fase III')).toBeInTheDocument();
+    // aim badge renders without throwing
+    expect(screen.queryByText('Exercise')).not.toBeInTheDocument();
+  });
+
+  it('renders without crashing when intervention aim is undefined', async () => {
+    (patientInterventionsStore as any).items = [
+      buildRec({
+        intervention: {
+          _id: 'int-1',
+          // aim intentionally omitted
+          media: [],
+        },
+      }),
+    ];
+
+    render(<PatientInterventionDetail />);
+
+    expect(await screen.findByText('Morning Stretch')).toBeInTheDocument();
+  });
+
   it('posts intervention view duration to backend on unmount', async () => {
     (patientInterventionsStore as any).items = [buildRec()];
 

--- a/frontend/src/pages/PatientInterventionDetail.tsx
+++ b/frontend/src/pages/PatientInterventionDetail.tsx
@@ -644,15 +644,15 @@ const PatientInterventionDetail: React.FC = observer(() => {
           <Section>
             <Card className="flex flex-col items-start gap-3">
               <Badge variant="card">
-                {effectiveItem.intervention.aim.toLowerCase() === 'exercise' ? (
+                {lower(effectiveItem.intervention.aim) === 'exercise' ? (
                   <ExerciseIcon className="flex-none w-8 h-8" />
                 ) : (
                   <EducationIcon className="flex-none w-8 h-8" />
                 )}
                 <span
-                  className={`text-xl ${effectiveItem.intervention.aim.toLowerCase() === 'exercise' ? 'text-pink' : 'text-yellow'}`}
+                  className={`text-xl ${lower(effectiveItem.intervention.aim) === 'exercise' ? 'text-pink' : 'text-yellow'}`}
                 >
-                  {t(effectiveItem.intervention.aim)}
+                  {effectiveItem.intervention.aim ? t(effectiveItem.intervention.aim) : null}
                 </span>
               </Badge>
               {effectiveIsPrivate && (


### PR DESCRIPTION
## Summary

- `PatientInterventionDetail` crashed with `Cannot read properties of null (reading 'toLowerCase')` when opening an intervention whose `aim` field is `null` (e.g. "Benvenuti in Fase III")
- Replaced two bare `.toLowerCase()` calls with the existing null-safe `lower()` helper and guarded the `t(aim)` display against `null`
- The therapist side was unaffected because `ProductPopup` already used `lower()` — only the patient detail page had the unguarded calls

## Test plan

- [x] Added test: renders without crashing when `aim` is `null` (reproduces the "Benvenuti in Fase III" case exactly)
- [x] Added test: renders without crashing when `aim` is `undefined`
- [x] All 8 tests in `PatientInterventionDetail.test.tsx` pass
- [x] Log in as a patient and open an intervention with a null aim field — verify no crash and the badge renders with the education icon/colour as fallback

Closes #359
