### PR TITLE
Fix/patient intervention tooltip remove child

### DIFF
--- a/frontend/src/__tests__/pages/PatientInterventionDetail.test.tsx
+++ b/frontend/src/__tests__/pages/PatientInterventionDetail.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 
 const mockNavigate = jest.fn();
 let mockInterventionId = 'int-1';
@@ -158,6 +158,7 @@ import authStore from '@/stores/authStore';
 import { patientInterventionsStore } from '@/stores/patientInterventionsStore';
 import { patientQuestionnairesStore } from '@/stores/patientQuestionnairesStore';
 import { patientInterventionsLibraryStore } from '@/stores/interventionsLibraryStore';
+import { translateText } from '@/utils/translate';
 
 const buildRec = (overrides: any = {}) => ({
   intervention_id: 'int-1',
@@ -375,5 +376,78 @@ describe('PatientInterventionDetail', () => {
     });
 
     jest.restoreAllMocks();
+  });
+
+  // --- Tests for the Sentry removeChild fix ---
+
+  it('shows private lock icon when intervention is marked private', async () => {
+    (patientInterventionsStore as any).items = [
+      buildRec({
+        intervention: { _id: 'int-1', aim: 'Exercise', media: [], is_private: true },
+      }),
+    ];
+
+    render(<PatientInterventionDetail />);
+    await screen.findByText('Morning Stretch');
+
+    expect(screen.getByTestId('fa-lock')).toBeInTheDocument();
+  });
+
+  it('does not show lock icon when intervention is not private', async () => {
+    render(<PatientInterventionDetail />);
+    await screen.findByText('Morning Stretch');
+
+    expect(screen.queryByTestId('fa-lock')).not.toBeInTheDocument();
+  });
+
+  it('displays translated title when translation returns different text', async () => {
+    (translateText as jest.Mock).mockImplementation(async (text: string) => {
+      if (text === 'Morning Stretch') {
+        return { translatedText: 'Morgenstreckung', detectedSourceLanguage: 'en' };
+      }
+      return { translatedText: text, detectedSourceLanguage: '' };
+    });
+
+    render(<PatientInterventionDetail />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Morgenstreckung')).toBeInTheDocument();
+    });
+  });
+
+  it('displays translated description when translation returns different text', async () => {
+    (translateText as jest.Mock).mockImplementation(async (text: string) => {
+      if (text === 'Daily movement routine') {
+        return { translatedText: 'Tägliche Bewegungsroutine', detectedSourceLanguage: 'en' };
+      }
+      return { translatedText: text, detectedSourceLanguage: '' };
+    });
+
+    render(<PatientInterventionDetail />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Tägliche Bewegungsroutine')).toBeInTheDocument();
+    });
+  });
+
+  it('alive guard: resolving translation after unmount does not throw', async () => {
+    // Simulate slow translation — resolve it only after component unmounts.
+    // The alive guard in the useEffect should prevent stale setState calls.
+    const resolvers: Array<(v: any) => void> = [];
+    (translateText as jest.Mock).mockImplementation(
+      () => new Promise((resolve) => resolvers.push(resolve))
+    );
+
+    const { unmount } = render(<PatientInterventionDetail />);
+    await screen.findByText('Morning Stretch');
+
+    unmount();
+
+    // Resolve all pending translation promises after unmount — must not throw.
+    await act(async () => {
+      for (const resolve of resolvers) {
+        resolve({ translatedText: 'Translated text', detectedSourceLanguage: 'en' });
+      }
+    });
   });
 });

