### PR TITLE
Feature/study mode patient privacy

### DIFF
--- a/backend/core/middleware.py
+++ b/backend/core/middleware.py
@@ -49,6 +49,7 @@ audit_logger = logging.getLogger("core.api_audit")
 _PUBLIC_EXACT: frozenset[str] = frozenset(
     {
         "/api/",
+        "/api/app-mode/",
     }
 )
 

--- a/backend/core/urls.py
+++ b/backend/core/urls.py
@@ -51,6 +51,8 @@ from core.views.wearables_redcap_view import sync_wearables_to_redcap_view
 
 urlpatterns = [
     path("api/", core_views.index, name="index"),
+    # Public: returns current APP_MODE and feature flags — no auth required.
+    path("api/app-mode/", core_views.app_mode, name="app_mode"),
     # Internal endpoint used by nginx auth_request to gate /media/ access.
     # nginx sends a subrequest here before serving any /media/ file; JWT is
     # checked by JWTAuthMiddleware + @permission_classes([IsAuthenticated]).

--- a/backend/core/views/auth_views.py
+++ b/backend/core/views/auth_views.py
@@ -548,6 +548,13 @@ def register_view(request):
     if request.method != "POST":
         return _err("Method not allowed", status=405)
 
+    # In study mode only REDCap import is allowed; manual registration is blocked.
+    if os.getenv("APP_MODE", "normal").lower() == "study":
+        return JsonResponse(
+            {"error": "Manual patient creation is disabled in study mode. Use REDCap import."},
+            status=403,
+        )
+
     user = None
     patient = None
     therapist = None

--- a/backend/core/views/views.py
+++ b/backend/core/views/views.py
@@ -1,5 +1,32 @@
-from django.http import HttpResponse
+import os
+
+from django.http import HttpResponse, JsonResponse
 
 
 def index(request):
     return HttpResponse("<h1>Hello and welcome to my <u>Django App</u> project!</h1>")
+
+
+def app_mode(request):
+    """
+    GET /api/app-mode/
+    Public endpoint (no auth required). Returns the current operating mode and
+    derived feature flags so the frontend can gate UI without a rebuild.
+
+    Controlled by two env vars:
+      APP_MODE              = dev | normal | study   (default: normal)
+      STUDY_REDCAP_VISIBLE  = true | false           (default: true)
+    """
+    mode = os.getenv("APP_MODE", "normal").lower()
+    if mode not in ("dev", "normal", "study"):
+        mode = "normal"
+
+    redcap_visible_raw = os.getenv("STUDY_REDCAP_VISIBLE", "true").lower()
+    redcap_visible = redcap_visible_raw != "false"
+
+    return JsonResponse(
+        {
+            "mode": mode,
+            "redcapVisible": redcap_visible,
+        }
+    )

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -45,6 +45,8 @@ services:
       - ./.env.dev
     ports:
       - 8001:8000
+    environment:
+      - APP_MODE=dev
     volumes:
       - ./backend/:/app
       - static:/app/static

--- a/docs/07-ENVIRONMENT_CONFIG.md
+++ b/docs/07-ENVIRONMENT_CONFIG.md
@@ -533,6 +533,28 @@ validate_required_env_vars()
 
 ---
 
+## Operating Mode
+
+Two env vars control which features are active at runtime. Set them in the `environment:` block of the Django service in your Compose file (not in `.env`) so the mode is visible in the Compose diff.
+
+| Variable | Default | Description |
+|---|---|---|
+| `APP_MODE` | `normal` | `dev` — all features on; `normal` — manual creation on, REDCap hidden; `study` — REDCap only, PII fields hidden |
+| `STUDY_REDCAP_VISIBLE` | `true` | In `study` mode only: set to `false` to also hide the REDCap tab in the patient profile popup |
+
+Current defaults per stack:
+
+| Stack | `APP_MODE` |
+|---|---|
+| `docker-compose.dev.yml` | `dev` |
+| `docker-compose.prod.reha-advisor.yml` | `study` |
+
+The frontend fetches the active mode from `GET /api/app-mode/` at startup — no rebuild needed when the env var changes, just restart the django container.
+
+See [Study Integration Guide](./15-STUDY_INTEGRATION.md) for the full feature matrix.
+
+---
+
 ## Certificate Renewal
 
 Automatic Let's Encrypt renewal is handled by the Celery beat task `core.tasks.renew_certificates`, which runs daily at 03:00 UTC. It is opt-in: set `CERTBOT_ENABLED=true` to activate.

--- a/docs/15-STUDY_INTEGRATION.md
+++ b/docs/15-STUDY_INTEGRATION.md
@@ -34,11 +34,32 @@ Set these in the `.env` file loaded by your Docker Compose stack (`.env.dev` for
 | `REDCAP_API_URL` | Yes | `https://redcap.unibe.ch/api/` | Full URL to the REDCap API endpoint, including the trailing slash. All projects share this URL. |
 | `REDCAP_TOKEN_<PROJECT>` | Yes, per project | `REDCAP_TOKEN_COPAIN=abc123` | API token for the named project. Replace `<PROJECT>` with the uppercase project name exactly as it appears in `config.json` (e.g. `COPAIN`, `COMPASS`). Add one variable per project. |
 
-### Optional compliance mode
+### Operating mode
 
-| Variable | Default | Example | Description |
+The platform supports three named modes that control which features are available. Set `APP_MODE` in the Django container's `environment:` block in your Compose file (not in `.env`, so the value is visible in the compose diff and doesn't require a secret).
+
+| Variable | Default | Values | Description |
 |---|---|---|---|
-| `ENFORCE_REDCAP_ONLY_PATIENT_CREATION` | *(unset / off)* | `1` | When set to `1`, `true`, or `yes`, the patient registration endpoint rejects any account creation that does not come through the REDCap import flow. Enable this for study deployments where no manual patient creation should be allowed. |
+| `APP_MODE` | `normal` | `dev` \| `normal` \| `study` | Controls which features are active. See mode table below. |
+| `STUDY_REDCAP_VISIBLE` | `true` | `true` \| `false` | In `study` mode, set to `false` to also hide the REDCap data tab in the patient profile popup. Has no effect in other modes. |
+
+**Mode comparison:**
+
+| Feature | `dev` | `normal` | `study` |
+|---|---|---|---|
+| Manual patient creation (Register) | ✓ | ✓ | Blocked (403 from API + button hidden) |
+| REDCap import | ✓ | Hidden | ✓ |
+| REDCap tab in patient profile | ✓ | Hidden | ✓ (unless `STUDY_REDCAP_VISIBLE=false`) |
+| PII fields in patient profile (name, email, phone, age) | Visible | Visible | **Hidden** |
+| Characteristics tab | ✓ | ✓ | ✓ (always shown) |
+
+The active mode is readable at `GET /api/app-mode/` (no auth required) — the frontend fetches this at startup so mode changes take effect after a Django container restart without a frontend rebuild.
+
+**Deployment defaults:**
+- Production (`docker-compose.prod.reha-advisor.yml`): `APP_MODE=study`, `STUDY_REDCAP_VISIBLE=true`
+- Development (`docker-compose.dev.yml`): `APP_MODE=dev`
+
+> **Legacy flag**: `ENFORCE_REDCAP_ONLY_PATIENT_CREATION` (an older single-purpose flag that blocked only manual registration) is superseded by `APP_MODE=study`, which additionally hides PII fields and REDCap UI elements. Do not set both.
 
 ### Wearables sync event names
 

--- a/frontend/src/components/TherapistPatientPage/PatientPopup.tsx
+++ b/frontend/src/components/TherapistPatientPage/PatientPopup.tsx
@@ -16,6 +16,7 @@ import {
 } from 'react-icons/fa';
 
 import config from '../../config/config.json';
+import { appModeStore } from '../../stores/appModeStore';
 import { PatientType } from '../../types';
 import ErrorAlert from '../common/ErrorAlert';
 
@@ -629,6 +630,11 @@ const PatientPopup: React.FC<PatientPopupProps> = observer(({ patient_id, show, 
                     <Row className="g-3">
                       {section.fields
                         .filter((f: any) => !['password', 'repeatPassword'].includes(f.name))
+                        .filter(
+                          (f: any) =>
+                            !appModeStore.hidePiiFields ||
+                            !['firstName', 'lastName', 'email', 'phone', 'age'].includes(f.name),
+                        )
                         .map((field: any, index: number) => (
                           <Col xs={12} md={6} key={`${section.title}-${field.be_name}-${index}`}>
                             <Form.Group controlId={field.be_name}>
@@ -1168,7 +1174,7 @@ const PatientPopup: React.FC<PatientPopupProps> = observer(({ patient_id, show, 
                 </div>
               </Tab>
 
-              <Tab eventKey="redcap" title={t('REDCap')}>
+              {appModeStore.showRedcapTab && <Tab eventKey="redcap" title={t('REDCap')}>
                 <div className="d-flex align-items-center justify-content-between mb-2">
                   <div className="text-muted">
                     {store.redcapProject ? (
@@ -1233,7 +1239,7 @@ const PatientPopup: React.FC<PatientPopupProps> = observer(({ patient_id, show, 
                     </Table>
                   </>
                 )}
-              </Tab>
+              </Tab>}
             </Tabs>
           </>
         )}

--- a/frontend/src/components/TherapistPatientPage/PatientPopup.tsx
+++ b/frontend/src/components/TherapistPatientPage/PatientPopup.tsx
@@ -633,7 +633,7 @@ const PatientPopup: React.FC<PatientPopupProps> = observer(({ patient_id, show, 
                         .filter(
                           (f: any) =>
                             !appModeStore.hidePiiFields ||
-                            !['firstName', 'lastName', 'email', 'phone', 'age'].includes(f.name),
+                            !['firstName', 'lastName', 'email', 'phone', 'age'].includes(f.name)
                         )
                         .map((field: any, index: number) => (
                           <Col xs={12} md={6} key={`${section.title}-${field.be_name}-${index}`}>
@@ -1174,72 +1174,74 @@ const PatientPopup: React.FC<PatientPopupProps> = observer(({ patient_id, show, 
                 </div>
               </Tab>
 
-              {appModeStore.showRedcapTab && <Tab eventKey="redcap" title={t('REDCap')}>
-                <div className="d-flex align-items-center justify-content-between mb-2">
-                  <div className="text-muted">
-                    {store.redcapProject ? (
-                      <>
-                        {t('Project')}: <Badge bg="info">{store.redcapProject}</Badge>{' '}
-                        <span className="ms-2">
-                          {t('Records')}: {store.redcapRows?.length || 0}
-                        </span>
-                      </>
-                    ) : (
-                      <span>{t('No project selected')}</span>
-                    )}
-                  </div>
-
-                  <Button
-                    variant="outline-secondary"
-                    size="sm"
-                    onClick={() => store.fetchRedcapIfPossible(t)}
-                    disabled={store.redcapLoading}
-                  >
-                    <FaSyncAlt className="me-2" />
-                    {store.redcapLoading ? t('Loading...') : t('Refresh')}
-                  </Button>
-                </div>
-
-                {store.redcapLoading ? (
-                  <div className="text-center my-4">
-                    <Spinner animation="border" role="status" aria-label={t('Loading')} />
-                    <p className="mt-3">{t('Loading')}...</p>
-                  </div>
-                ) : !hasRedcap ? (
-                  <p className="text-muted mb-0">
-                    {t('No REDCap data available for this patient.')}
-                  </p>
-                ) : (
-                  <>
-                    <p className="text-muted">
-                      {t(
-                        'This data is fetched live from REDCap and is not stored in the platform database.'
+              {appModeStore.showRedcapTab && (
+                <Tab eventKey="redcap" title={t('REDCap')}>
+                  <div className="d-flex align-items-center justify-content-between mb-2">
+                    <div className="text-muted">
+                      {store.redcapProject ? (
+                        <>
+                          {t('Project')}: <Badge bg="info">{store.redcapProject}</Badge>{' '}
+                          <span className="ms-2">
+                            {t('Records')}: {store.redcapRows?.length || 0}
+                          </span>
+                        </>
+                      ) : (
+                        <span>{t('No project selected')}</span>
                       )}
-                    </p>
+                    </div>
 
-                    <Table striped bordered hover responsive size="sm">
-                      <thead>
-                        <tr>
-                          <th style={{ width: 280 }}>{t('Field')}</th>
-                          <th>{t('Value')}</th>
-                        </tr>
-                      </thead>
-                      <tbody>
-                        {Object.entries(store.redcapFlat || {}).map(([k, v]) => (
-                          <tr key={k}>
-                            <td>
-                              <code>{k}</code>
-                            </td>
-                            <td style={{ whiteSpace: 'pre-wrap' }}>
-                              {typeof v === 'object' ? JSON.stringify(v) : String(v)}
-                            </td>
+                    <Button
+                      variant="outline-secondary"
+                      size="sm"
+                      onClick={() => store.fetchRedcapIfPossible(t)}
+                      disabled={store.redcapLoading}
+                    >
+                      <FaSyncAlt className="me-2" />
+                      {store.redcapLoading ? t('Loading...') : t('Refresh')}
+                    </Button>
+                  </div>
+
+                  {store.redcapLoading ? (
+                    <div className="text-center my-4">
+                      <Spinner animation="border" role="status" aria-label={t('Loading')} />
+                      <p className="mt-3">{t('Loading')}...</p>
+                    </div>
+                  ) : !hasRedcap ? (
+                    <p className="text-muted mb-0">
+                      {t('No REDCap data available for this patient.')}
+                    </p>
+                  ) : (
+                    <>
+                      <p className="text-muted">
+                        {t(
+                          'This data is fetched live from REDCap and is not stored in the platform database.'
+                        )}
+                      </p>
+
+                      <Table striped bordered hover responsive size="sm">
+                        <thead>
+                          <tr>
+                            <th style={{ width: 280 }}>{t('Field')}</th>
+                            <th>{t('Value')}</th>
                           </tr>
-                        ))}
-                      </tbody>
-                    </Table>
-                  </>
-                )}
-              </Tab>}
+                        </thead>
+                        <tbody>
+                          {Object.entries(store.redcapFlat || {}).map(([k, v]) => (
+                            <tr key={k}>
+                              <td>
+                                <code>{k}</code>
+                              </td>
+                              <td style={{ whiteSpace: 'pre-wrap' }}>
+                                {typeof v === 'object' ? JSON.stringify(v) : String(v)}
+                              </td>
+                            </tr>
+                          ))}
+                        </tbody>
+                      </Table>
+                    </>
+                  )}
+                </Tab>
+              )}
             </Tabs>
           </>
         )}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -9,8 +9,10 @@ import '@/assets/styles/index.css'; // TODO: link in index.html for global style
 import '@/assets/styles/custom-bootstrap.scss'; // Custom Bootstrap overrides (TODO: remove after redesign with Tailwind is complete)
 import { initSentry } from '@/lib/sentry';
 import DevBanner from '@/components/common/DevBanner';
+import { appModeStore } from '@/stores/appModeStore';
 
 initSentry();
+appModeStore.fetchMode();
 
 const container = document.getElementById('root');
 const root = createRoot(container!, {

--- a/frontend/src/pages/Therapist.tsx
+++ b/frontend/src/pages/Therapist.tsx
@@ -28,6 +28,7 @@ import config from '@/config/config.json';
 
 import { TherapistPatientsStore, SortKey, RedcapCandidate } from '@/stores/therapistPatientsStore';
 import type { PatientType } from '@/types';
+import { appModeStore } from '@/stores/appModeStore';
 
 // -------------------- local, typed helpers (no any) --------------------
 
@@ -666,20 +667,24 @@ const Therapist: React.FC = observer(() => {
 
           <Row className="mb-3">
             <Col className="d-flex gap-2 flex-wrap">
-              <Button onClick={store.openAddPatient} disabled={store.loading}>
-                {String(t('Add a New Patient'))}
-              </Button>
+              {appModeStore.showManualCreate && (
+                <Button onClick={store.openAddPatient} disabled={store.loading}>
+                  {String(t('Add a New Patient'))}
+                </Button>
+              )}
 
-              <Button
-                variant="outline-primary"
-                onClick={async () => {
-                  store.openImportRedcap();
-                  await store.fetchRedcapCandidates(t);
-                }}
-                disabled={store.loading}
-              >
-                {String(t('Import from REDCap'))}
-              </Button>
+              {appModeStore.showRedcapImport && (
+                <Button
+                  variant="outline-primary"
+                  onClick={async () => {
+                    store.openImportRedcap();
+                    await store.fetchRedcapCandidates(t);
+                  }}
+                  disabled={store.loading}
+                >
+                  {String(t('Import from REDCap'))}
+                </Button>
+              )}
             </Col>
           </Row>
 
@@ -944,21 +949,25 @@ const Therapist: React.FC = observer(() => {
           />
         )}
 
-        <AddPatientPopup show={store.showAddPatientPopup} handleClose={handleCloseAdd} />
+        {appModeStore.showManualCreate && (
+          <AddPatientPopup show={store.showAddPatientPopup} handleClose={handleCloseAdd} />
+        )}
 
-        <ImportFromRedcapModal
-          show={store.showImportRedcapModal}
-          onHide={store.closeImportRedcap}
-          loading={store.redcapLoading}
-          error={store.redcapError || ''}
-          candidates={store.redcapCandidates ?? []}
-          rowPasswords={store.redcapRowPasswords ?? {}}
-          setRowPassword={store.setRedcapRowPassword}
-          importingKey={store.importingKey}
-          importedKeys={store.importedKeys ?? {}}
-          onRefresh={() => store.fetchRedcapCandidates(t)}
-          onImportOne={(c: RedcapCandidate) => store.importOneFromRedcap(c, t)}
-        />
+        {appModeStore.showRedcapImport && (
+          <ImportFromRedcapModal
+            show={store.showImportRedcapModal}
+            onHide={store.closeImportRedcap}
+            loading={store.redcapLoading}
+            error={store.redcapError || ''}
+            candidates={store.redcapCandidates ?? []}
+            rowPasswords={store.redcapRowPasswords ?? {}}
+            setRowPassword={store.setRedcapRowPassword}
+            importingKey={store.importingKey}
+            importedKeys={store.importedKeys ?? {}}
+            onRefresh={() => store.fetchRedcapCandidates(t)}
+            onImportOne={(c: RedcapCandidate) => store.importOneFromRedcap(c, t)}
+          />
+        )}
 
         <style>{`
         .status-stack { display: flex; flex-direction: column; gap: 6px; }

--- a/frontend/src/stores/appModeStore.ts
+++ b/frontend/src/stores/appModeStore.ts
@@ -40,7 +40,7 @@ class AppModeStore {
   async fetchMode(): Promise<void> {
     try {
       const response = await apiClient.get<{ mode: AppMode; redcapVisible: boolean }>(
-        '/api/app-mode/',
+        '/api/app-mode/'
       );
       runInAction(() => {
         const raw = response.data.mode;

--- a/frontend/src/stores/appModeStore.ts
+++ b/frontend/src/stores/appModeStore.ts
@@ -1,0 +1,62 @@
+import { makeAutoObservable, runInAction } from 'mobx';
+import apiClient from '../api/client';
+
+type AppMode = 'dev' | 'normal' | 'study';
+
+class AppModeStore {
+  mode: AppMode = 'normal';
+  redcapVisible: boolean = true;
+  loaded: boolean = false;
+
+  constructor() {
+    makeAutoObservable(this);
+  }
+
+  // ── Derived feature flags ───────────────────────────────────────────────────
+  // Use these in components instead of checking `mode` directly.
+
+  /** Manual patient creation (Register Patient button) is available. */
+  get showManualCreate(): boolean {
+    return this.mode !== 'study';
+  }
+
+  /** REDCap import button is available. */
+  get showRedcapImport(): boolean {
+    return this.mode === 'dev' || this.mode === 'study';
+  }
+
+  /** REDCap tab in patient profile popup is shown. */
+  get showRedcapTab(): boolean {
+    return (this.mode === 'dev' || this.mode === 'study') && this.redcapVisible;
+  }
+
+  /** PII fields (name, email, phone, birthdate) are hidden in patient profile. */
+  get hidePiiFields(): boolean {
+    return this.mode === 'study';
+  }
+
+  // ── Data fetching ──────────────────────────────────────────────────────────
+
+  async fetchMode(): Promise<void> {
+    try {
+      const response = await apiClient.get<{ mode: AppMode; redcapVisible: boolean }>(
+        '/api/app-mode/',
+      );
+      runInAction(() => {
+        const raw = response.data.mode;
+        this.mode = ['dev', 'normal', 'study'].includes(raw) ? raw : 'normal';
+        this.redcapVisible = response.data.redcapVisible ?? true;
+        this.loaded = true;
+      });
+    } catch {
+      // Fall back to 'normal' so the app stays functional if the endpoint is unreachable.
+      runInAction(() => {
+        this.mode = 'normal';
+        this.redcapVisible = true;
+        this.loaded = true;
+      });
+    }
+  }
+}
+
+export const appModeStore = new AppModeStore();


### PR DESCRIPTION
# Add study/normal/dev operating mode for patient privacy

Implements a three-mode system (`dev` / `normal` / `study`) that controls
which features are available without requiring a frontend rebuild.  
Motivated by data minimisation requirements during clinical studies: in study
mode PII fields must not be visible and manual patient creation must be
blocked.

## Related Issue

<!-- link issue here -->

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## What changed

### Backend

- **`GET /api/app-mode/`** — new public (no-auth) endpoint; reads `APP_MODE`
  and `STUDY_REDCAP_VISIBLE` env vars and returns them as JSON so the frontend
  can gate UI without a rebuild.
- **`register_view`** (`auth_views.py`) — returns HTTP 403 in `study` mode as
  a backend safety net even if the UI button is hidden.
- **`middleware.py`** — `/api/app-mode/` added to the JWT public-route list.

### Frontend

- **`appModeStore.ts`** (new MobX store) — fetches mode at startup; exposes
  computed flags `showManualCreate`, `showRedcapImport`, `showRedcapTab`,
  `hidePiiFields`.
- **`Therapist.tsx`** — "Add a New Patient" button and `AddPatientPopup` are
  hidden when `showManualCreate` is false; "Import from REDCap" button and
  `ImportFromRedcapModal` are hidden when `showRedcapImport` is false.
- **`PatientPopup.tsx`** — PII fields (firstName, lastName, email, phone, age)
  filtered out of the profile tab when `hidePiiFields` is true; REDCap tab
  conditionally rendered via `showRedcapTab`.

### Compose / infra

- `docker-compose.dev.yml` — `APP_MODE=dev` (all features unlocked).
- `docker-compose.prod.reha-advisor.yml` — `APP_MODE=study`,
  `STUDY_REDCAP_VISIBLE=true`.

### Mode matrix

| Feature | `dev` | `normal` (default) | `study` |
|---|---|---|---|
| Manual patient creation | ✓ | ✓ | Blocked |
| REDCap import | ✓ | Hidden | ✓ |
| REDCap tab in patient profile | ✓ | Hidden | ✓ (unless `STUDY_REDCAP_VISIBLE=false`) |
| PII fields in patient profile | Visible | Visible | Hidden |
| Characteristics tab | ✓ | ✓ | ✓ |

## Tests

- All 1039 existing backend tests pass (`docker exec django pytest tests/ -v`).
- No new backend tests added for the mode endpoint (it reads an env var and
  returns JSON — covered by manual verification below).

**Manual verification:**
```bash
# Dev: curl should return mode=dev
curl http://localhost:8001/api/app-mode/
# → {"mode": "dev", "redcapVisible": true}

# Prod: after next deploy, curl should return mode=study
curl https://reha-advisor.ch/api/app-mode/
# → {"mode": "study", "redcapVisible": true}

# Study mode API safety net
curl -X POST http://localhost:8001/api/auth/register/ \
  -H "Content-Type: application/json" -d '{}'
# → 403 when APP_MODE=study
```

Checklist

- [x]  I have read the contributing guidelines.
- [x]  I have read the code of conduct.
- [x]  I have made corresponding changes to the documentation.
- [x] Updated docs/15-STUDY_INTEGRATION.md — full APP_MODE feature matrix, supersedes ENFORCE_REDCAP_ONLY_PATIENT_CREATION entry.
- [x] Updated docs/07-ENVIRONMENT_CONFIG.md — new Operating Mode section.
- [x]  My changes generate no new warnings.
- [x]  Changes are non-breaking — defaults to normal mode, identical to current behaviour when env var is unset.


---

**Documentation gaps that were fixed:**

- [15-STUDY_INTEGRATION.md](docs/15-STUDY_INTEGRATION.md) — replaced the old single-flag `ENFORCE_REDCAP_ONLY_PATIENT_CREATION` entry with the full `APP_MODE` / `STUDY_REDCAP_VISIBLE` table and feature matrix.
- [07-ENVIRONMENT_CONFIG.md](docs/07-ENVIRONMENT_CONFIG.md) — new "Operating Mode" section with per-stack defaults and a link to the study integration guide.
