### PR TITLE
fix(nginx): proxy /translate/ to LibreTranslate in prod

### DIFF
--- a/docker-compose.prod.reha-advisor.yml
+++ b/docker-compose.prod.reha-advisor.yml
@@ -183,6 +183,7 @@ services:
     depends_on:
       - django-prod
       - react-prod
+      - libretranslate
     volumes:
       - ./nginx/conf/prod.reha-advisor.nginx.conf:/etc/nginx/conf.d/default.conf:ro
       - static-prod:/srv/app/static:ro

--- a/nginx/conf/prod.reha-advisor.nginx.conf
+++ b/nginx/conf/prod.reha-advisor.nginx.conf
@@ -92,6 +92,14 @@ server {
         add_header Content-Type text/plain;
     }
 
+    location /translate/ {
+        proxy_pass http://libretranslate:5000/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
+        rewrite ^/translate(/.*)$ $1 break;
+    }
+
     location / {
         proxy_pass http://react-prod:3000;
         proxy_set_header Host $host;


### PR DESCRIPTION
## Summary

- Adds a `/translate/` proxy location to the prod nginx config pointing to the `libretranslate` service
- The location existed in `dev.nginx.conf` but was never added to `prod.reha-advisor.nginx.conf`, so `POST /translate/detect` fell through to the React static server and returned 405
- Adds `libretranslate` to `nginx-prod` `depends_on` so nginx starts after LibreTranslate is ready

## Root cause

`frontend/src/utils/translate.ts` calls `fetch('/translate/detect', ...)` for language detection. In prod, nginx had no `/translate/` location block, so the request matched the catch-all `location /` → React static server → 405 (static servers reject POST).

## Test plan

- [x] Deploy to prod and verify language detection no longer shows 405 in the network tab
- [x] Open an intervention and confirm auto-translation works (detected language matches content)

