### PR TITLE
fix(fitbit): surface Fitbit auth errors instead of silently failing

### DIFF
--- a/backend/api/settings/prod.py
+++ b/backend/api/settings/prod.py
@@ -28,7 +28,10 @@ SESSION_COOKIE_SECURE = True
 CSRF_COOKIE_SECURE = True
 
 # Fitbit settings
-FITBIT_CLIENT_ID = os.environ.get("FITBIT_CLIENT_ID", "")
+# FITBIT_CLIENT_ID is non-sensitive (already baked into the frontend bundle).
+# FITBIT_CLIENT_SECRET must be set in .env.prod — no fallback to prevent silent
+# empty-credential token exchange failures against Fitbit's API.
+FITBIT_CLIENT_ID = os.environ.get("FITBIT_CLIENT_ID", "23Q9W2")
 FITBIT_CLIENT_SECRET = os.environ.get("FITBIT_CLIENT_SECRET", "")
 FITBIT_REDIRECT_URI = os.environ.get("FITBIT_REDIRECT_URI", "https://reha-advisor.ch/api/fitbit/callback/")
 FRONTEND_URL = os.environ.get("FRONTEND_URL", "https://reha-advisor.ch")

--- a/backend/core/views/fitbit_view.py
+++ b/backend/core/views/fitbit_view.py
@@ -444,6 +444,23 @@ def fitbit_status(request, patient_id):
 @api_view(["GET"])
 @permission_classes([IsAuthenticated])
 def fitbit_callback(request):
+    # Fitbit sends ?error=<code>&error_description=<text>&state=<state> when the
+    # user declines or when the app config is wrong (e.g. redirect_uri_mismatch,
+    # invalid_client).  Capture and log these before anything else so we have a
+    # clear diagnostic trail in the server logs.
+    fitbit_error = request.GET.get("error")
+    fitbit_error_desc = request.GET.get("error_description", "")
+    if fitbit_error:
+        logger.error(
+            "[fitbit_callback] Fitbit returned an authorization error: %s — %s "
+            "(configured redirect_uri=%s, client_id=%s)",
+            fitbit_error,
+            fitbit_error_desc,
+            getattr(settings, "FITBIT_REDIRECT_URI", "NOT SET"),
+            getattr(settings, "FITBIT_CLIENT_ID", "NOT SET") or "EMPTY",
+        )
+        return redirect(f"{settings.FRONTEND_URL}/patient" f"?fitbit_status=auth_error&fitbit_error={fitbit_error}")
+
     code = request.GET.get("code")
     state = request.GET.get("state")  # carries patient_id from frontend
 
@@ -468,6 +485,16 @@ def fitbit_callback(request):
     client_id = settings.FITBIT_CLIENT_ID
     client_secret = settings.FITBIT_CLIENT_SECRET
     redirect_uri = settings.FITBIT_REDIRECT_URI
