### PR TITLE
feat(icf): expand intro questions — 4 assistance options + explicit device selection

### DIFF
--- a/backend/core/models.py
+++ b/backend/core/models.py
@@ -728,8 +728,10 @@ class HealthSliderEntry(Document):
     audio_mime = StringField()  # "audio/webm", "audio/wav", ...
 
     answered_at = DateTimeField(default=timezone.now)
-    device_type = StringField(max_length=20, required=False, null=True)
-    assistance = StringField(max_length=20, required=False, null=True)  # "alone" or "with_help"
+    device_type = StringField(max_length=20, required=False, null=True)  # "smartphone"|"tablet"|"laptop"|"desktop"
+    assistance = StringField(
+        max_length=30, required=False, null=True
+    )  # "alone"|"family_friend"|"healthcare"|"study_interviewer"
 
     meta = {
         "indexes": [

--- a/frontend/e2e/icf-monitor.spec.ts
+++ b/frontend/e2e/icf-monitor.spec.ts
@@ -82,21 +82,35 @@ async function gotoWithPatientId(page: Page, patientId = 'P01') {
   await page.goto(`/icf/${patientId}`);
 }
 
-/**
- * Answer the assistance question screen that appears after clicking "Übungslauf starten".
- * The screen is a separate full page between the welcome screen and practice mode.
- */
+/** Answer the assistance question screen (step 2 of the intro flow). */
 async function answerAssistanceQuestion(
   page: Page,
-  choice: 'Alleine' | 'Mit Unterstützung' = 'Alleine'
+  choice:
+    | 'Alleine'
+    | 'Angehörige:r, Freund:in'
+    | 'Gesundheitsfachperson'
+    | 'Studien Interviewer:in' = 'Alleine'
 ) {
   await page.getByRole('button', { name: choice }).click();
 }
 
-/** Navigate through welcome → assistance question → practice mode. */
+/** Answer the device question screen (step 3 of the intro flow). */
+async function answerDeviceQuestion(
+  page: Page,
+  choice:
+    | 'Smartphone, Handy'
+    | 'Tablet, iPad'
+    | 'Laptop, Notebook'
+    | 'Computer' = 'Smartphone, Handy'
+) {
+  await page.getByRole('button', { name: choice }).click();
+}
+
+/** Navigate through welcome → assistance → device → practice mode. */
 async function startMicAndPractice(page: Page) {
   await page.getByRole('button', { name: 'Übungslauf starten' }).click();
   await answerAssistanceQuestion(page);
+  await answerDeviceQuestion(page);
   // Wait for the practice mode banner to appear
   await expect(page.getByText('ÜBUNGSMODUS')).toBeVisible();
 }
@@ -337,9 +351,10 @@ test.describe('ICF Monitor — MediaRecorder not available', () => {
     });
 
     await gotoWithPatientId(page);
-    // Advance to the assistance screen, then attempt to start — the error appears there
+    // Advance through both intro screens; startMic() fires after device selection
     await page.getByRole('button', { name: 'Übungslauf starten' }).click();
-    await page.getByRole('button', { name: 'Alleine' }).click();
+    await answerAssistanceQuestion(page);
+    await answerDeviceQuestion(page);
 
     await expect(page.getByText(/MediaRecorder fehlt|nicht unterstützt/i)).toBeVisible();
   });
