### PR TITLE
Feature/persistent api audit logging

### DIFF
--- a/backend/api/settings/base.py
+++ b/backend/api/settings/base.py
@@ -65,6 +65,9 @@ MIDDLEWARE = [
     # Enforces JWT Bearer tokens on all /api/ routes that lack @api_view.
     # See core/middleware.py for the list of public (token-exempt) paths.
     "core.middleware.JWTAuthMiddleware",
+    # Logs every authenticated API request (method, path, status, user_id, ip)
+    # to the core.api_audit logger — written to a rotating file in prod.
+    "core.middleware.ApiAuditMiddleware",
 ]
 
 STATIC_URL = "/static/"
@@ -162,6 +165,10 @@ import sys
 print("STATICFILES_DIRS =", STATICFILES_DIRS, file=sys.stderr)
 print("STATIC_ROOT =", STATIC_ROOT, file=sys.stderr)
 
+_log_dir = os.getenv("LOG_DIR", "")
+if _log_dir:
+    os.makedirs(_log_dir, exist_ok=True)
+
 LOGGING = {
     "version": 1,
     "disable_existing_loggers": False,
@@ -177,6 +184,20 @@ LOGGING = {
             "class": "logging.StreamHandler",
             "formatter": "verbose",
         },
+        **(
+            {
+                "api_audit_file": {
+                    "class": "logging.handlers.RotatingFileHandler",
+                    "filename": os.path.join(_log_dir, "api_access.log"),
+                    "maxBytes": 10 * 1024 * 1024,  # 10 MB per file
+                    "backupCount": 10,
+                    "formatter": "verbose",
+                    "encoding": "utf-8",
+                }
+            }
+            if _log_dir
+            else {}
+        ),
     },
     "root": {
         "handlers": ["console"],
@@ -191,6 +212,11 @@ LOGGING = {
         "core": {
             "handlers": ["console"],
             "level": os.getenv("APP_LOG_LEVEL", "INFO"),
+            "propagate": False,
+        },
+        "core.api_audit": {
+            "handlers": ["console"] + (["api_audit_file"] if _log_dir else []),
+            "level": "INFO",
             "propagate": False,
         },
     },

--- a/backend/api/settings/prod.py
+++ b/backend/api/settings/prod.py
@@ -46,16 +46,9 @@ CELERY_RESULT_BACKEND = os.environ.get("CELERY_RESULT_BACKEND", CELERY_RESULT_BA
 # Silence bot-triggered DisallowedHost rejections — bots probe with raw server
 # IP as Host header; Django correctly rejects them with 400 but Sentry captures
 # the SuspiciousOperation as an error, creating noise. These are not actionable.
-LOGGING = {
-    "version": 1,
-    "disable_existing_loggers": False,
-    "handlers": {
-        "null": {"class": "logging.NullHandler"},
-    },
-    "loggers": {
-        "django.security.DisallowedHost": {
-            "handlers": ["null"],
-            "propagate": False,
-        },
-    },
+# Extend (not replace) the base LOGGING dict so the file handler from LOG_DIR is preserved.
+LOGGING["handlers"]["null"] = {"class": "logging.NullHandler"}
+LOGGING["loggers"]["django.security.DisallowedHost"] = {
+    "handlers": ["null"],
+    "propagate": False,
 }

--- a/backend/core/middleware.py
+++ b/backend/core/middleware.py
@@ -154,10 +154,7 @@ class ApiAuditMiddleware:
             except Exception:
                 pass
 
-        ip = (
-            request.META.get("HTTP_X_FORWARDED_FOR", "").split(",")[0].strip()
-            or request.META.get("REMOTE_ADDR", "-")
-        )
+        ip = request.META.get("HTTP_X_FORWARDED_FOR", "").split(",")[0].strip() or request.META.get("REMOTE_ADDR", "-")
 
         audit_logger.info(
             "%s %s %s user_id=%s ip=%s",

--- a/backend/core/middleware.py
+++ b/backend/core/middleware.py
@@ -43,6 +43,7 @@ from rest_framework_simplejwt.exceptions import TokenError
 from rest_framework_simplejwt.tokens import AccessToken
 
 logger = logging.getLogger(__name__)
+audit_logger = logging.getLogger("core.api_audit")
 
 # Exact-match public paths (no token needed)
 _PUBLIC_EXACT: frozenset[str] = frozenset(
@@ -112,3 +113,58 @@ class JWTAuthMiddleware:
         if path in _PUBLIC_EXACT:
             return True
         return any(path.startswith(prefix) for prefix in _PUBLIC_PREFIXES)
+
+
+class ApiAuditMiddleware:
+    """
+    Log every authenticated API request to the core.api_audit logger.
+
+    In production (when LOG_DIR is set) this logger writes to a rotating file
+    at <LOG_DIR>/api_access.log which is bind-mounted to the host — so the log
+    survives container restarts and redeployments.
+
+    Format per line:
+        method path status user_id=<id> ip=<ip>
+
+    Skips public routes (auth, healthslider) and test mode.
+    User identity is extracted from the Bearer JWT without a DB lookup.
+    For full user details (email, role) cross-reference with the MongoDB
+    User collection using the logged user_id.
+    """
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        response = self.get_response(request)
+
+        if getattr(settings, "TESTING", False):
+            return response
+
+        path = request.path
+        if not path.startswith("/api/") or JWTAuthMiddleware._is_public(path):
+            return response
+
+        auth_header = request.headers.get("Authorization", "")
+        user_id = "-"
+        if auth_header.startswith("Bearer "):
+            try:
+                token = AccessToken(auth_header.split(" ", 1)[1])
+                user_id = str(token.get("user_id", "-"))
+            except Exception:
+                pass
+
+        ip = (
+            request.META.get("HTTP_X_FORWARDED_FOR", "").split(",")[0].strip()
+            or request.META.get("REMOTE_ADDR", "-")
+        )
+
+        audit_logger.info(
+            "%s %s %s user_id=%s ip=%s",
+            request.method,
+            request.get_full_path(),
+            response.status_code,
+            user_id,
+            ip,
+        )
+        return response

--- a/backend/core/models.py
+++ b/backend/core/models.py
@@ -195,6 +195,7 @@ class Logs(Document):
             "INTERVENTION_UNCOMPLETE",
             "TEMPLATE_APPLY",
             "PATIENT_REGISTER",
+            "ADMIN_EXPORT",
         ],
         required=True,
     )

--- a/backend/core/urls.py
+++ b/backend/core/urls.py
@@ -15,7 +15,7 @@ from core.views.access_change_views import (
     admin_access_change_requests,
     submit_access_change_request,
 )
-from core.views.admin_export_views import admin_export_clinics, admin_export_patients
+from core.views.admin_export_views import admin_export_audit, admin_export_clinics, admin_export_patients
 from core.views.admin_intervention_views import admin_interventions
 from core.views.admin_questionnaire_views import admin_questionnaires
 from core.views.eva_view import (
@@ -67,6 +67,7 @@ urlpatterns = [
     # Admin data export
     path("api/admin/export/patients/", admin_export_patients),
     path("api/admin/export/clinics/", admin_export_clinics),
+    path("api/admin/export/audit/", admin_export_audit),
     # Therapist access change requests
     path("api/therapist/access-change-request/", submit_access_change_request),
     path("api/admin/access-change-requests/", admin_access_change_requests),

--- a/backend/core/views/admin_export_views.py
+++ b/backend/core/views/admin_export_views.py
@@ -30,6 +30,8 @@ from datetime import date
 from django.http import HttpResponse, JsonResponse
 from rest_framework.decorators import api_view, permission_classes
 
+from bson import ObjectId
+
 from core.models import (
     FitbitData,
     GeneralFeedback,
@@ -38,8 +40,11 @@ from core.models import (
     Patient,
     PatientICFRating,
     PatientInterventionLogs,
+    PatientThresholds,
+    PatientThresholdsSnapshot,
     PatientVitals,
     RehabilitationPlan,
+    User,
 )
 from core.permissions import IsAdmin
 
@@ -622,10 +627,59 @@ def admin_export_patients(request):
 
         response = HttpResponse(zip_buf.getvalue(), content_type="application/zip")
         response["Content-Disposition"] = f'attachment; filename="{filename}"'
+
+        # Audit log — persisted in MongoDB so it survives container restarts.
+        # Wrapped in try/except so a DB hiccup never blocks the download.
+        try:
+            mongo_user = User.objects.get(pk=ObjectId(request.user.id))
+            Logs(
+                userId=mongo_user,
+                action="ADMIN_EXPORT",
+                actor_role="Admin",
+                user_agent=(request.META.get("HTTP_USER_AGENT") or "")[:300],
+                details=f"clinics={clinics_param} rows={len(patients)}",
+            ).save()
+        except Exception:
+            logger.warning("admin_export_patients: could not write audit log for user %s", getattr(request.user, "id", "?"))
+
+        logger.info(
+            "ADMIN_EXPORT user=%s clinics=%s patients=%d",
+            getattr(request.user, "id", "?"),
+            clinics_param,
+            len(patients),
+        )
         return response
 
     except Exception:
         logger.exception("admin_export_patients failed")
+        return JsonResponse({"error": "Internal server error"}, status=500)
+
+
+@api_view(["GET"])
+@permission_classes([IsAdmin])
+def admin_export_audit(request):
+    """
+    GET /api/admin/export/audit/
+    Returns the audit log of all patient-data export downloads.
+    Requires Admin role. Returns at most 200 most-recent entries.
+    """
+    try:
+        entries = []
+        for log in Logs.objects(action="ADMIN_EXPORT").order_by("-timestamp")[:200]:
+            email = None
+            try:
+                email = log.userId.email
+            except Exception:
+                pass
+            entries.append({
+                "timestamp": log.timestamp.strftime("%Y-%m-%dT%H:%M:%SZ") if log.timestamp else None,
+                "user_email": email,
+                "details": log.details or "",
+                "user_agent": log.user_agent or "",
+            })
+        return JsonResponse({"total": len(entries), "entries": entries})
+    except Exception:
+        logger.exception("admin_export_audit failed")
         return JsonResponse({"error": "Internal server error"}, status=500)
 
 

--- a/backend/core/views/admin_export_views.py
+++ b/backend/core/views/admin_export_views.py
@@ -27,10 +27,9 @@ import logging
 import zipfile
 from datetime import date
 
+from bson import ObjectId
 from django.http import HttpResponse, JsonResponse
 from rest_framework.decorators import api_view, permission_classes
-
-from bson import ObjectId
 
 from core.models import (
     FitbitData,
@@ -640,7 +639,9 @@ def admin_export_patients(request):
                 details=f"clinics={clinics_param} rows={len(patients)}",
             ).save()
         except Exception:
-            logger.warning("admin_export_patients: could not write audit log for user %s", getattr(request.user, "id", "?"))
+            logger.warning(
+                "admin_export_patients: could not write audit log for user %s", getattr(request.user, "id", "?")
+            )
 
         logger.info(
             "ADMIN_EXPORT user=%s clinics=%s patients=%d",
@@ -671,12 +672,14 @@ def admin_export_audit(request):
                 email = log.userId.email
             except Exception:
                 pass
-            entries.append({
-                "timestamp": log.timestamp.strftime("%Y-%m-%dT%H:%M:%SZ") if log.timestamp else None,
-                "user_email": email,
-                "details": log.details or "",
-                "user_agent": log.user_agent or "",
-            })
+            entries.append(
+                {
+                    "timestamp": log.timestamp.strftime("%Y-%m-%dT%H:%M:%SZ") if log.timestamp else None,
+                    "user_email": email,
+                    "details": log.details or "",
+                    "user_agent": log.user_agent or "",
+                }
+            )
         return JsonResponse({"total": len(entries), "entries": entries})
     except Exception:
         logger.exception("admin_export_audit failed")

--- a/backend/tests/admin_export_views/test_admin_export_views.py
+++ b/backend/tests/admin_export_views/test_admin_export_views.py
@@ -741,3 +741,94 @@ def test_clinics_empty_when_no_patients(mongo_mock):
 
 def test_clinics_method_not_allowed(mongo_mock):
     assert client.post(CLINICS_URL, {}).status_code == 405
+
+
+# ===========================================================================
+# Audit log — ADMIN_EXPORT Logs entry
+# ===========================================================================
+
+AUDIT_URL = "/api/admin/export/audit/"
+
+
+def test_export_creates_audit_log_entry(mongo_mock):
+    """A successful export must write a Logs document with action=ADMIN_EXPORT."""
+    client.get(EXPORT_URL + "?clinics=all")
+    assert Logs.objects(action="ADMIN_EXPORT").count() == 1
+
+
+def test_export_audit_log_contains_clinics_and_rows(mongo_mock):
+    """The details field must capture the clinics filter and patient count."""
+    therapist = _make_therapist()
+    _make_patient(therapist, "P001", clinic="Inselspital")
+    client.get(EXPORT_URL + "?clinics=Inselspital")
+    log = Logs.objects(action="ADMIN_EXPORT").first()
+    assert log is not None
+    assert "clinics=Inselspital" in (log.details or "")
+    assert "rows=1" in (log.details or "")
+
+
+def test_export_each_download_creates_one_log_entry(mongo_mock):
+    """Each download is logged separately."""
+    client.get(EXPORT_URL + "?clinics=all")
+    client.get(EXPORT_URL + "?clinics=all")
+    assert Logs.objects(action="ADMIN_EXPORT").count() == 2
+
+
+def test_audit_endpoint_returns_export_history(mongo_mock):
+    """GET /api/admin/export/audit/ returns entries for logged exports."""
+    client.get(EXPORT_URL + "?clinics=all")
+    resp = client.get(AUDIT_URL)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["total"] == 1
+    entry = data["entries"][0]
+    assert "timestamp" in entry
+    assert entry["user_email"] == "admin@test.example.com"
+    assert "clinics=all" in entry["details"]
+
+
+def test_audit_endpoint_requires_admin(mongo_mock):
+    """The audit endpoint must be inaccessible to non-admin users."""
+    non_admin = User(
+        username="plain",
+        email="plain@example.com",
+        role="Therapist",
+        isActive=True,
+        createdAt=datetime.now(),
+    )
+    non_admin.pwdhash = "x"
+    non_admin.save()
+    c = APIClient()
+    c.force_authenticate(user=SimpleNamespace(is_authenticated=True, id=str(non_admin.id)))
+    assert c.get(AUDIT_URL).status_code == 403
+
+
+# ===========================================================================
+# ApiAuditMiddleware
+# ===========================================================================
+
+
+def test_api_audit_middleware_skips_in_test_mode(mongo_mock):
+    """In TESTING mode ApiAuditMiddleware emits no log lines (JWT not available),
+    but the export and its MongoDB audit entry must still complete normally."""
+    import logging
+
+    records = []
+
+    class _Capture(logging.Handler):
+        def emit(self, record):
+            records.append(record)
+
+    handler = _Capture()
+    log = logging.getLogger("core.api_audit")
+    log.addHandler(handler)
+    try:
+        resp = client.get(EXPORT_URL + "?clinics=all")
+    finally:
+        log.removeHandler(handler)
+
+    assert resp.status_code == 200
+    # Middleware is skipped in TESTING mode — no request-level audit lines expected.
+    assert len(records) == 0
+    # The per-endpoint MongoDB audit entry is still created by the view itself.
+    assert Logs.objects(action="ADMIN_EXPORT").count() == 1

--- a/docker-compose.gateway.yml
+++ b/docker-compose.gateway.yml
@@ -30,6 +30,7 @@ services:
       - ./nginx/gateway.nginx.conf:/etc/nginx/conf.d/default.conf:ro
       - ./nginx/certbot/conf:/etc/letsencrypt:ro
       - ./nginx/certbot/www:/var/www/certbot:ro
+      - ./logs/gateway:/var/log/nginx
     # Networks are connected dynamically via `docker network connect`
     # (see usage instructions above) so this compose file has no hard
     # external network dependencies and can start independently.


### PR DESCRIPTION
# Description

Adds three layers of persistent audit logging so every patient-data export can be traced to a specific admin user, and the records survive container restarts and redeployments.

**Motivation:** On 18 June 2026 several downloads of `/api/admin/export/patients/` were made that could not be recovered because the nginx-prod container had been restarted earlier that day — logs lived only in container memory. There was no application-level record of who downloaded what or when.

**What was added:**

* **MongoDB export audit trail** — every successful export writes a `Logs` document (`action="ADMIN_EXPORT"`) containing the admin's email, clinics filter, patient count, browser UA, and timestamp. A new read-only endpoint `GET /api/admin/export/audit/` (Admin only) returns the full history.
* **`ApiAuditMiddleware`** — logs every authenticated API request (method, path, HTTP status, user\_id from JWT, client IP) to `core.api_audit` logger. In production this writes to a `RotatingFileHandler` at `/app/logs/api_access.log` (10 MB × 10 files).
* **Persistent nginx access logs** — `/var/log/nginx/` in `nginx-prod` and `gateway` is now bind-mounted to `./logs/nginx/` / `./logs/gateway/` on the host. Previously lost on every container restart.
* **Bug fix in `prod.py`** — `LOGGING` was being replaced entirely, silently discarding the base file handler. Fixed to extend the dict instead.

**Dependencies:** None. Log directories (`./logs/`) are created automatically by Docker on first start.

## Related Issue

[Feature: Persistent audit logging for admin data exports and API access](#)

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Documentation update
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (specify)

## Tests

Six new tests added in `backend/tests/admin_export_views/test_admin_export_views.py`:

| Test | What it verifies |
|---|---|
| `test_export_creates_audit_log_entry` | Each download writes one `Logs(action="ADMIN_EXPORT")` document |
| `test_export_audit_log_contains_clinics_and_rows` | `details` field captures clinics filter and patient count |
| `test_export_each_download_creates_one_log_entry` | Two downloads → two log entries |
| `test_audit_endpoint_returns_export_history` | `GET /api/admin/export/audit/` returns entries with correct email and details |
| `test_audit_endpoint_requires_admin` | Non-Admin users receive 403 |
| `test_api_audit_middleware_skips_in_test_mode` | Middleware skips in `TESTING=True`; MongoDB entry still written by the view |

To reproduce locally:

```bash
docker exec django pytest tests/admin_export_views/ -v
# Expected: 36 passed
```

**Test Configuration:** Django + mongomock (in-memory MongoDB), TESTING=True, DRF force_authenticate.

### Checklist
- [x]  I have read the [contributing guidelines](vscode-webview://1nb7o4qiscv2qjp7qopi664uf4b3dhgjoa00jqhprielh8bhpehl/docs/12-CONTRIBUTING.md).
- [x]  I have read the [code of conduct](vscode-webview://1nb7o4qiscv2qjp7qopi664uf4b3dhgjoa00jqhprielh8bhpehl/CODE_OF_CONDUCT.md).
- [x]  I have commented my code, particularly in hard-to-understand areas.
- [x]  I have made corresponding changes to the documentation.
- [x]  My changes generate no new warnings.
- [x]  I have added tests that prove my fix is effective or that my feature works.