### PR TITLE
fix: guard null aim in InterventionItem to prevent toLowerCase crash

### DIFF
--- a/frontend/src/__tests__/components/PatientPage/InterventionList.test.tsx
+++ b/frontend/src/__tests__/components/PatientPage/InterventionList.test.tsx
@@ -265,6 +265,21 @@ describe('InterventionList Component', () => {
     // Only 2026-02-16 items are in the mock; nothing titled 'Mismatch' exists
     expect(screen.queryByText(/Mismatch/)).not.toBeInTheDocument();
   });
+
+  it('renders without crashing when intervention aim is null ("Benvenuti in Fase III" case)', () => {
+    (patientInterventionsStore as any).items = [
+      {
+        intervention_id: 'int-null-aim',
+        intervention_title: 'Benvenuti in Fase III',
+        translated_title: 'Benvenuti in Fase III',
+        dates: ['2026-02-16T08:00:00.000Z'],
+        duration: 5,
+        intervention: { _id: 'int-null-aim', aim: null, media: [] },
+      },
+    ];
+    render(<InterventionList />);
+    expect(screen.getByText('Benvenuti in Fase III')).toBeInTheDocument();
+  });
 });
 
 // ── InterventionList (store interaction / event tests) ───────────────────────

--- a/frontend/src/components/PatientPage/InterventionItem.tsx
+++ b/frontend/src/components/PatientPage/InterventionItem.tsx
@@ -32,7 +32,7 @@ const InterventionItem: React.FC<InterventionItemProps> = ({
   const completed = patientInterventionsStore.isCompletedOn(rec, date);
   const title = rec.translated_title || rec.intervention_title || '';
   const duration = rec.duration || rec.intervention?.duration;
-  const isExercise = rec.intervention?.aim?.toLowerCase() === 'exercise';
+  const isExercise = (rec.intervention?.aim ?? '').toLowerCase() === 'exercise';
 
   return (
     <Card


### PR DESCRIPTION
rec.intervention?.aim?.toLowerCase() treats null as truthy — optional chaining only skips undefined, so a null aim still throws. Replace with (rec.intervention?.aim ?? '').toLowerCase() so null falls back to ''.

Root cause of the Sentry crash on intervention 69dc989b42f2e83c4e805955 (2026-06-18). Adds a regression test for the null-aim render case.

#361 