### PR TITLE
Fix/media auth cookie forwarding

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,6 +30,7 @@ on:
     paths:
       - 'frontend/**'
       - 'backend/**'
+      - 'nginx/**'
       - '.github/workflows/tests.yml'
       - 'docker-compose*.yml'
   pull_request:
@@ -37,6 +38,7 @@ on:
     paths:
       - 'frontend/**'
       - 'backend/**'
+      - 'nginx/**'
       - '.github/workflows/tests.yml'
       - 'docker-compose*.yml'
 

--- a/nginx/conf/prod.reha-advisor.nginx.conf
+++ b/nginx/conf/prod.reha-advisor.nginx.conf
@@ -47,12 +47,10 @@ server {
     # runs JWTAuthMiddleware + @permission_classes([IsAuthenticated]).
     # On 401/403 nginx returns that status directly to the client.
     #
-    # Note: browser-initiated requests (img/video/audio src="") do NOT
-    # attach Authorization headers automatically.  The frontend must fetch
-    # media URLs through a proxy endpoint or use short-lived signed URLs
-    # for embedded media elements.  Direct object-storage downloads (e.g.
-    # the therapist media library) use fetch() with the JWT header and
-    # therefore work correctly with this setup.
+    # The subrequest forwards both the Authorization header (used by API
+    # clients and fetch() calls) and the Cookie header (used by browser-
+    # native <video>/<audio>/<img> elements, which send the httpOnly JWT
+    # access_token cookie automatically but no Authorization header).
     location = /api/media-auth/ {
         internal;
         proxy_pass http://django-prod:8000;
@@ -62,8 +60,11 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
-        # Forward the Authorization header so JWTAuthMiddleware can read the token
+        # Forward both the Authorization header (API clients) and the Cookie
+        # (browser-initiated requests from <video>/<audio> elements which send
+        # the httpOnly JWT access_token cookie but no Authorization header).
         proxy_set_header Authorization $http_authorization;
+        proxy_set_header Cookie $http_cookie;
     }
 
     location /media/ {


### PR DESCRIPTION
### Problem
Browser-native media elements (<video>, <audio>, <img>) fetch their src URLs directly from the browser without JavaScript involvement. They do not attach an Authorization: Bearer header — they can only send cookies automatically via the browser's standard cookie mechanism.

The nginx auth_request subrequest for /media/ only forwarded the Authorization header to Django's /api/media-auth/ endpoint. When JWTAuthMiddleware received the subrequest it found no Authorization header and no cookie (because Cookie wasn't being proxied), so it returned 401. This meant any <video> or <audio> element pointing at a /media/ URL was blocked for users authenticated via httpOnly cookies.

### Change
In nginx/conf/prod.reha-advisor.nginx.conf, add proxy_set_header Cookie $http_cookie; to the location = /api/media-auth/ block so the browser's httpOnly access_token cookie reaches Django's auth middleware:


```
# Forward both the Authorization header (API clients) and the Cookie
# (browser-initiated requests from <video>/<audio> elements which send
# the httpOnly JWT access_token cookie but no Authorization header).
proxy_set_header Authorization $http_authorization;
proxy_set_header Cookie $http_cookie;
The comment on the block was also updated to document this dual-path auth requirement instead of the previous note saying "the frontend must use fetch()".
```

Why this is safe
The auth_request location is internal — it is only reachable by nginx itself, never by external clients. Forwarding the Cookie header here does not expose cookies to the world; it simply lets Django see what the browser sent so it can validate the session.

### Test plan
 Stream a video/audio file from /media/ while authenticated via cookie — expect 200, content plays
 Attempt the same unauthenticated — expect 401
 API fetch() calls that use Authorization: Bearer continue to work for media downloads (therapist media library)
 Nginx config reload succeeds: docker exec nginx-prod nginx -t