### PR TITLE
fix(fitbit): allow unauthenticated access to OAuth callback endpoint

### DIFF
--- a/backend/core/views/fitbit_view.py
+++ b/backend/core/views/fitbit_view.py
@@ -9,7 +9,7 @@ from django.http import JsonResponse
 from django.shortcuts import redirect
 from django.utils import timezone
 from rest_framework.decorators import api_view, permission_classes
-from rest_framework.permissions import IsAuthenticated
+from rest_framework.permissions import AllowAny, IsAuthenticated
 
 from core.models import FitbitData, FitbitUserToken, Patient, User
 
@@ -442,8 +442,13 @@ def fitbit_status(request, patient_id):
 
 
 @api_view(["GET"])
-@permission_classes([IsAuthenticated])
+@permission_classes([AllowAny])
 def fitbit_callback(request):
+    # The callback is a browser redirect from fitbit.com — no JWT cookie or
+    # Authorization header is sent (SameSite=Strict blocks cookies on cross-site
+    # redirects). The user is identified by the 'state' param (their User ObjectId)
+    # set when the auth flow was initiated, so IsAuthenticated is not needed here.
+
     # Fitbit sends ?error=<code>&error_description=<text>&state=<state> when the
     # user declines or when the app config is wrong (e.g. redirect_uri_mismatch,
     # invalid_client).  Capture and log these before anything else so we have a

--- a/backend/tests/fitbit_views/test_fitbit_views.py
+++ b/backend/tests/fitbit_views/test_fitbit_views.py
@@ -197,13 +197,29 @@ def test_fitbit_status_unresolved_identifier_returns_false():
     assert body["last_data"] is None
 
 
+def test_fitbit_callback_does_not_require_authentication():
+    """
+    The callback is a browser redirect from fitbit.com — no JWT is sent because
+    SameSite=Strict blocks cookies on cross-site redirects and browser navigations
+    never include Authorization headers.
+
+    The view must NOT return 401; the user is identified by the 'state' param.
+    Any response other than 401 (redirect or error) proves auth is not gating the
+    request.
+    """
+    _, _, patient_user, _ = create_patient_graph()
+    resp = client.get(f"/api/fitbit/callback/?state={patient_user.id}&code=testcode")
+    assert resp.status_code != 401, (
+        "fitbit_callback must not require authentication — " "browser redirects from fitbit.com cannot carry a JWT"
+    )
+
+
 def test_fitbit_callback_auth_error_from_fitbit_redirects():
     """When Fitbit returns ?error=... (e.g. redirect_uri_mismatch), the callback
     must redirect to the patient page with fitbit_status=auth_error and include
     the fitbit_error code so the frontend can show an actionable message."""
     resp = client.get(
         "/api/fitbit/callback/?error=redirect_uri_mismatch&error_description=The+redirect+URI+did+not+match",
-        HTTP_AUTHORIZATION="Bearer test",
     )
     assert resp.status_code == 302
     location = resp.headers["Location"]
@@ -213,22 +229,19 @@ def test_fitbit_callback_auth_error_from_fitbit_redirects():
 
 def test_fitbit_callback_missing_code_redirects():
     _, _, patient_user, _ = create_patient_graph()
-    resp = client.get(
-        f"/api/fitbit/callback/?state={patient_user.id}",
-        HTTP_AUTHORIZATION="Bearer test",
-    )
+    resp = client.get(f"/api/fitbit/callback/?state={patient_user.id}")
     assert resp.status_code == 302
     assert "fitbit_status=missing_code" in resp.headers["Location"]
 
 
 def test_fitbit_callback_missing_state_redirects():
-    resp = client.get("/api/fitbit/callback/?code=abc", HTTP_AUTHORIZATION="Bearer test")
+    resp = client.get("/api/fitbit/callback/?code=abc")
     assert resp.status_code == 302
     assert "fitbit_status=unauthorized" in resp.headers["Location"]
 
 
 def test_fitbit_callback_invalid_user_redirects():
-    resp = client.get("/api/fitbit/callback/?code=abc&state=invalid", HTTP_AUTHORIZATION="Bearer test")
+    resp = client.get("/api/fitbit/callback/?code=abc&state=invalid")
     assert resp.status_code == 302
     assert "fitbit_status=invalid_user" in resp.headers["Location"]
 


### PR DESCRIPTION
## Summary

The Fitbit OAuth callback (`/api/fitbit/callback/`) was decorated with
`@permission_classes([IsAuthenticated])`, which caused **every real Fitbit
authorization attempt to return 401** before the view code ever ran.

**Why it always failed:** The callback is a browser redirect from
`fitbit.com`. Browser navigations never include an `Authorization` header,
and `SameSite=Strict` cookies are not sent on cross-site redirects. So no
JWT reached Django, and the auth middleware rejected the request immediately.

**Why the check was wrong in the first place:** The user is already identified
by the `state` parameter (set to the User ObjectId when the auth flow starts),
so `IsAuthenticated` was both redundant and broken. Changed to `AllowAny`.

Confirmed in nginx logs: 4 failed attempts spanning June 19–22, all 401.

## Test plan

- [x] Deploy and have a user go through the Fitbit connect flow — they should land on `/patient?fitbit_status=connected` instead of seeing the DRF 401 HTML page
- [x] Existing callback tests now run without `HTTP_AUTHORIZATION` header
- [x] New test `test_fitbit_callback_does_not_require_authentication` guards against regression