--- a/frontend/src/pages/PatientInterventionDetail.tsx
+++ b/frontend/src/pages/PatientInterventionDetail.tsx
@@ -319,6 +319,7 @@ const PatientInterventionDetail: React.FC = observer(() => {
   const patientId = localStorage.getItem('id') || authStore.id || '';
   const viewOpenedAt = useRef<number>(Date.now());
   const mediaRef = useRef<HTMLDivElement>(null);
+  const tooltipContainerRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     let alive = true;
@@ -529,11 +530,14 @@ const PatientInterventionDetail: React.FC = observer(() => {
   useEffect(() => {
     if (!effectiveItem) return;
 
+    let alive = true;
+
     const run = async () => {
       try {
         const desc = effectiveItem?.description || '';
         if (desc) {
           const { translatedText: tx, detectedSourceLanguage } = await translateText(desc);
+          if (!alive) return;
           setTranslatedText(tx);
           setDetectedLang(tx !== desc ? detectedSourceLanguage : '');
         } else {
@@ -544,6 +548,7 @@ const PatientInterventionDetail: React.FC = observer(() => {
         const title = effectiveItem?.title || effectiveItem?.intervention_title || '';
         if (title) {
           const { translatedText: tt, detectedSourceLanguage: tl } = await translateText(title);
+          if (!alive) return;
           setTranslatedTitle(tt);
           setTitleLang(tt !== title ? tl : '');
         } else {
@@ -551,6 +556,7 @@ const PatientInterventionDetail: React.FC = observer(() => {
           setTitleLang('');
         }
       } catch {
+        if (!alive) return;
         setTranslatedText(effectiveItem?.description || '');
         setTranslatedTitle(effectiveItem?.title || effectiveItem?.intervention_title || '');
         setDetectedLang('');
@@ -559,6 +565,9 @@ const PatientInterventionDetail: React.FC = observer(() => {
     };
 
     void run();
+    return () => {
+      alive = false;
+    };
   }, [effectiveItem]);
 
   const effectiveMediaList: InterventionMedia[] = useMemo(
@@ -611,7 +620,7 @@ const PatientInterventionDetail: React.FC = observer(() => {
 
   return (
     <Layout>
-      <div className="flex flex-col gap-2">
+      <div ref={tooltipContainerRef} className="flex flex-col gap-2">
         <div className="flex justify-between align-items-center">
           <Button size="icon" variant="secondary" onClick={() => navigate(-1)} className="bg-white">
             <ArrowLeftIcon />
@@ -656,7 +665,10 @@ const PatientInterventionDetail: React.FC = observer(() => {
                 </span>
               </Badge>
               {effectiveIsPrivate && (
-                <OverlayTrigger overlay={<Tooltip>{t('Private intervention')}</Tooltip>}>
+                <OverlayTrigger
+                  container={tooltipContainerRef}
+                  overlay={<Tooltip>{t('Private intervention')}</Tooltip>}
+                >
                   <span className="text-zinc-800 -mb-4">
                     <FaLock />
                   </span>
@@ -664,7 +676,10 @@ const PatientInterventionDetail: React.FC = observer(() => {
               )}
               <div className="font-bold text-2xl leading-7 text-zinc-800">
                 {titleLang ? (
-                  <OverlayTrigger overlay={<Tooltip>{titleRaw}</Tooltip>}>
+                  <OverlayTrigger
+                    container={tooltipContainerRef}
+                    overlay={<Tooltip>{titleRaw}</Tooltip>}
+                  >
                     <span>{translatedTitle}</span>
                   </OverlayTrigger>
                 ) : (
@@ -739,7 +754,10 @@ const PatientInterventionDetail: React.FC = observer(() => {
 
               <Card className="text-lg text-zinc-500">
                 {detectedLang ? (
-                  <OverlayTrigger overlay={<Tooltip>{effectiveItem?.description || ''}</Tooltip>}>
+                  <OverlayTrigger
+                    container={tooltipContainerRef}
+                    overlay={<Tooltip>{effectiveItem?.description || ''}</Tooltip>}
+                  >
                     <span>{translatedText}</span>
                   </OverlayTrigger>
                 ) : (


### PR DESCRIPTION
## Summary

Fixes a `NotFoundError: Failed to execute 'removeChild' on 'Node'` reported in Sentry at `/patient-intervention/:id`.

- **Root cause**: Three `OverlayTrigger` components (private-intervention lock icon, translated title, translated description) rendered their `Tooltip` portals to `document.body` by default. When a tooltip was visible and the component unmounted — either from navigation or from an async translation completing and flipping a conditional `OverlayTrigger` in/out — both React's fiber reconciler and React-Bootstrap's portal cleanup tried to call `removeChild` on the same node, producing a `NotFoundError`.

- **Fix 1 — scoped tooltip container**: Added a `tooltipContainerRef` pointing to the page's root `<div>` and passed it as `container` to all three `OverlayTrigger`s. Tooltips now render inside the component's own DOM subtree, so React removes them atomically on unmount with no separate cleanup race.

- **Fix 2 — alive guard on translation effect**: The `translateText` calls are async; if the user navigated to a different intervention before they resolved, the stale result would call `setTitleLang` / `setDetectedLang` on the new render, conditionally mounting an `OverlayTrigger` for content that no longer matches. Added an `alive` flag (returned as cleanup) to discard stale responses.

## Test plan

- [ ] 5 new Jest tests added to `PatientInterventionDetail.test.tsx` (13 total, all passing):
  - Lock icon visible when `is_private: true`, hidden otherwise
  - Translated title rendered via the OverlayTrigger branch when translation differs
  - Translated description rendered via the OverlayTrigger branch when translation differs
  - Alive guard: resolving a pending translation promise after unmount does not throw
- [ ] Manually navigate rapidly between interventions in the patient app and verify no console errors
- [ ] Hover over a translated title / private-intervention lock icon, then click Back — verify no crash