@@ -714,9 +729,10 @@ test.describe('#324 — MediaRecorder started with timeslice', () => {
     await stubSubmitItem(page);
     await gotoWithPatientId(page);
 
-    // Click start → assistance screen appears → answer it → startMic() → timeslice recorded
+    // Click start → assistance → device → startMic() → timeslice recorded
     await page.getByRole('button', { name: 'Übungslauf starten' }).click();
     await answerAssistanceQuestion(page);
+    await answerDeviceQuestion(page);
     await expect(page.getByText('ÜBUNGSMODUS')).toBeVisible();
 
     // Read the timeslice that was passed to FakeMediaRecorder.start()
@@ -728,82 +744,115 @@ test.describe('#324 — MediaRecorder started with timeslice', () => {
 });
 
 // ---------------------------------------------------------------------------
-// Assistance question (feat/device-tracking-assistance)
+// Assistance + Device intro screens
 // ---------------------------------------------------------------------------
-// The assistance question appears as a full page (same icf-page style as the
-// Willkommen screen) AFTER the patient clicks "Übungslauf starten". The mic is
-// requested only after the patient answers.
+// Flow: Willkommen → AssistanceScreen → DeviceScreen → Practice mode.
+// The mic is requested only after the device is selected (step 3).
 // ---------------------------------------------------------------------------
 
-test.describe('ICF Monitor — assistance question', () => {
+test.describe('ICF Monitor — assistance + device intro screens', () => {
   test('assistance screen does not appear on the welcome screen itself', async ({ page }) => {
     await mockAudioAPIs(page);
     await gotoWithPatientId(page);
 
-    // On the welcome screen the question must NOT yet be visible
     await expect(
-      page.getByText('Machen Sie Ihre Übungen heute alleine oder mit Unterstützung?')
+      page.getByText('Werden Sie das FunktionsBarometer jetzt alleine verwenden')
     ).not.toBeVisible();
     await expect(page.getByText('Willkommen')).toBeVisible();
   });
 
-  test('assistance screen appears after clicking Übungslauf starten', async ({ page }) => {
+  test('assistance screen appears after clicking Übungslauf starten with all four options', async ({
+    page,
+  }) => {
     await mockAudioAPIs(page);
     await gotoWithPatientId(page);
 
     await page.getByRole('button', { name: 'Übungslauf starten' }).click();
 
     await expect(
-      page.getByText('Machen Sie Ihre Übungen heute alleine oder mit Unterstützung?')
+      page.getByText('Werden Sie das FunktionsBarometer jetzt alleine verwenden')
     ).toBeVisible();
     await expect(page.getByRole('button', { name: 'Alleine' })).toBeVisible();
-    await expect(page.getByRole('button', { name: 'Mit Unterstützung' })).toBeVisible();
-    // Welcome screen is gone
+    await expect(page.getByRole('button', { name: 'Angehörige:r, Freund:in' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Gesundheitsfachperson' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Studien Interviewer:in' })).toBeVisible();
     await expect(page.getByText('Willkommen')).not.toBeVisible();
   });
 
-  test('selecting Alleine starts the session and shows practice mode', async ({ page }) => {
+  test('device screen appears after selecting an assistance option with all four devices', async ({
+    page,
+  }) => {
+    await mockAudioAPIs(page);
+    await gotoWithPatientId(page);
+
+    await page.getByRole('button', { name: 'Übungslauf starten' }).click();
+    await answerAssistanceQuestion(page);
+
+    await expect(page.getByText('Welches Gerät nutzen Sie jetzt dafür?')).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Smartphone, Handy' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Tablet, iPad' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Laptop, Notebook' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Computer' })).toBeVisible();
+    await expect(
+      page.getByText('Werden Sie das FunktionsBarometer jetzt alleine verwenden')
+    ).not.toBeVisible();
+  });
+
+  test('selecting a device starts the session and shows practice mode', async ({ page }) => {
     await mockAudioAPIs(page);
     await stubSubmitItem(page);
     await gotoWithPatientId(page);
 
     await page.getByRole('button', { name: 'Übungslauf starten' }).click();
-    await page.getByRole('button', { name: 'Alleine' }).click();
+    await answerAssistanceQuestion(page);
+    await answerDeviceQuestion(page);
 
     await expect(page.getByText('ÜBUNGSMODUS')).toBeVisible();
-    await expect(
-      page.getByText('Machen Sie Ihre Übungen heute alleine oder mit Unterstützung?')
-    ).not.toBeVisible();
+    await expect(page.getByText('Welches Gerät nutzen Sie jetzt dafür?')).not.toBeVisible();
   });
 
-  test('selecting Mit Unterstützung starts the session and shows practice mode', async ({
+  test('assistance and device screens are not shown when resuming a mid-survey session', async ({
     page,
   }) => {
     await mockAudioAPIs(page);
     await stubSubmitItem(page);
-    await gotoWithPatientId(page);
 
-    await page.getByRole('button', { name: 'Übungslauf starten' }).click();
-    await page.getByRole('button', { name: 'Mit Unterstützung' }).click();
-
-    await expect(page.getByText('ÜBUNGSMODUS')).toBeVisible();
-  });
-
-  test('assistance screen is not shown when resuming a mid-survey session', async ({ page }) => {
-    await mockAudioAPIs(page);
-    await stubSubmitItem(page);
-
-    // Seed a mid-survey state — survey_sessionId already set means testMode is false
     await seedMidSurveyState(page, { questionIndex: 2, patientId: 'P01-001T1' });
     await page.goto('/icf/P01-001T1');
 
     await expect(page.getByText('/ 29')).toBeVisible();
     await expect(
-      page.getByText('Machen Sie Ihre Übungen heute alleine oder mit Unterstützung?')
+      page.getByText('Werden Sie das FunktionsBarometer jetzt alleine verwenden')
     ).not.toBeVisible();
+    await expect(page.getByText('Welches Gerät nutzen Sie jetzt dafür?')).not.toBeVisible();
   });
 
-  test('sends assistance=alone with ICF item submissions after selecting Alleine', async ({
+  test('sends assistance=alone when Alleine was selected', async ({ page }) => {
+    await mockAudioAPIs(page);
+
+    const capturedBodies: string[] = [];
+    await page.route('**/api/healthslider/submit-item/**', async (route) => {
+      capturedBodies.push(route.request().postData() ?? '');
+      await route.fulfill({ status: 201, body: '{"ok":true}' });
+    });
+
+    await gotoWithPatientId(page);
+    await page.getByRole('button', { name: 'Übungslauf starten' }).click();
+    await page.getByRole('button', { name: 'Alleine' }).click();
+    await answerDeviceQuestion(page);
+    await expect(page.getByText('ÜBUNGSMODUS')).toBeVisible();
+
+    await page.getByRole('button', { name: 'Start' }).click();
+    await expect(page.getByText('/ 29')).toBeVisible();
+    const naBtn = page.getByRole('button', { name: 'Kann ich nicht beantworten' });
+    await expect(naBtn).toBeEnabled({ timeout: 5000 });
+    await naBtn.click();
+
+    await expect.poll(() => capturedBodies.length).toBeGreaterThan(0);
+    expect(capturedBodies.some((b) => b.includes('assistance') && b.includes('alone'))).toBe(true);
+  });
+
+  test('sends assistance=study_interviewer when Studien Interviewer:in was selected', async ({
     page,
   }) => {
     await mockAudioAPIs(page);
@@ -816,23 +865,23 @@ test.describe('ICF Monitor — assistance question', () => {
 
     await gotoWithPatientId(page);
     await page.getByRole('button', { name: 'Übungslauf starten' }).click();
-    await page.getByRole('button', { name: 'Alleine' }).click();
+    await answerAssistanceQuestion(page, 'Studien Interviewer:in');
+    await answerDeviceQuestion(page);
     await expect(page.getByText('ÜBUNGSMODUS')).toBeVisible();
 
     await page.getByRole('button', { name: 'Start' }).click();
     await expect(page.getByText('/ 29')).toBeVisible();
-
     const naBtn = page.getByRole('button', { name: 'Kann ich nicht beantworten' });
     await expect(naBtn).toBeEnabled({ timeout: 5000 });
     await naBtn.click();
 
     await expect.poll(() => capturedBodies.length).toBeGreaterThan(0);
     expect(
-      capturedBodies.some((body) => body.includes('assistance') && body.includes('alone'))
+      capturedBodies.some((b) => b.includes('assistance') && b.includes('study_interviewer'))
     ).toBe(true);
   });
 
-  test('sends assistance=with_help when Mit Unterstützung was selected', async ({ page }) => {
+  test('sends deviceType=laptop when Laptop, Notebook was selected', async ({ page }) => {
     await mockAudioAPIs(page);
 
     const capturedBodies: string[] = [];
@@ -843,19 +892,17 @@ test.describe('ICF Monitor — assistance question', () => {
 
     await gotoWithPatientId(page);
     await page.getByRole('button', { name: 'Übungslauf starten' }).click();
-    await page.getByRole('button', { name: 'Mit Unterstützung' }).click();
+    await answerAssistanceQuestion(page);
+    await answerDeviceQuestion(page, 'Laptop, Notebook');
     await expect(page.getByText('ÜBUNGSMODUS')).toBeVisible();
 
     await page.getByRole('button', { name: 'Start' }).click();
     await expect(page.getByText('/ 29')).toBeVisible();
-
     const naBtn = page.getByRole('button', { name: 'Kann ich nicht beantworten' });
     await expect(naBtn).toBeEnabled({ timeout: 5000 });
     await naBtn.click();
 
     await expect.poll(() => capturedBodies.length).toBeGreaterThan(0);
-    expect(
-      capturedBodies.some((body) => body.includes('assistance') && body.includes('with_help'))
-    ).toBe(true);
+    expect(capturedBodies.some((b) => b.includes('deviceType') && b.includes('laptop'))).toBe(true);
   });
 });

--- a/frontend/src/__tests__/components/icf/AssistanceScreen.test.tsx
+++ b/frontend/src/__tests__/components/icf/AssistanceScreen.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import AssistanceScreen from '@/components/icf/AssistanceScreen';
+
+describe('AssistanceScreen', () => {
+  const noop = () => {};
+
+  it('renders the assistance question and all four options', () => {
+    render(<AssistanceScreen onSelect={noop} />);
+    expect(
+      screen.getByText(/Werden Sie das FunktionsBarometer jetzt alleine verwenden/)
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Alleine' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Angehörige:r, Freund:in' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Gesundheitsfachperson' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Studien Interviewer:in' })).toBeInTheDocument();
+  });
+
+  it('calls onSelect with alone when Alleine is clicked', () => {
+    const onSelect = jest.fn();
+    render(<AssistanceScreen onSelect={onSelect} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Alleine' }));
+    expect(onSelect).toHaveBeenCalledWith('alone');
+  });
+
+  it('calls onSelect with family_friend when Angehörige:r, Freund:in is clicked', () => {
+    const onSelect = jest.fn();
+    render(<AssistanceScreen onSelect={onSelect} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Angehörige:r, Freund:in' }));
+    expect(onSelect).toHaveBeenCalledWith('family_friend');
+  });
+
+  it('calls onSelect with healthcare when Gesundheitsfachperson is clicked', () => {
+    const onSelect = jest.fn();
+    render(<AssistanceScreen onSelect={onSelect} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Gesundheitsfachperson' }));
+    expect(onSelect).toHaveBeenCalledWith('healthcare');
+  });
+
+  it('calls onSelect with study_interviewer when Studien Interviewer:in is clicked', () => {
+    const onSelect = jest.fn();
+    render(<AssistanceScreen onSelect={onSelect} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Studien Interviewer:in' }));
+    expect(onSelect).toHaveBeenCalledWith('study_interviewer');
+  });
+});

--- a/frontend/src/__tests__/components/icf/DeviceScreen.test.tsx
+++ b/frontend/src/__tests__/components/icf/DeviceScreen.test.tsx
@@ -1,0 +1,57 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import DeviceScreen from '@/components/icf/DeviceScreen';
+
+describe('DeviceScreen', () => {
+  const noop = () => {};
+
+  it('renders the device question and all four options', () => {
+    render(<DeviceScreen onSelect={noop} />);
+    expect(screen.getByText('Welches Gerät nutzen Sie jetzt dafür?')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Smartphone, Handy' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Tablet, iPad' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Laptop, Notebook' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Computer' })).toBeInTheDocument();
+  });
+
+  it('calls onSelect with smartphone when Smartphone, Handy is clicked', () => {
+    const onSelect = jest.fn();
+    render(<DeviceScreen onSelect={onSelect} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Smartphone, Handy' }));
+    expect(onSelect).toHaveBeenCalledWith('smartphone');
+  });
+
+  it('calls onSelect with tablet when Tablet, iPad is clicked', () => {
+    const onSelect = jest.fn();
+    render(<DeviceScreen onSelect={onSelect} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Tablet, iPad' }));
+    expect(onSelect).toHaveBeenCalledWith('tablet');
+  });
+
+  it('calls onSelect with laptop when Laptop, Notebook is clicked', () => {
+    const onSelect = jest.fn();
+    render(<DeviceScreen onSelect={onSelect} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Laptop, Notebook' }));
+    expect(onSelect).toHaveBeenCalledWith('laptop');
+  });
+
+  it('calls onSelect with desktop when Computer is clicked', () => {
+    const onSelect = jest.fn();
+    render(<DeviceScreen onSelect={onSelect} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Computer' }));
+    expect(onSelect).toHaveBeenCalledWith('desktop');
+  });
+
+  it('does not show mic error when micError is not provided', () => {
+    const { container } = render(<DeviceScreen onSelect={noop} />);
+    expect(container.querySelector('.icf-audio-error')).not.toBeInTheDocument();
+  });
+
+  it('shows mic error when micError is provided', () => {
+    const { container } = render(
+      <DeviceScreen onSelect={noop} micError="Mikrofon nicht verfügbar" />
+    );
+    const errorEl = container.querySelector('.icf-audio-error');
+    expect(errorEl).toBeInTheDocument();
+    expect(errorEl).toHaveTextContent('Mikrofon nicht verfügbar');
+  });
+});

--- a/frontend/src/__tests__/pages/HealthSlider.fullsync.test.tsx
+++ b/frontend/src/__tests__/pages/HealthSlider.fullsync.test.tsx
@@ -62,12 +62,12 @@ describe('HealthSlider (Full Sync)', () => {
     });
   };
 
-  // Click "Übungslauf starten" (shows AssistanceScreen) then answer "Alleine"
-  // (which calls startMic). The caller is still responsible for awaiting
-  // waitFor(ÜBUNGSMODUS) if practice mode is needed.
+  // Click through the two intro screens (AssistanceScreen → DeviceScreen) to
+  // reach practice mode. startMic() is called after the device selection.
   const startPracticeMode = async () => {
     fireEvent.click(screen.getByRole('button', { name: /Übungslauf starten/i }));
     fireEvent.click(screen.getByRole('button', { name: /Alleine/i }));
+    fireEvent.click(screen.getByRole('button', { name: /Smartphone, Handy/i }));
   };
 
   beforeEach(() => {

--- a/frontend/src/components/icf/DeviceScreen.tsx
+++ b/frontend/src/components/icf/DeviceScreen.tsx
@@ -2,13 +2,14 @@ import logoImage from '@/assets/icf/logo_funktionsbarometer.png';
 import { FlowerSides } from './FlowerDecoration';
 import '@/assets/styles/icf.css';
 
-export type AssistanceMode = 'alone' | 'family_friend' | 'healthcare' | 'study_interviewer';
+export type DeviceChoice = 'smartphone' | 'tablet' | 'laptop' | 'desktop';
 
 interface Props {
-  onSelect: (mode: AssistanceMode) => void;
+  onSelect: (device: DeviceChoice) => void;
+  micError?: string;
 }
 
-export default function AssistanceScreen({ onSelect }: Props) {
+export default function DeviceScreen({ onSelect, micError }: Props) {
   return (
     <main className="icf-page">
       <FlowerSides />
@@ -16,39 +17,38 @@ export default function AssistanceScreen({ onSelect }: Props) {
       <img src={logoImage} alt="Logo" className="icf-logo" />
 
       <div className="mt-6 max-w-2xl w-full">
-        <p className="mb-8 text-xl font-semibold">
-          Werden Sie das FunktionsBarometer jetzt alleine verwenden, oder unterstützt Sie jemand
-          dabei?
-        </p>
+        <p className="mb-8 text-xl font-semibold">Welches Gerät nutzen Sie jetzt dafür?</p>
+
+        {!!micError && <p className="icf-audio-error">{micError}</p>}
 
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
           <button
             type="button"
             className="icf-btn icf-btn--neutral"
-            onClick={() => onSelect('alone')}
+            onClick={() => onSelect('smartphone')}
           >
-            Alleine
+            Smartphone, Handy
           </button>
           <button
             type="button"
             className="icf-btn icf-btn--neutral"
-            onClick={() => onSelect('family_friend')}
+            onClick={() => onSelect('tablet')}
           >
-            Angehörige:r, Freund:in
+            Tablet, iPad
           </button>
           <button
             type="button"
             className="icf-btn icf-btn--neutral"
-            onClick={() => onSelect('healthcare')}
+            onClick={() => onSelect('laptop')}
           >
-            Gesundheitsfachperson
+            Laptop, Notebook
           </button>
           <button
             type="button"
             className="icf-btn icf-btn--neutral"
-            onClick={() => onSelect('study_interviewer')}
+            onClick={() => onSelect('desktop')}
           >
-            Studien Interviewer:in
+            Computer
           </button>
         </div>
       </div>

--- a/frontend/src/pages/eva2.tsx
+++ b/frontend/src/pages/eva2.tsx
@@ -9,15 +9,16 @@
  * -----------------------------------------
  * 1. Patient-ID input   — when no patientId in URL param or localStorage.
  *                         Validates "P\d+-\d+T\d+" format, persists to localStorage.
- * 2. Assistance screen  — full-page screen (same style as step 1) asking
- *                         "alleine oder mit Unterstützung?". Appears after the patient
- *                         clicks "Übungslauf starten" on the welcome screen.
+ * 2. Assistance screen  — full-page screen asking who is helping the patient:
+ *                         "Alleine / Angehörige:r / Gesundheitsfachperson / Studien Interviewer:in".
+ *                         Appears after clicking "Übungslauf starten" on the welcome screen.
  *                         Not shown when resuming a mid-survey session (survey_sessionId
- *                         already set in localStorage → testMode is false). Answer is
- *                         stored in component state (not localStorage) and sent with
- *                         every subsequent POST to /api/healthslider/submit-item/.
- * 3. Mic permission     — getUserMedia is requested when the patient picks their answer
- *                         on the assistance screen.
+ *                         already set in localStorage → testMode is false).
+ * 3. Device screen      — full-page screen asking which device is being used:
+ *                         "Smartphone / Tablet / Laptop / Computer".
+ *                         Both answers are stored in component state and sent with every
+ *                         subsequent POST to /api/healthslider/submit-item/.
+ * 4. Mic permission     — getUserMedia is requested after the device is selected.
  * 4. Practice mode      — one warm-up question (not uploaded to backend).
  * 5. Survey questions   — 29 ICF domain questions with vertical slider + optional audio cue.
  *                         Each answer POSTs to /api/healthslider/submit-item/ including
@@ -46,7 +47,8 @@ import { useState, useRef, useEffect, useCallback } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 
 import { PlayFill, BellFill, BellSlashFill, InfoLg } from 'react-bootstrap-icons';
-import AssistanceScreen from '@/components/icf/AssistanceScreen';
+import AssistanceScreen, { type AssistanceMode } from '@/components/icf/AssistanceScreen';
+import DeviceScreen, { type DeviceChoice } from '@/components/icf/DeviceScreen';
 import EndScreen from '@/components/icf/EndScreen';
 import InfoScreen from '@/components/icf/InfoScreen';
 import PatientIdScreen from '@/components/icf/PatientIdScreen';
@@ -139,13 +141,6 @@ const extFromMime = (mime: string) => {
   return 'webm';
 };
 
-const getDeviceType = (): string => {
-  const ua = navigator.userAgent;
-  if (/tablet|ipad/i.test(ua)) return 'Tablet';
-  if (/mobile|android|iphone|ipod|blackberry|windows phone/i.test(ua)) return 'Mobile';
-  return 'Desktop';
-};
-
 const pickRecorderMime = () => {
   if (typeof MediaRecorder === 'undefined') return '';
   // Keep only webm/mp4 (no ogg)
@@ -171,8 +166,10 @@ export default function HealthSlider() {
   const navigate = useNavigate();
 
   // --- questionnaire states ---
-  const [assistanceMode, setAssistanceMode] = useState<'alone' | 'with_help' | null>(null);
+  const [assistanceMode, setAssistanceMode] = useState<AssistanceMode | null>(null);
+  const [deviceChoice, setDeviceChoice] = useState<DeviceChoice | null>(null);
   const [showingAssistanceScreen, setShowingAssistanceScreen] = useState(false);
+  const [showingDeviceScreen, setShowingDeviceScreen] = useState(false);
   const [sliderPosition, setSliderPosition] = useState(50);
   const [sliderMoved, setSliderMoved] = useState(false);
   const [questionIndex, setQuestionIndex] = useState(() => {
@@ -609,7 +606,7 @@ export default function HealthSlider() {
     fd.append('questionText', payload.questionText);
     fd.append('answerValue', String(payload.answerValue));
     fd.append('answeredAt', new Date().toISOString());
-    fd.append('deviceType', getDeviceType());
+    if (deviceChoice) fd.append('deviceType', deviceChoice);
     if (assistanceMode) fd.append('assistance', assistanceMode);
 
     if (payload.audio) {
@@ -903,13 +900,23 @@ export default function HealthSlider() {
   }
 
   if (testMode) {
+    if (showingDeviceScreen) {
+      return (
+        <DeviceScreen
+          micError={micError}
+          onSelect={(device) => {
+            setDeviceChoice(device);
+            startMic();
+          }}
+        />
+      );
+    }
     if (showingAssistanceScreen) {
       return (
         <AssistanceScreen
-          micError={micError}
           onSelect={(mode) => {
             setAssistanceMode(mode);
-            startMic();
+            setShowingDeviceScreen(true);
           }}
         />
       );


### PR DESCRIPTION
## Summary

Replaces the two-option assistance question with the four-option wording from the study team, and adds a new **DeviceScreen** as a third intro step so patients explicitly state which device they are using.

**Why the device question is needed**: user-agent detection (`navigator.userAgent`) can reliably detect Mobile (smartphone) and Tablet, but returns `"Desktop"` for both Laptop/Notebook *and* Desktop Computer — so the distinction requires asking the patient.

### New flow
Willkommen → **AssistanceScreen** → **DeviceScreen** → Mic → Practice → Survey

### Assistance options (stored as `assistance` in each POST)
- Alleine → `alone`
- Angehörige:r, Freund:in → `family_friend`
- Gesundheitsfachperson → `healthcare`
- Studien Interviewer:in → `study_interviewer`

### Device options (stored as `deviceType` in each POST)
- Smartphone, Handy → `smartphone`
- Tablet, iPad → `tablet`
- Laptop, Notebook → `laptop`
- Computer → `desktop`

Mic error (e.g. missing MediaRecorder) now appears on the DeviceScreen since `startMic()` is called after device selection, not after assistance.

## Test plan

- [x] 9 new/updated unit tests (AssistanceScreen + DeviceScreen components)
- [x] e2e helpers updated: `answerAssistanceQuestion` extended to 4 options, new `answerDeviceQuestion` helper, `startMicAndPractice` includes both steps
- [x] 8 e2e tests rewritten in the intro-screens describe block, covering all options and POST payload assertions for `assistance` and `deviceType`
- [x] Manually open `/icf/P…` in dev and click through the new flow on phone, tablet, and desktop