+
+    if not client_id or not client_secret:
+        logger.error(
+            "[fitbit_callback] FITBIT_CLIENT_ID or FITBIT_CLIENT_SECRET is not configured. "
+            "client_id=%s, secret_set=%s",
+            client_id or "EMPTY",
+            bool(client_secret),
+        )
+        return redirect(f"{settings.FRONTEND_URL}/patient?fitbit_status=misconfigured")
+
     basic_auth = requests.auth.HTTPBasicAuth(client_id, client_secret)
 
     data = {
@@ -498,7 +525,11 @@ def fitbit_callback(request):
             return redirect(f"{settings.FRONTEND_URL}/patient?fitbit_status=connected")
 
         else:
-            logger.error(f"[fitbit_callback] Fitbit token exchange failed: {response.text}")
+            logger.error(
+                "[fitbit_callback] Fitbit token exchange failed (status %s): %s",
+                response.status_code,
+                response.text,
+            )
             return redirect(f"{settings.FRONTEND_URL}/patient?fitbit_status=error")
 
     except Exception as e:

--- a/backend/tests/fitbit_views/test_fitbit_views.py
+++ b/backend/tests/fitbit_views/test_fitbit_views.py
@@ -197,6 +197,20 @@ def test_fitbit_status_unresolved_identifier_returns_false():
     assert body["last_data"] is None
 
 
+def test_fitbit_callback_auth_error_from_fitbit_redirects():
+    """When Fitbit returns ?error=... (e.g. redirect_uri_mismatch), the callback
+    must redirect to the patient page with fitbit_status=auth_error and include
+    the fitbit_error code so the frontend can show an actionable message."""
+    resp = client.get(
+        "/api/fitbit/callback/?error=redirect_uri_mismatch&error_description=The+redirect+URI+did+not+match",
+        HTTP_AUTHORIZATION="Bearer test",
+    )
+    assert resp.status_code == 302
+    location = resp.headers["Location"]
+    assert "fitbit_status=auth_error" in location
+    assert "fitbit_error=redirect_uri_mismatch" in location
+
+
 def test_fitbit_callback_missing_code_redirects():
     _, _, patient_user, _ = create_patient_graph()
     resp = client.get(

--- a/frontend/src/pages/Patient.tsx
+++ b/frontend/src/pages/Patient.tsx
@@ -38,6 +38,7 @@ const PatientView: React.FC = observer(() => {
   const [pageError, setPageError] = useState('');
 
   const fitbitStatus = useMemo(() => searchParams.get('fitbit_status'), [searchParams]);
+  const fitbitError = useMemo(() => searchParams.get('fitbit_error'), [searchParams]);
   const patientId = localStorage.getItem('id') || authStore.id || '';
 
   // Get today's interventions completion count for badge
@@ -94,6 +95,19 @@ const PatientView: React.FC = observer(() => {
       }
 
       if (fitbitStatus === 'error') setPageError(String(t('Fitbit connection failed.')));
+      if (fitbitStatus === 'misconfigured')
+        setPageError(String(t('Fitbit is not configured on this server. Please contact support.')));
+      if (fitbitStatus === 'auth_error') {
+        const desc =
+          fitbitError === 'redirect_uri_mismatch'
+            ? t('Fitbit redirect URI mismatch — please contact support.')
+            : fitbitError === 'invalid_client'
+              ? t('Fitbit client credentials are invalid — please contact support.')
+              : fitbitError === 'access_denied'
+                ? t('Fitbit authorization was denied.')
+                : t('Fitbit authorization failed: {{error}}.', { error: fitbitError ?? 'unknown' });
+        setPageError(String(desc));
+      }
 
       if (patientId) {
         patientFitbitStore.fetchStatus(patientId);
@@ -111,7 +125,7 @@ const PatientView: React.FC = observer(() => {
     return () => {
       alive = false;
     };
-  }, [navigate, fitbitStatus, t, patientId, i18n.language]);
+  }, [navigate, fitbitStatus, fitbitError, t, patientId, i18n.language]);
 
   if (loading) return null;
 


### PR DESCRIPTION

### Problem

When Fitbit rejects the OAuth authorization (e.g. redirect_uri_mismatch, invalid_client, access_denied), it redirects back to the callback URL with ?error=<code>&error_description=<text> instead of ?code=. The previous fitbit_callback view never checked for the error param — it fell through to the "missing code" branch, logged nothing, and redirected the patient to a generic fitbit_status=missing_code page. This made root-cause diagnosis impossible and gave the patient no useful information.

This is currently manifesting in production: after the VITE_FITBIT_CLIENT_ID fix in #363, Fitbit now receives a valid client ID and reaches the redirect step — but then rejects the request (most likely redirect_uri_mismatch if the URI registered in the Fitbit Developer Console differs from https://reha-advisor.ch/api/fitbit/callback/). The patient sees Fitbit's own "Fitbit Callback" error page rather than being returned to the app.

### Changes

Backend — fitbit_callback view:

Check for Fitbit's ?error= parameter before looking for ?code=
Log the error code, error description, configured FITBIT_REDIRECT_URI, and FITBIT_CLIENT_ID so the server logs show exactly what Fitbit rejected
Redirect to /patient?fitbit_status=auth_error&fitbit_error=<code> so the error code reaches the frontend
Guard against empty FITBIT_CLIENT_ID / FITBIT_CLIENT_SECRET before attempting the token exchange — redirect with fitbit_status=misconfigured rather than sending a broken request to Fitbit
Frontend — Patient.tsx:

Map the new auth_error status to specific human-readable messages per error code (redirect_uri_mismatch, invalid_client, access_denied, generic fallback)
Map misconfigured to "Fitbit is not configured on this server. Please contact support."
Tests:

Add test_fitbit_callback_auth_error_from_fitbit_redirects: verifies the ?error=redirect_uri_mismatch case redirects with fitbit_status=auth_error and fitbit_error=redirect_uri_mismatch in the location header
How to diagnose the current production issue
After deploying, attempt a Fitbit connection and check the Django logs. You will see a log line like:


[fitbit_callback] Fitbit returned an authorization error: redirect_uri_mismatch — The redirect URI in the request did not match a registered redirect URI. (configured redirect_uri=https://reha-advisor.ch/api/fitbit/callback/, client_id=23Q9W2)
Go to [dev.fitbit.com](https://dev.fitbit.com/) → your app → OAuth 2.0 settings and ensure https://reha-advisor.ch/api/fitbit/callback/ is listed as an allowed redirect URI. If the registered URI differs, either update it there or update FITBIT_REDIRECT_URI in .env.prod to match.

### Test plan

 Existing Fitbit callback tests pass (pytest tests/fitbit_views/ -v)
 New test_fitbit_callback_auth_error_from_fitbit_redirects passes
 Deploy to production, attempt Fitbit connect, confirm Django logs show the specific Fitbit error code
 Verify patient sees actionable error message instead of being stuck on Fitbit's error page